### PR TITLE
Return notifier instance from `init`

### DIFF
--- a/src/globalnotifier.js
+++ b/src/globalnotifier.js
@@ -63,4 +63,6 @@ wrapper.init = function(config) {
 
   // Finally, start processing payloads using the global notifier
   Notifier.processPayloads();
+  
+  return Notifier;
 };


### PR DESCRIPTION
I'm trying to understand if I've totally misunderstood something (please let me know if I have!).

But I think the instance must be returned, otherwise there isn't a way to send errors to rollbar via `log` (when the global errorhandler isn't used, which is often the case for larger frameworks).