### PR TITLE
Don't choke on null callbacks in removeEventListener

### DIFF
--- a/src/globalnotifier.js
+++ b/src/globalnotifier.js
@@ -26,7 +26,7 @@ function _extendListenerPrototype(client, prototype) {
 
     var oldRemoveEventListener = prototype.removeEventListener;
     prototype.removeEventListener = function(event, callback, bubble) {
-      oldRemoveEventListener.call(this, event, callback._wrapped || callback, bubble);
+      oldRemoveEventListener.call(this, event, callback && callback._wrapped || callback, bubble);
     };
   }
 }


### PR DESCRIPTION
We're seeing situations where third-party libraries are mistakenly passing `null` as the second parameter to `removeEventListener`. Since Rollbar tries to access `._wrapped` on the argument, we get exceptions from inside the overwritten method.

This PR implements a check to ensure that the value is truthy before trying to access the `._wrapped` property.
