### PR TITLE
Retain more of the context on null rejections

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -721,23 +721,20 @@ NotifierPrototype.uncaughtError = _wrapNotifierFn(function(message, url, lineNo,
 });
 
 NotifierPrototype.unhandledRejection = _wrapNotifierFn(function(reason, promise) {
-  if (reason == null) {
-    _topLevelNotifier._log(_topLevelNotifier.options.uncaughtErrorLevel, //level
-      'unhandled rejection was null or undefined!', // message
-      null, // err
-      {}, // custom
-      null,  // callback
-      false, // isUncaught
-      false); // ignoreRateLimit
-    return;
-  }
-
-  var message = reason.message || (reason ? String(reason) : 'unhandled rejection');
-
+  var message;
   // If the reason error was thrown within a wrap call, we'll extract the context given there.
   // If users want to provide their Promise implementation with knowledge of the rollbar
   // context they are created in, we'll search for that attribute, too.
-  var context = reason._rollbarContext || promise._rollbarContext || null;
+  var context;
+
+  if (reason) {
+    message = reason.message || String(reason);
+    context = reason._rollbarContext;
+  } else {
+    message = 'unhandled rejection was null or undefined!';
+  }
+
+  context = context || promise._rollbarContext || null;
 
   if (reason && Util.isType(reason, 'error')) {
     this._log(this.options.uncaughtErrorLevel, message, reason, context, null, true);

--- a/test/notifier.test.js
+++ b/test/notifier.test.js
@@ -483,13 +483,23 @@ describe('Notfier.unhandledRejection()', function() {
   });
 
   context('with a null value', function() {
-    it('should not enqueue a payload', function(done) {
+    it('should enqueue a payload with trace and other details', function(done) {
       var err = null;
       var promise = {};
 
       notifier.unhandledRejection(err, promise);
 
-      expect(enqueueSpy.called).to.equal(false);
+      expect(enqueueSpy.calledOnce).to.equal(true);
+      var args = enqueueSpy.getCall(0).args;
+
+      var payloadData = args[0].data;
+      expect(payloadData.level).to.equal('error');
+      var description = args[0].data.body.trace.exception.description;
+      var message = args[0].data.body.trace.exception.message;
+      var frames = args[0].data.body.trace.frames;
+      expect(description).to.equal('unhandled rejection was null or undefined!');
+      expect(message).to.equal('unhandled rejection was null or undefined!');
+      expect(frames.length).to.equal(1);
       done();
     });
   })


### PR DESCRIPTION
This adds support for getting more context, even when the rejection error itself is null. Without it, there is no information to go on.