### PR TITLE
Make npm install easier for git:// dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "dist/rollbar.umd.nojson.min.js",
   "dependencies": {
     "console-polyfill": "0.2.2",
-    "error-stack-parser": "git://github.com/rollbar/error-stack-parser.git",
+    "error-stack-parser": "git+https://github.com/rollbar/error-stack-parser.git#master",
     "extend": "3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
For some people installing dependencies with git:// protocol is blocked. This is making it a little easier.