### PR TITLE
Only load the jQuery plugin if `_rollbar` is available

### DIFF
--- a/src/plugins/jquery.js
+++ b/src/plugins/jquery.js
@@ -1,7 +1,7 @@
 /*jslint continue: true, nomen: true, plusplus: true, regexp: true, vars: true, white: true, passfail: false, indent: 2 */
 (function(jQuery, window, document) {
   
-  if (!window._rolllbar) {
+  if (!window._rollbar) {
     return;
   }
   


### PR DESCRIPTION
We don't load Rollbar in development by default, but the jQuery plugin is packaged together with other vendored scripts and always loaded.

In a more broader sense I think it's useful if library scripts take a two-staged approach where the 1. load and 2. are initialised, where the latter is up to the user. That way one can easily do e.g. `if (myApp.environment == 'production') { var someLibrary = new SomeLibrary(); }`

Moving the Plugin (and the base Rollbar js client) to such a setup would be desirable, but until then this solves the immediate problem (for the plugin).
