### PR TITLE
remove a remnant from our old usage of TraceKit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
-[submodule "vendor/TraceKit"]
-	path = vendor/TraceKit
-	url = https://github.com/rollbar/TraceKit.git
 [submodule "vendor/JSON-js"]
 	path = vendor/JSON-js
 	url = https://github.com/rollbar/JSON-js.git


### PR DESCRIPTION
Fixes #132.  We had a legacy reference to TraceKit, but we haven't been using it since v1.3.0