### PR TITLE
Bug: Leaked sensitive data when stringifying custom data

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -341,6 +341,11 @@ NotifierPrototype._buildPayload = function(ts, level, message, stackInfo, custom
 
 NotifierPrototype._buildBody = function(message, stackInfo, custom) {
   var body;
+
+  if (custom) {
+    custom = extend(true, {}, this._scrub(custom));
+  }
+
   if (stackInfo) {
     body = _buildPayloadBodyTrace(message, stackInfo, custom);
   } else {
@@ -483,7 +488,7 @@ NotifierPrototype._messageIsIgnored = function(payload){
   try {
     messageIsIgnored = false;
     ignoredMessages = this.options.ignoredMessages;
-    
+
     if (!ignoredMessages || ignoredMessages.length === 0) {
       return false;
     }
@@ -492,13 +497,13 @@ NotifierPrototype._messageIsIgnored = function(payload){
             payload.data &&
             payload.data.body;
 
-    traceMessage =  body && 
+    traceMessage =  body &&
                     body.trace &&
-                    body.trace.exception && 
+                    body.trace.exception &&
                     body.trace.exception.message;
-    
-    bodyMessage = body && 
-                  body.message && 
+
+    bodyMessage = body &&
+                  body.message &&
                   body.message.body;
 
     exceptionMessage = traceMessage || bodyMessage;
@@ -897,7 +902,7 @@ function _buildPayloadBodyMessage(message, custom) {
   };
 
   if (custom) {
-    result.extra = extend(true, {}, custom);
+    result.extra = custom;
   }
 
   return {
@@ -975,7 +980,7 @@ function _buildPayloadBodyTrace(description, stackInfo, custom) {
     trace.frames.reverse();
 
     if (custom) {
-      trace.extra = extend(true, {}, custom);
+      trace.extra = custom;
     }
     return {trace: trace};
   } else {
@@ -1087,4 +1092,3 @@ module.exports = {
   setupJSON: setupJSON,
   topLevelNotifier: topLevelNotifier
 };
-

--- a/test/notifier.test.js
+++ b/test/notifier.test.js
@@ -1804,7 +1804,7 @@ describe('Notifier._buildPayload()', function() {
 
     expect(spy.called).to.equal(true);
 
-    var call = spy.getCall(0);
+    var call = spy.getCall(1);
     var scrubbedPayload = call.args[0];
 
     expect(payload.data).to.equal(scrubbedPayload);
@@ -1831,7 +1831,7 @@ describe('Notifier._buildPayload()', function() {
 
     expect(spy.called).to.equal(true);
 
-    var call = spy.getCall(0);
+    var call = spy.getCall(1);
     var scrubbedPayload = call.args[0];
 
     expect(payload.data).to.equal(scrubbedPayload);
@@ -1840,6 +1840,30 @@ describe('Notifier._buildPayload()', function() {
     expect(payload.access_token).to.equal('access token');
     expect(payload.data.body.message.extra.access_token).to.equal('******');
     expect(payload.data.body.message.extra.visible).to.equal('visible');
+
+    done();
+  });
+
+  it.only('should scrub custom object when used as message', function(done) {
+    var notifier = new Notifier();
+    notifier.configure({accessToken: 'access token', scrubFields: ['access_token']});
+
+    var custom = {
+      access_token: 'hidden',
+      visible: 'visible',
+      password: 'hidden',
+    };
+
+    var spy = sinon.spy(notifier, '_scrub');
+
+    var payload = notifier._buildPayload(new Date(), 'error', null, null, custom);
+
+    expect(spy.called).to.equal(true);
+
+    var call = spy.getCall(0);
+    var scrubbedPayload = call.args[0];
+
+    expect(payload.data.body.message.body).to.not.contain('hidden');
 
     done();
   });


### PR DESCRIPTION
When custom is used as a message it is currently sent unscrubbed. This fix ensures that custom is scrubbed when applied as the body message.

This change does require an extra call to `_scrub` it could be refactored in the following way if desired;

```
var payloadData = {
  ...
  body: { extra : custom },
  ...
};

// continue and scrub payload.data

payload.data.body = this._buildBody(message, stackInfo, payload.data.body.extra);

return payload;
```

This would avoid having to call `_scrub` twice.
