### PR TITLE
Load full source with crossOrigin

### DIFF
--- a/src/shim.js
+++ b/src/shim.js
@@ -141,6 +141,7 @@ Rollbar.prototype.loadFull = function(window, document, immediate, config, callb
   var f = document.getElementsByTagName('script')[0];
   var parentNode = f.parentNode;
 
+  s.crossOrigin = '';
   s.src = config.rollbarJsUrl;
   s.async = !immediate;
 


### PR DESCRIPTION
Hi!

I noticed that your CloudFront hosted snippet has `Access-Control-Allow-Origin: *` set.
It would be nice to load the full code with crossorigin attribute as then any runtime or syntax errors inside Rollbar.js get properly reported.


Blank string means `anonymous`.
More at https://bugsnag.com/blog/script-error