### PR TITLE
Update captureUnhandledRejections in Quickstart docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Be sure to replace ```POST_CLIENT_ITEM_ACCESS_TOKEN``` with your project's ```po
 var _rollbarConfig = {
     accessToken: "POST_CLIENT_ITEM_ACCESS_TOKEN",
     captureUncaught: true,
-    captureUnhandledRejections: false,
+    captureUnhandledRejections: true,
     payload: {
         environment: "production"
     }


### PR DESCRIPTION
A user emailed us to let us know that he thinks this flag should be set to true and not false in our quickstart docs: "I think the simplest way to get someone started quickly and on the right foot with Rollbar would be to make the `captureUnhandledRejections` option set to `true` in your first quick start snippet. That way, the developer using Rollbar will see all errors from the get-go instead of mistakenly assuming their app is having no issues because nothing is showing up on Rollbar, and they can pare back their settings if they're getting overwhelmed by one type of request."

I agreed with him. Hopefully you do too 😸 