### PR TITLE
Remove unneed else if. @brianr.

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -872,10 +872,11 @@ var payloadProcessorTimeout;
 Notifier.processPayloads = function(immediate) {
   if (immediate) {
     _deferredPayloadProcess();
+
+    return;
   }
-  else if (!payloadProcessorTimeout) {
-    _notifyPayloadAvailable();
-  }
+
+  _notifyPayloadAvailable();
 };
 
 function _notifyPayloadAvailable() {


### PR DESCRIPTION
I've removed the `else if` and use return inside the `if` statement,
since I think now is very clear the concept of `immediate`.