### PR TITLE
Export RollbarNotifier to window

### DIFF
--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -854,6 +854,11 @@
       err = preSetupErrors.shift();
     }
   }
+  
+  // Export `RollbarNotifier` to window
+  // (Used for embedded implemetations and other instances where 
+  // the library is loaded before `_rollbar` is setup)
+  window['RollbarNotifier'] = RollbarNotifier;
 
   /*** END rollbar.js ***/
 


### PR DESCRIPTION
Useful for embedded implemetations and other instances where the library is loaded before `_rollbar` is setup.
