### PR TITLE
ignore the release folder when building the package, #215

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,7 @@
+node_modules
+bower_components
+.idea
+vendor/*.min.js
+test/*.bundle.js*
+sauce_connect.log
+release


### PR DESCRIPTION
I created a `.npmignore` file which is a clone of `.gitignore` but with the `release` folder added.  This will make it so the `release` folder is not included in future builds.

https://docs.npmjs.com/misc/developers#keeping-files-out-of-your-package