### PR TITLE
Allow non-functions to be passed to Rollbar.wrap

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -620,6 +620,10 @@ Notifier.prototype.scope = _wrapNotifierFn(function(payloadOptions) {
 Notifier.prototype.wrap = function(f) {
   var _this = this;
 
+  if (typeof f !== 'function') {
+    return f;
+  }
+
   // If the given function is already a wrapped function, just
   // return it instead of wrapping twice
   if (f._isWrap) {

--- a/src/shim.js
+++ b/src/shim.js
@@ -127,6 +127,10 @@ Rollbar.prototype.loadFull = function(window, document, immediate, config) {
 Rollbar.prototype.wrap = function(f) {
   var _this = this;
 
+  if (typeof f !== 'function') {
+    return f;
+  }
+
   if (f._isWrap) {
     return f;
   }

--- a/test/notifier.test.js
+++ b/test/notifier.test.js
@@ -1475,4 +1475,9 @@ describe("Notifier.wrap()", function() {
 
     done();
   });
+
+  it("should let non-functions pass through unchanged", function() {
+    var object = {};
+    expect(window.Rollbar.wrap(object)).to.be.equal(object);
+  });
 });

--- a/test/shim.test.js
+++ b/test/shim.test.js
@@ -296,6 +296,13 @@ describe("window.Rollbar.log/debug/info/warn/warning/error/critical()", function
   });
 });
 
+describe("window.Rollbar.wrap()", function() {
+  it("should let non-functions pass through unchanged", function() {
+    var object = {};
+    expect(window.Rollbar.wrap(object)).to.be.equal(object);
+  });
+});
+
 describe("window.Rollbar.loadFull()", function() {
   var errArgs;
 


### PR DESCRIPTION
`Rollbar.wrap` currently returns a function that errors out immediately (with "has no method 'apply'") when passed a non-function. This causes errors when, for example, `addEventListener` is called with an object implementing `EventListener` (https://developer.mozilla.org/en-US/docs/Web/API/EventListener) rather than a plain function.
