### PR TITLE
Moving back to the upstream version of console-polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "main": "src/server/rollbar.js",
   "browser": "dist/rollbar.umd.min.js",
   "dependencies": {
-    "console-polyfill": "rollbar/console-polyfill#eab6ff9d2b7597fc2f259baa18100556bdb94dbe",
+    "console-polyfill": "0.3.0",
     "error-stack-parser": "1.3.3",
     "extend": "3.0.0",
     "async": "~1.2.1",


### PR DESCRIPTION
Fixes #277

`console-polyfill` 0.3.0 is out on npmjs now, which has the fix that was contained in the rollbar fork.