### PR TITLE
Fix unbinding events with object handlers

### DIFF
--- a/src/shim.js
+++ b/src/shim.js
@@ -201,7 +201,7 @@ function _extendListenerPrototype(client, prototype) {
 
     var oldRemoveEventListener = prototype.removeEventListener;
     prototype.removeEventListener = function(event, callback, bubble) {
-      oldRemoveEventListener.call(this, event, callback ? callback._wrapped : callback, bubble);
+      oldRemoveEventListener.call(this, event, (callback && callback._wrapped) ? callback._wrapped : callback, bubble);
     };
   }
 }


### PR DESCRIPTION
After the changes in https://github.com/rollbar/rollbar.js/commit/65a108e4e1b64bca6d6c6408849ff3c59260347f, event handlers implementing `EventListener` directly (i.e. plain non-function objects, https://developer.mozilla.org/en-US/docs/Web/API/EventListener) cannot not be unbound, since `Rollbar.prototype.wrap` passes them through without adding a `._wrapped` key.

This allows these types of handlers to be unbound. A more complete solution would also wrap them correctly :)
