### PR TITLE
Retry events that failed to send due to network failures

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -43,8 +43,6 @@ function _notifyPayloadAvailable() {
   }
 }
 
-
-
 // Updated by the build process to match package.json
 Notifier.NOTIFIER_VERSION = __NOTIFIER_VERSION__;
 Notifier.DEFAULT_ENDPOINT = __DEFAULT_ENDPOINT__;
@@ -62,6 +60,8 @@ Notifier.LEVELS = {
   error: 3,
   critical: 4
 };
+
+Notifier.RETRY_DELAY = 1000 * 10;
 
 // This is the global queue where all notifiers will put their
 // payloads to be sent to Rollbar.
@@ -1017,7 +1017,7 @@ function _processPayload(payloadObject) {
         payloadObject.callback = function () { };
         setTimeout(function () {
           directlyEnqueuePayload(payloadObject);
-        }, 1000 * 10);
+        }, Notifier.RETRY_DELAY);
       }
 
       return callback(err);

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -8,6 +8,15 @@ function setupJSON(JSON) {
   RollbarJSON = JSON;
 }
 
+function ConnectionError(message) {
+  this.name = 'Connection Error';
+  this.message = message;
+  this.stack = (new Error()).stack;
+}
+
+ConnectionError.prototype = Object.create(Error.prototype);
+ConnectionError.prototype.constructor = ConnectionError;
+
 var XHR = {
   XMLHttpFactories: [
       function () {
@@ -66,7 +75,7 @@ var XHR = {
                   // IE will return a status 12000+ on some sort of connection failure,
                   // so we return a blank error
                   // http://msdn.microsoft.com/en-us/library/aa383770%28VS.85%29.aspx
-                  callback(new Error());
+                  callback(new ConnectionError('XHR response had no status code (likely connection failure)'));
                 }
               }
             } catch (ex) {
@@ -103,7 +112,7 @@ var XHR = {
             }
 
             var ontimeout = function() {
-              callback(new Error('Request timed out'));
+              callback(new ConnectionError('Request timed out'));
             };
 
             var onerror = function() {
@@ -132,5 +141,6 @@ var XHR = {
 
 module.exports = {
   XHR: XHR,
-  setupJSON: setupJSON
+  setupJSON: setupJSON,
+  ConnectionError: ConnectionError
 };

--- a/test/notifier_retry.test.js
+++ b/test/notifier_retry.test.js
@@ -1,0 +1,126 @@
+/* globals expect */
+/* globals describe */
+/* globals it */
+/* globals sinon */
+
+var Rollbar = require('../src/shim.js');
+Rollbar = Rollbar.Rollbar;
+var Notifier = require('../src/notifier').Notifier;
+
+var xhr = require('../src/xhr');
+var XHR = xhr.XHR;
+var ConnectionError = xhr.ConnectionError;
+
+
+var config = {
+  accessToken: '12c99de67a444c229fca100e0967486f',
+  captureUncaught: true
+};
+
+
+Rollbar.init(window, config);
+
+/*
+ * Notifier automatic retry on connection failure
+ */
+describe('Notifier automatic retry', function() {
+  var clockStub;
+  var xhrPostStub;
+  var notifier;
+
+  beforeEach(function () {
+    clockStub = sinon.useFakeTimers();
+    xhrPostStub = sinon.stub(XHR, 'post');
+    notifier = new Notifier();
+  });
+
+  afterEach(function () {
+    clockStub.restore();
+    xhrPostStub.restore();
+  });
+
+  it('should not retry successful processing', function() {
+    notifier.error('test');
+    givenXhrsSucceed();
+
+    Notifier.processPayloads(true);
+
+    expect(xhrPostStub.callCount).to.equal(1);
+    waitUntilNextRetry();
+    expect(xhrPostStub.callCount).to.equal(1);
+  });
+
+  it('should not retry processing that fails but gets a status code back', function() {
+    notifier.error('test');
+    givenXhrsReceiveUpstreamErrors();
+
+    Notifier.processPayloads(true);
+
+    expect(xhrPostStub.callCount).to.equal(1);
+    waitUntilNextRetry();
+    expect(xhrPostStub.callCount).to.equal(1);
+  });
+
+  it('should retry processing that fails at the network level after a timeout', function() {
+    notifier.error('test');
+    givenXhrsHaveConnectionErrors();
+
+    Notifier.processPayloads(true);
+
+    expect(xhrPostStub.callCount).to.equal(1);
+
+    waitUntilNextRetry();
+    expect(xhrPostStub.callCount).to.equal(2);
+
+    waitUntilNextRetry();
+    expect(xhrPostStub.callCount).to.equal(3);
+  });
+
+  it('should stop retrying processing that failed once it eventually succeeds', function() {
+    notifier.error('test');
+    givenXhrsHaveConnectionErrors();
+
+    Notifier.processPayloads(true);
+
+    givenXhrsSucceed();
+    waitUntilNextRetry();
+    expect(xhrPostStub.callCount).to.equal(2);
+
+    waitUntilNextRetry();
+    expect(xhrPostStub.callCount).to.equal(2);
+  });
+
+  it('should call error callback once initially on error, regardless of future failed or successful retries', function() {
+    var callback = sinon.stub();
+
+    notifier.error('test', callback);
+    givenXhrsHaveConnectionErrors();
+
+    Notifier.processPayloads(true);
+    expect(callback.callCount).to.equal(1);
+
+    waitUntilNextRetry();
+
+    givenXhrsSucceed();
+    waitUntilNextRetry();
+
+    expect(callback.callCount).to.equal(1);
+  });
+
+  function givenXhrsSucceed() {
+    xhrPostStub.yields(null, {});
+  }
+
+  function givenXhrsHaveConnectionErrors() {
+    xhrPostStub.yields(new ConnectionError());
+  }
+
+  function givenXhrsReceiveUpstreamErrors() {
+    xhrPostStub.yields(new Error(String(401)));
+  }
+
+  function waitUntilNextRetry() {
+    clockStub.tick(1000 * 10);
+    Notifier.processPayloads(true);
+  }
+});


### PR DESCRIPTION
This is a first run at fixing #107. If a payload fails to be delivered to Rollbar because of something that's likely to be a network failure (a response back without any status code, or a network timeout) then the payload is put back on queue 10 seconds later to be retried.

This is a first run to scope this out and start some discussion. There's a good few debatable points here:

- What should happen with the callback for the event that's being logged? Currently I've opted to be maximally backward compatible: it fires on the first error, exactly as now, and future retries never trigger it, whether they're successful or not.
- The retry delay should presumably be configurable? Should it be disableable?
- Should we eventually stop retrying?
- Should this be some sort of exponential backoff approach instead? (adds a little extra complexity; there's currently no real state between retries)

Regardless, I think this is probably a workable approach in the meantime, so you could potentially treat those as extensions to follow if you like.

There's notably a few more complex approaches to solving this that I'm totally ignoring here (like queuing into LocalStorage and firing later on totally separate page loads, or triggering all waiting previously failed payloads if one of them is successfully delivered). I expect the minimal approach gets most of the benefit of this for most users, with much less effort.