### PR TITLE
Fixes #290 handle objects without Object in prototype chain

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -176,9 +176,11 @@ Rollbar.prototype.wrap = function(f, context) {
 
       f._wrapped._isWrap = true;
 
-      for (var prop in f) {
-        if (f.hasOwnProperty(prop)) {
-          f._wrapped[prop] = f[prop];
+      if (f.hasOwnProperty) {
+        for (var prop in f) {
+          if (f.hasOwnProperty(prop)) {
+            f._wrapped[prop] = f[prop];
+          }
         }
       }
     }

--- a/src/browser/shim.js
+++ b/src/browser/shim.js
@@ -148,9 +148,11 @@ Shim.prototype.wrap = function(f, context) {
 
       f._wrapped._isWrap = true;
 
-      for (var prop in f) {
-        if (f.hasOwnProperty(prop)) {
-          f._wrapped[prop] = f[prop];
+      if (f.hasOwnProperty) {
+        for (var prop in f) {
+          if (f.hasOwnProperty(prop)) {
+            f._wrapped[prop] = f[prop];
+          }
         }
       }
     }

--- a/src/server/parser.js
+++ b/src/server/parser.js
@@ -44,7 +44,7 @@ function getMultipleErrors(errors) {
   errArray = [];
 
   for (key in errors) {
-    if (errors.hasOwnProperty(key)) {
+    if (Object.prototype.hasOwnProperty.call(errors, key)) {
       errArray.push(errors[key]);
     }
   }

--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -188,13 +188,8 @@ function _buildRequestData(req) {
   if (req.body) {
     var bodyParams = {};
     if (_.isIterable(req.body)) {
-      var isPlainObject = req.body.constructor === undefined;
-
       for (var k in req.body) {
-        var _hasOwnProperty = typeof req.body.hasOwnProperty === 'function'
-          && req.body.hasOwnProperty(k);
-
-        if (_hasOwnProperty || isPlainObject) {
+        if (Object.prototype.hasOwnProperty.call(req.body, k)) {
           bodyParams[k] = req.body[k];
         }
       }

--- a/src/utility.js
+++ b/src/utility.js
@@ -125,7 +125,7 @@ function traverse(obj, func) {
 
   if (isObj) {
     for (k in obj) {
-      if (obj.hasOwnProperty(k)) {
+      if (Object.prototype.hasOwnProperty.call(obj, k)) {
         keys.push(k);
       }
     }
@@ -144,11 +144,9 @@ function traverse(obj, func) {
   return obj;
 }
 
-/* eslint-disable no-unused-vars */
-function redact(val) {
+function redact() {
   return '********';
 }
-/* eslint-enable no-unused-vars */
 
 // from http://stackoverflow.com/a/8809472/1138191
 function uuid4() {
@@ -238,7 +236,7 @@ function addParamsAndAccessTokenToPath(accessToken, options, params) {
   var paramsArray = [];
   var k;
   for (k in params) {
-    if (params.hasOwnProperty(k)) {
+    if (Object.prototype.hasOwnProperty.call(params, k)) {
       paramsArray.push([k, params[k]].join('='));
     }
   }


### PR DESCRIPTION
Sometimes people use `Object.create(null)` which means that Object does not end up in the prototype chain of said created objects. This means that hasOwnProperty is not a method on that object so calling `obj.hasOwnProperty(prop)` will break. To get around this, we can use `Object.prototype.hasOwnProperty.call(obj, prop)`. As far as I can tell this is safe at least as far back as IE 6 and all version of node. It is only relevant when we don't really know how the object was constructed, so it isn't necessary to use this universally. There is a miniscule performance hit and a bit of a readability issue with it, so prefer not to use this style when we create the object ourselves.