### PR TITLE
Added ability to send custom stack traces to _ratchet.push

### DIFF
--- a/src/ratchet.js
+++ b/src/ratchet.js
@@ -461,7 +461,7 @@
         errMsg = errMsg.replace((errClassMatch[errClassMatch.length - 2] || '') + errClass + ':', '');
       }
 
-      _pushTrace({
+      this._pushTrace({
             exception: {
               'class': errClass,
               message: errMsg
@@ -488,7 +488,7 @@
         } 
       }
       
-      _pushTrace(trace, callback);
+      this._pushTrace(trace, callback);
     },
     
     /*
@@ -511,7 +511,7 @@
         return;
       }
 
-      _pushTrace(obj.trace, callback);
+      this._pushTrace(obj.trace, callback);
     },
 
     // Internal function for pushing stack traces


### PR DESCRIPTION
I went above and beyond to re-use some methods, and made the object detection work with iframes/popups.

This should also probably be added to the documentation somewhere.

``` javascript
var trace = {
  exception: {'class': 'com.example.ErrorType', 'message': 'Somebody borked my stack trace'},
  frames: [
    {'filename': 'FancyClass.coffee', 'lineno': 104}, 
    {'filename': 'ImportScript.ts', 'lineno': 102},
    {'filename': 'CompiledGwt.java', 'lineno': 102},
    ...
  ]
}
_ratchet.push({_t: 'trace', trace: trace})
```
