### PR TITLE
Change argument name in Stack() to fix uglify bug.

### DIFF
--- a/src/error_parser.js
+++ b/src/error_parser.js
@@ -27,12 +27,12 @@ function Frame(stackFrame) {
   return data;
 };
 
-function Stack(e) {
+function Stack(exception) {
   function getStack() {
     var parserStack = [];
 
     try {
-      parserStack = ErrorStackParser.parse(e);
+      parserStack = ErrorStackParser.parse(exception);
     } catch(e) {
       parserStack = [];
     }
@@ -48,8 +48,8 @@ function Stack(e) {
 
   return {
     stack: getStack(),
-    message: e.message,
-    name: e.name
+    message: exception.message,
+    name: exception.name
   };
 };
 


### PR DESCRIPTION
The minified version of the buggy function is this:

```javascript
function o(n) {
            function e() {
                var e = [];
                try {
                    e = l.parse(n)
                } catch (t) {
                    e = []
                }
                for (var r = [], s = 0; s < e.length; s++) r.push(new a(e[s]));
                return r
            }
            return {
                stack: e(),
                message: n.message,
                name: n.name
            }
        }
```