### PR TITLE
subclasses of errors were not treated as errors before

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -31,6 +31,7 @@ setupJSON();
  * @param t - a lowercase string containing one of the following type names:
  *    - undefined
  *    - null
+ *    - error
  *    - number
  *    - boolean
  *    - string
@@ -54,6 +55,9 @@ function typeName(x) {
   }
   if (!x) {
     return 'null';
+  }
+  if (x instanceof Error) {
+    return 'error';
   }
   return ({}).toString.call(x).match(/\s([a-zA-Z]+)/)[1].toLowerCase();
 }

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -115,6 +115,45 @@ describe('isError', function() {
     expect(_.isError(e)).to.be.ok();
     done();
   });
+  it('should handle subclasses of error', function(done) {
+    // This is a mostly browser compliant way of doing this
+    // just for the sake of doing it, even though we mostly
+    // need this to work in node environments
+    function TestCustomError(message) {
+      Object.defineProperty(this, 'name', {
+        enumerable: false,
+        writable: false,
+        value: 'TestCustomError'
+      });
+
+      Object.defineProperty(this, 'message', {
+        enumerable: false,
+        writable: true,
+        value: message
+      });
+
+      if (Error.hasOwnProperty('captureStackTrace')) {
+        Error.captureStackTrace(this, TestCustomError);
+      } else {
+        Object.defineProperty(this, 'stack', {
+          enumerable: false,
+          writable: false,
+          value: (new Error(message)).stack
+        });
+      }
+    }
+
+    if (typeof Object.setPrototypeOf === 'function') {
+      Object.setPrototypeOf(TestCustomError.prototype, Error.prototype);
+    } else {
+      TestCustomError.prototype = Object.create(Error.prototype, {
+        constructor: { value: TestCustomError }
+      });
+    }
+    var e = new TestCustomError('bork');
+    expect(_.isError(e)).to.be.ok();
+    done();
+  });
 });
 
 describe('extend', function() {


### PR DESCRIPTION
this fixes it as long as the prototype chain is correct