### PR TITLE
Fix/improve async logic for full script load

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ var _rollbarConfig = {
 
 By default, the snippet loads the full Rollbar source **asynchronously**. You can disable this which will cause the browser to download and evaluate the full rollbar source before evaluating the rest of the page.
 
-More information can be found here: http://www.w3schools.com/tags/att_script_async.asp
+More information can be found here: http://www.w3schools.com/tags/att_script_async.asp and https://www.w3schools.com/tags/att_script_defer.asp
 
 ```js
 var _rollbarConfig = {

--- a/src/bundles/rollbar.snippet.js
+++ b/src/bundles/rollbar.snippet.js
@@ -9,4 +9,4 @@ _rollbarConfig.rollbarJsUrl = _rollbarConfig.rollbarJsUrl || __DEFAULT_ROLLBARJS
 var shim = RollbarShim.init(window, _rollbarConfig);
 var callback = snippetCallback(shim, _rollbarConfig);
 
-shim.loadFull(window, document, !!_rollbarConfig.async, _rollbarConfig, callback);
+shim.loadFull(window, document, _rollbarConfig.async === undefined || _rollbarConfig.async, _rollbarConfig, callback);

--- a/src/bundles/rollbar.snippet.js
+++ b/src/bundles/rollbar.snippet.js
@@ -9,4 +9,4 @@ _rollbarConfig.rollbarJsUrl = _rollbarConfig.rollbarJsUrl || __DEFAULT_ROLLBARJS
 var shim = RollbarShim.init(window, _rollbarConfig);
 var callback = snippetCallback(shim, _rollbarConfig);
 
-shim.loadFull(window, document, _rollbarConfig.async === undefined || _rollbarConfig.async, _rollbarConfig, callback);
+shim.loadFull(window, document, !(_rollbarConfig.async === undefined || _rollbarConfig.async), _rollbarConfig, callback);

--- a/src/bundles/rollbar.snippet.js
+++ b/src/bundles/rollbar.snippet.js
@@ -9,4 +9,4 @@ _rollbarConfig.rollbarJsUrl = _rollbarConfig.rollbarJsUrl || __DEFAULT_ROLLBARJS
 var shim = RollbarShim.init(window, _rollbarConfig);
 var callback = snippetCallback(shim, _rollbarConfig);
 
-shim.loadFull(window, document, !_rollbarConfig.async, _rollbarConfig, callback);
+shim.loadFull(window, document, !!_rollbarConfig.async, _rollbarConfig, callback);

--- a/src/shim.js
+++ b/src/shim.js
@@ -158,6 +158,7 @@ Rollbar.prototype.loadFull = function(window, document, immediate, config, callb
   s.crossOrigin = '';
   s.src = config.rollbarJsUrl;
   s.async = !immediate;
+  s.defer = !immediate;
 
   // From http://stackoverflow.com/questions/4845762/onload-handler-for-script-tag-in-internet-explorer
   s.onload = s.onreadystatechange = _wrapInternalErr(function() {


### PR DESCRIPTION
* Fix default behavior to match README
* Add defer attribute to script tag for supported browsers


Fixes https://github.com/rollbar/rollbar.js/issues/255