### PR TITLE
Bower update

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -2,8 +2,22 @@
   "name": "rollbar",
   "dependencies": {},
   "main": [
-    "dist/rollbar.js", 
+    "dist/rollbar.js",
     "dist/rollbar.snippet.js",
     "src/plugins/jquery.js"
+  ],
+  "ignore": [
+    "docs",
+    "examples",
+    "release",
+    "test",
+    "tasks",
+    ".gitignore",
+    ".gitmodules",
+    ".travis.yml",
+    "Gruntfile.js",
+    "Makefile",
+    "travis.yml",
+    "package.json"
   ]
 }


### PR DESCRIPTION
This PR updates the Bower version to 1.1.12 and adds an `ignore` array ([see spec](https://github.com/bower/bower.json-spec#ignore)) so that the install footprint is a lot smaller than it would be otherwise.
