### PR TITLE
[Fixes #205] add Object.create polyfill for IE8

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -130,6 +130,30 @@ function uuid4() {
 }
 
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/create
+if (typeof Object.create != 'function') {
+  Object.create = (function(undefined) {
+    var Temp = function() {};
+    return function (prototype, propertiesObject) {
+      if(prototype !== null && prototype !== Object(prototype)) {
+        throw TypeError('Argument must be an object, or null');
+      }
+      Temp.prototype = prototype || {};
+      var result = new Temp();
+      Temp.prototype = null;
+      if (propertiesObject !== undefined) {
+        Object.defineProperties(result, propertiesObject);
+      }
+
+      // to imitate the case of Object.create(null)
+      if(prototype === null) {
+         result.__proto__ = null;
+      }
+      return result;
+    };
+  })();
+}
+
 var Util = {
   isType: isType,
   parseUri: parseUri,


### PR DESCRIPTION
Fixes #205 even though there is a separate old PR which also does some fixing, this is the minimal change to get things working. There is a higher order question about a better fix not to rely on Object.create, but in the meantime to alleviate some pain this is more straightforward.