### PR TITLE
add back verbose logging

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -291,6 +291,7 @@ var defaultOptions = {
   reportLevel: __DEFAULT_REPORT_LEVEL__,
   uncaughtErrorLevel: __DEFAULT_UNCAUGHT_ERROR_LEVEL,
   endpoint: __DEFAULT_ENDPOINT__,
+  verbose: false,
   enabled: true
 };
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -216,14 +216,20 @@ Queue.prototype._dequeuePendingRequest = function(item) {
 };
 
 Queue.prototype._maybeLog = function(item) {
-  if (this.logger && this.options.verbose) {
-    var message = _.get(item, 'data.body.trace.exception.message');
-    if (!message) {
-      message = _.get(item, 'data.body.trace_chain.0.exception.message');
-    }
-    if (message) {
-      this.logger.error(message);
-    }
+  if (!this.logger || !this.options.verbose) {
+    return;
+  }
+
+  var message = _.get(item, 'data.body.trace.exception.message');
+  message = message || _.get(item, 'data.body.trace_chain.0.exception.message');
+  if (message) {
+    this.logger.error(message);
+    return;
+  }
+
+  message = _.get(item, 'data.body.message.body');
+  if (messagge) {
+    this.logger.log(message);
   }
 };
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -39,7 +39,7 @@ Queue.prototype.configure = function(options) {
 
 /*
  * addPredicate - adds a predicate to the end of the list of predicates for this queue
- * 
+ *
  * @param predicate - function(item, options) -> (bool|{err: Error})
  *  Returning true means that this predicate passes and the item is okay to go on the queue
  *  Returning false means do not add the item to the queue, but it is not an error
@@ -216,20 +216,17 @@ Queue.prototype._dequeuePendingRequest = function(item) {
 };
 
 Queue.prototype._maybeLog = function(item) {
-  if (!this.logger || !this.options.verbose) {
-    return;
-  }
-
-  var message = _.get(item, 'data.body.trace.exception.message');
-  message = message || _.get(item, 'data.body.trace_chain.0.exception.message');
-  if (message) {
-    this.logger.error(message);
-    return;
-  }
-
-  message = _.get(item, 'data.body.message.body');
-  if (message) {
-    this.logger.log(message);
+  if (this.logger && this.options.verbose) {
+    var message = _.get(item, 'data.body.trace.exception.message');
+    message = message || _.get(item, 'data.body.trace_chain.0.exception.message');
+    if (message) {
+      this.logger.error(message);
+      return;
+    }
+    message = _.get(item, 'data.body.message.body');
+    if (message) {
+      this.logger.log(message);
+    }
   }
 };
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -228,7 +228,7 @@ Queue.prototype._maybeLog = function(item) {
   }
 
   message = _.get(item, 'data.body.message.body');
-  if (messagge) {
+  if (message) {
     this.logger.log(message);
   }
 };

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -13,7 +13,7 @@ var _ = require('./utility');
 function Rollbar(options, api, logger) {
   this.options = _.extend(true, {}, options);
   this.logger = logger;
-  this.queue = new Queue(Rollbar.rateLimiter, api, this.options);
+  this.queue = new Queue(Rollbar.rateLimiter, api, logger, this.options);
   this.notifier = new Notifier(this.queue, this.options);
 }
 

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -484,6 +484,7 @@ Rollbar.defaultOptions = {
   scrubFields: packageJson.defaults.server.scrubFields,
   addRequestData: null,
   reportLevel: packageJson.defaults.reportLevel,
+  verbose: false,
   enabled: true
 };
 

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -37,7 +37,7 @@ function TestApiGenerator() {
   };
 
   TestApi.prototype.configure = function() {};
-  
+
   return TestApi;
 }
 
@@ -85,7 +85,7 @@ describe('configure', function() {
     var logger = new (TestLoggerGenerator())();
     var options = {a: 1, b: 42};
     var queue = new Queue(rateLimiter, api, logger, options);
-  
+
     expect(queue.options.a).to.eql(1);
     expect(queue.options.b).to.eql(42);
 
@@ -108,7 +108,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var serverResponse = {success: true};
 
@@ -129,7 +129,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var serverResponse = {success: true};
 
@@ -150,7 +150,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var serverResponse = {success: true};
 
@@ -173,7 +173,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {verbose: true};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {data: {body: {trace: {exception: {message: 'hello'}}}}};
         var serverResponse = {success: true};
 
@@ -191,13 +191,61 @@ describe('addItem', function() {
           done(err);
         });
       });
+      it('should call the logger if a message is about to be logged', function(done) {
+        var rateLimiter = new (TestRateLimiterGenerator())();
+        var api = new (TestApiGenerator())();
+        var logger = new (TestLoggerGenerator())();
+        var options = {verbose: true};
+        var queue = new Queue(rateLimiter, api, logger, options);
+
+        var item = {data: {body: {message: {body: 'hello'}}}};
+        var serverResponse = {success: true};
+
+        rateLimiter.handler = function(i) {
+          expect(i).to.eql(item);
+          return {error: null, shouldSend: true, payload: null};
+        };
+        api.handler = function(i, cb) {
+          expect(i).to.eql(item);
+          cb(null, serverResponse);
+        };
+        queue.addItem(item, function(err, resp) {
+          expect(resp).to.eql(serverResponse);
+          expect(logger.calls.log[0][0]).to.eql('hello');
+          done(err);
+        });
+      });
+      it('should not call the logger if verbose is false', function(done) {
+        var rateLimiter = new (TestRateLimiterGenerator())();
+        var api = new (TestApiGenerator())();
+        var logger = new (TestLoggerGenerator())();
+        var options = {verbose: false};
+        var queue = new Queue(rateLimiter, api, logger, options);
+
+        var item = {data: {body: {message: {body: 'hello'}}}};
+        var serverResponse = {success: true};
+
+        rateLimiter.handler = function(i) {
+          expect(i).to.eql(item);
+          return {error: null, shouldSend: true, payload: null};
+        };
+        api.handler = function(i, cb) {
+          expect(i).to.eql(item);
+          cb(null, serverResponse);
+        };
+        queue.addItem(item, function(err, resp) {
+          expect(resp).to.eql(serverResponse);
+          expect(logger.calls.log.length).to.eql(0);
+          done(err);
+        });
+      });
       it('should stop if a predicate returns false', function(done) {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var serverResponse = {success: true};
 
@@ -223,7 +271,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var serverResponse = {success: true};
 
@@ -251,7 +299,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var serverResponse = {success: true};
 
@@ -283,7 +331,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var serverResponse = {success: true};
 
@@ -311,7 +359,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var serverResponse = {success: true};
 
@@ -333,7 +381,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var serverResponse = {success: true};
 
@@ -363,7 +411,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var exception = 'boom!';
 
@@ -391,7 +439,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {retryInterval: 1};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var apiError = {code: 'NOPE', message: 'borked'};
 
@@ -413,7 +461,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var apiError = {code: 'ENOTFOUND', message: 'No internet connection'};
 
@@ -435,7 +483,7 @@ describe('addItem', function() {
         var logger = new (TestLoggerGenerator())();
         var options = {retryInterval: 1};
         var queue = new Queue(rateLimiter, api, logger, options);
-      
+
         var item = {mykey: 'myvalue'};
         var serverResponse = {success: true};
         var apiError = {code: 'ENOTFOUND', message: 'No internet connection'};
@@ -468,7 +516,7 @@ describe('addItem', function() {
       var logger = new (TestLoggerGenerator())();
       var options = {};
       var queue = new Queue(rateLimiter, api, logger, options);
-    
+
       var item = {mykey: 'myvalue'};
       var rateLimitError = 'bork';
 
@@ -496,7 +544,7 @@ describe('addItem', function() {
       var logger = new (TestLoggerGenerator())();
       var options = {};
       var queue = new Queue(rateLimiter, api, logger, options);
-    
+
       var item = {mykey: 'myvalue'};
       var rateLimitPayload = {something: 'went wrong'};
       var serverResponse = {message: 'good times'};


### PR DESCRIPTION
As far as I can tell, all the verbose option used to do was log to console.error when we are about to log an exception, so this adds that functionality back