### PR TITLE
Re-add snippet for Bower distribution

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,6 @@
     "dist/rollbar.umd.js"
   ],
   "ignore": [
-    "dist/*.snippet*",
     "dist/*.nojson*",
     "dist/*.named-amd*",
     "docs",
@@ -22,6 +21,7 @@
     "Makefile",
     "travis.yml",
     "package.json",
-    "webpack.config.js"
+    "webpack.config.js",
+    "browserstack*"
   ]
 }


### PR DESCRIPTION
I also removed the Browserstack files from Bower since they are only used during development/testing.