### PR TITLE
Don't call shim's onerror and use the original one.

### DIFF
--- a/src/globalnotifier.js
+++ b/src/globalnotifier.js
@@ -45,11 +45,19 @@ wrapper.init = function(config, parent) {
 
   if (config.captureUncaught) {
     // Set the global onerror handler
-    var old = window.onerror;
+    var oldOnError;
+
+    // If the parent, probably a shim, stores a oldOnError, use that so we don't
+    // send reports twice.
+    if (parent && typeof parent.oldOnError !== 'undefined') {
+      oldOnError = parent.oldOnError;
+    } else {
+      oldOnError = window.onerror;
+    }
 
     window.onerror = function() {
       var args = Array.prototype.slice.call(arguments, 0);
-      _rollbarWindowOnError(notifier, old, args);
+      _rollbarWindowOnError(notifier, oldOnError, args);
     };
 
     // Adapted from https://github.com/bugsnag/bugsnag-js

--- a/src/globalnotifier.js
+++ b/src/globalnotifier.js
@@ -49,8 +49,8 @@ wrapper.init = function(config, parent) {
 
     // If the parent, probably a shim, stores a oldOnError, use that so we don't
     // send reports twice.
-    if (parent && typeof parent.oldOnError !== 'undefined') {
-      oldOnError = parent.oldOnError;
+    if (parent && typeof parent._rollbarOldOnError !== 'undefined') {
+      oldOnError = parent._rollbarOldOnError;
     } else {
       oldOnError = window.onerror;
     }

--- a/src/shim.js
+++ b/src/shim.js
@@ -7,7 +7,7 @@ function Rollbar(parentShim) {
   this.notifier = null;
   this.parentShim = parentShim;
   this.logger = function() {};
-  this.oldOnError = null;
+  this._rollbarOldOnError = null;
 
   if (window.console) {
     if (window.console.shimId === undefined) {
@@ -52,11 +52,11 @@ Rollbar.init = function(window, config) {
 
     if (config.captureUncaught) {
       // Create the client and set the onerror handler
-      client.oldOnError = window.onerror;
+      client._rollbarOldOnError = window.onerror;
 
       window.onerror = function() {
         var args = Array.prototype.slice.call(arguments, 0);
-        _rollbarWindowOnError(client, client.oldOnError, args);
+        _rollbarWindowOnError(client, client._rollbarOldOnError, args);
       };
 
       // Adapted from https://github.com/bugsnag/bugsnag-js

--- a/src/shim.js
+++ b/src/shim.js
@@ -7,6 +7,7 @@ function Rollbar(parentShim) {
   this.notifier = null;
   this.parentShim = parentShim;
   this.logger = function() {};
+  this.oldOnError = null;
 
   if (window.console) {
     if (window.console.shimId === undefined) {
@@ -51,11 +52,11 @@ Rollbar.init = function(window, config) {
 
     if (config.captureUncaught) {
       // Create the client and set the onerror handler
-      var old = window.onerror;
+      client.oldOnError = window.onerror;
 
       window.onerror = function() {
         var args = Array.prototype.slice.call(arguments, 0);
-        _rollbarWindowOnError(client, old, args);
+        _rollbarWindowOnError(client, client.oldOnError, args);
       };
 
       // Adapted from https://github.com/bugsnag/bugsnag-js


### PR DESCRIPTION
This prevents the shim to send reports when full notifier is already loaded.