### PR TITLE
Use sendBeacon when available

### DIFF
--- a/src/xhr.js
+++ b/src/xhr.js
@@ -55,6 +55,12 @@ var XHR = {
     }
     payload = RollbarJSON.stringify(payload);
     callback = callback || function() {};
+
+    if("sendBeacon" in navigator) {
+      if(navigator.sendBeacon(url, payload))
+          return callback(null, {});
+    }
+
     var request = XHR.createXMLHTTPObject();
     if (request) {
       try {


### PR DESCRIPTION
Special API to send small payloads, available in Edge, Firefox and Chrome. Reliable and very small, but useful