### PR TITLE
Remove examples and coverage from published package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -5,3 +5,5 @@ vendor/*.min.js
 test/*.bundle.js*
 sauce_connect.log
 release
+examples
+coverage


### PR DESCRIPTION
These don't add a lot of value inside of a published tarball. This should shave ~1.5Mb from the installed package