### PR TITLE
log out json for objects in IE8 and below

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "main": "dist/rollbar.umd.nojson.min.js",
   "dependencies": {
-    "console-polyfill": "0.2.3",
+    "console-polyfill": "rollbar/console-polyfill#eab6ff9d2b7597fc2f259baa18100556bdb94dbe",
     "error-stack-parser": "1.3.3",
     "extend": "3.0.0"
   },

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,0 +1,26 @@
+// This browser.js module is used to encapsulate any ugly browser/feature
+// detection we may need to do.
+
+// Figure out which version of IE we're using, if any.
+// This is gleaned from http://stackoverflow.com/questions/5574842/best-way-to-check-for-ie-less-than-9-in-javascript-without-library
+// Will return an integer on IE (i.e. 8)
+// Will return undefined otherwise
+function getIEVersion() {
+  var undef,
+    v = 3,
+    div = document.createElement('div'),
+    all = div.getElementsByTagName('i');
+
+  while (
+    div.innerHTML = '<!--[if gt IE ' + (++v) + ']><i></i><![endif]-->',
+      all[0]
+    );
+
+  return v > 4 ? v : undef;
+}
+
+var Browser = {
+  ieVersion: getIEVersion
+};
+
+module.exports = Browser;

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -22,6 +22,7 @@ var RollbarJSON = null;
 function setupJSON(JSON) {
   RollbarJSON = JSON;
   xhr.setupJSON(JSON);
+  Util.setupJSON(JSON);
 }
 
 function _wrapNotifierFn(fn, ctx) {
@@ -30,7 +31,7 @@ function _wrapNotifierFn(fn, ctx) {
     try {
       return fn.apply(self, arguments);
     } catch (e) {
-      console.error('[Rollbar]:', e);
+      Util.consoleError('[Rollbar]:', e);
     }
   };
 }
@@ -470,7 +471,7 @@ NotifierPrototype._urlIsWhitelisted = function(payload){
     }
   } catch (e) {
     this.configure({hostWhiteList: null});
-    console.error("[Rollbar]: Error while reading your configuration's hostWhiteList option. Removing custom hostWhiteList.", e);
+    Util.consoleError("[Rollbar]: Error while reading your configuration's hostWhiteList option. Removing custom hostWhiteList.", e);
     return true;
   }
 
@@ -518,7 +519,7 @@ NotifierPrototype._messageIsIgnored = function(payload){
   }
   catch(e) {
     this.configure({ignoredMessages: null});
-    console.error("[Rollbar]: Error while reading your configuration's ignoredMessages option. Removing custom ignoredMessages.");
+    Util.consoleError("[Rollbar]: Error while reading your configuration's ignoredMessages option. Removing custom ignoredMessages.");
   }
 
   return messageIsIgnored;
@@ -562,7 +563,7 @@ NotifierPrototype._enqueuePayload = function(payload, isUncaught, callerArgs, ca
   } catch (e) {
     // Disable the custom checkIgnore and report errors in the checkIgnore function
     this.configure({checkIgnore: null});
-    console.error('[Rollbar]: Error while calling custom checkIgnore() function. Removing custom checkIgnore().', e);
+    Util.consoleError('[Rollbar]: Error while calling custom checkIgnore() function. Removing custom checkIgnore().', e);
   }
 
   if (!this._urlIsWhitelisted(payload)) {
@@ -577,12 +578,10 @@ NotifierPrototype._enqueuePayload = function(payload, isUncaught, callerArgs, ca
     if (payload.data && payload.data.body && payload.data.body.trace) {
       var trace = payload.data.body.trace;
       var exceptionMessage = trace.exception.message;
-      console.error('[Rollbar]: ', exceptionMessage);
+      Util.consoleError('[Rollbar]: ', exceptionMessage);
     }
 
-    // FIXME: Some browsers do not output objects as json to the console, and
-    // instead write [object Object], so let's write the message first to ensure that is logged.
-    console.info('[Rollbar]: ', payloadToSend);
+    Util.consoleInfo('[Rollbar]: ', payloadToSend);
   }
 
   if (Util.isType(this.options.logFunction, 'function')) {
@@ -595,12 +594,13 @@ NotifierPrototype._enqueuePayload = function(payload, isUncaught, callerArgs, ca
     }
   } catch (e) {
     this.configure({transform: null});
-    console.error('[Rollbar]: Error while calling custom transform() function. Removing custom transform().', e);
+    Util.consoleError('[Rollbar]: Error while calling custom transform() function. Removing custom transform().', e);
   }
 
   if (this.options.enabled) {
     directlyEnqueuePayload(payloadToSend);
   }
+
 };
 
 function directlyEnqueuePayload(payloadToSend) {
@@ -663,7 +663,7 @@ NotifierPrototype._log = function(level, message, err, custom, callback, isUncau
 
       this.lastError = err;
     } catch (e) {
-      console.error('[Rollbar]: Error while parsing the error object.', e);
+      Util.consoleError('[Rollbar]: Error while parsing the error object.', e);
       // err is not something we can parse so let's just send it along as a string
       message = err.message || err.description || message || String(err);
       err = null;
@@ -868,7 +868,7 @@ NotifierPrototype.wrap = function(f, context) {
 
 
 NotifierPrototype.loadFull = function() {
-  console.error('[Rollbar]: Unexpected Rollbar.loadFull() called on a Notifier instance');
+  Util.consoleError('[Rollbar]: Unexpected Rollbar.loadFull() called on a Notifier instance');
 };
 
 

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,13 @@
 require('console-polyfill');
 
+var browser = require('./browser');
+
+var RollbarJSON = null;
+
+function setupJSON(JSON) {
+  RollbarJSON = JSON;
+}
+
 var parseUriOptions = {
   strictMode: false,
     key: [
@@ -156,7 +164,51 @@ function objectCreate(prototype) {
   }
 }
 
+// IE8 logs objects as [object Object].  This is a wrapper that makes it a bit
+// more convenient by logging the JSON of the object.  But only do that in IE8 and below
+// because other browsers are smarter and handle it properly.
+function formatArgsAsString() {
+  var args = [];
+  for (var i=0; i < arguments.length; i++) {
+    var arg = arguments[i];
+    if (typeof arg === 'object') {
+      arg = RollbarJSON.stringify(arg);
+      if (arg.length > 500)
+        arg = arg.substr(0,500)+'...';
+    } else if (typeof arg === 'undefined') {
+      arg = 'undefined';
+    }
+    args.push(arg);
+  }
+  return args.join(' ');
+}
+
+function consoleError() {
+  if (browser.ieVersion() <= 8) {
+    console.error(formatArgsAsString.apply(null, arguments));
+  } else {
+    console.error.apply(null, arguments);
+  }
+}
+
+function consoleInfo() {
+  if (browser.ieVersion() <= 8) {
+    console.info(formatArgsAsString.apply(null, arguments));
+  } else {
+    console.info.apply(null, arguments);
+  }
+}
+
+function consoleLog() {
+  if (browser.ieVersion() <= 8) {
+    console.log(formatArgsAsString.apply(null, arguments));
+  } else {
+    console.log.apply(null, arguments);
+  }
+}
+
 var Util = {
+  setupJSON: setupJSON,
   isType: isType,
   parseUri: parseUri,
   parseUriOptions: parseUriOptions,
@@ -165,7 +217,10 @@ var Util = {
   traverse: traverse,
   typeName: typeName,
   uuid4: uuid4,
-  objectCreate: objectCreate
+  objectCreate: objectCreate,
+  consoleError: consoleError,
+  consoleInfo: consoleInfo,
+  consoleLog: consoleLog
 };
 
 

--- a/src/xhr.js
+++ b/src/xhr.js
@@ -74,7 +74,7 @@ var XHR = {
                   if (request.status == 403) {
                     // likely caused by using a server access token, display console message to let
                     // user know
-                    console.error('[Rollbar]:' + jsonResponse.message);
+                    Util.consoleError('[Rollbar]:' + jsonResponse.message);
                   }
                   // return valid http status codes
                   callback(new Error(String(request.status)));

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -1,12 +1,16 @@
 /* globals expect */
 /* globals describe */
 /* globals it */
+/* globals sinon */
 
 
+
+var browser = require('../src/browser.js');
 var Util = require('../src/util.js');
 
-
 describe('Util', function() {
+  Util.setupJSON(JSON);
+
   it('should parse a URI properly', function(done) {
     var uri = 'http://usr:pwd@www.test.com:81/dir/dir.2/index.htm?q1=0&&test1&test2=value#top';
 
@@ -159,6 +163,37 @@ describe('Util', function() {
 
     // null is an object, (typeof null === 'object')... how silly is that?
     expect(Util.redact(null)).to.equal('****');
+
+    done();
+  });
+
+  it('should wrap console functions in IE8', function(done) {
+    var obj = {};
+    for (var i=0; i < 100; i+=1) obj['test'+i] = i;
+    var ieVersion = null;
+    var check = null;
+
+    sinon.stub(browser, 'ieVersion', function(){ return ieVersion; });
+    sinon.stub(console, 'error', function() { check.apply(this, arguments); });
+
+    // Check that it behaves like normal on IE9
+    ieVersion = 9;
+    check = function() {
+      expect(arguments[0]).to.equal('before');
+      expect(arguments[1]).to.equal(obj);
+      expect(arguments[2]).to.equal('after');
+      expect(typeof arguments[3]).to.equal('undefined');
+    };
+    Util.consoleError('before', obj, 'after', undefined);
+
+    // Now check that it returns a singnle formatted string for IE8
+    ieVersion = 8;
+    check = function() {
+      expect(arguments.length).to.equal(1);
+      expect(arguments[0]).to.match(/^before {/);
+      expect(arguments[0]).to.match(/\.\.\. after undefined$/);
+    };
+    Util.consoleError('before', obj, 'after', undefined);
 
     done();
   });

--- a/test/util.test.js
+++ b/test/util.test.js
@@ -195,6 +195,16 @@ describe('Util', function() {
     };
     Util.consoleError('before', obj, 'after', undefined);
 
+    // Now check that it works for non-IE versions as well
+    ieVersion = undefined;
+    check = function() {
+      expect(arguments[0]).to.equal('before');
+      expect(arguments[1]).to.equal(obj);
+      expect(arguments[2]).to.equal('after');
+      expect(typeof arguments[3]).to.equal('undefined');
+    };
+    Util.consoleError('before', obj, 'after', undefined);
+
     done();
   });
 });


### PR DESCRIPTION
Addresses #128 by providing a customized console.log/error/info renderer to prevent the dreaded `[object Object]` by rendering JSON instead.