### PR TITLE
Do not fail if the request object does not have a headers key (update request-ip)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "debug": "2.2.0",
     "json-stringify-safe": "~5.0.0",
     "lru-cache": "~2.2.1",
-    "request-ip": "~1.2.3",
+    "request-ip": "~2.0.1",
     "uuid": "3.0.x"
   },
   "devDependencies": {

--- a/test/server.transforms.test.js
+++ b/test/server.transforms.test.js
@@ -311,6 +311,21 @@ vows.describe('transforms')
                   assert.equal(item.data.request, undefined);
                 }
               },
+              'with an empty request object': {
+                topic: function(options) {
+                  var item = {
+                    request: {},
+                    data: {body: {message: 'hey'}}
+                  };
+                  t.addRequestData(item, options, this.callback);
+                },
+                'should not error': function(err, item) {
+                  assert.ifError(err);
+                },
+                'should not change request object': function(err, item) {
+                  assert.equal(item.request.headers, undefined);
+                }
+              },
               'with a request': {
                 topic: function(options) {
                   var item = {


### PR DESCRIPTION
Hey ☺️,

with the latest version having a request object without a headers key fails (even though that's allowed according to the docs). This can be solved by just updating `request-ip` to the latest version. I also added a new test that will check that using an empty request object will not fail.

Thank you for your great product by the way, it's very helpful for us at greenkeeper ✨  