### PR TITLE
Pass window.onerror args to old onerror

### DIFF
--- a/src/shim.js
+++ b/src/shim.js
@@ -21,7 +21,7 @@ function _rollbarWindowOnError(client, old, args) {
 
   client.uncaughtError.apply(client, args);
   if (old) {
-    old.apply(window, arguments);
+    old.apply(window, args);
   }
 }
 


### PR DESCRIPTION
The current code passes the arguments of an internal function rather
than the original arguments passed into window.onerror. This breaks the
functionality of the old window.onerror callback.
