### PR TITLE
Recognise of objects with stack property as error

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -157,12 +157,6 @@ NotifierPrototype._getLogArgs = function(args) {
       }
     } else if (argT === 'function') {
       callback = _wrapNotifierFn(arg, this);  // wrap the callback in a try/catch block
-    } else if (argT === 'object') {
-      if (custom) {
-        extraArgs.push(arg);
-      } else {
-        custom = arg;
-      }
     } else if (argT === 'date') {
       extraArgs.push(arg);
     } else if (argT === 'error' ||
@@ -172,6 +166,12 @@ NotifierPrototype._getLogArgs = function(args) {
         extraArgs.push(arg);
       } else {
         err = arg;
+      }
+    } else if (argT === 'object') {
+      if (custom) {
+        extraArgs.push(arg);
+      } else {
+        custom = arg;
       }
     }
   }


### PR DESCRIPTION
When a Subclass of Error or any other object with a stack is provided with rollbar it is understood as the error argument.
Then the stack is read from it and made available with the respective rollbar item.

This fix what I have seen at #63.
