### PR TITLE
Unhandled rejections [Fixes #307]

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -123,7 +123,7 @@ Rollbar.prototype.handleUnhandledRejection = function(reason, promise) {
   if (_.isError(reason)) {
     item = this._createItem([message, reason, context]);
   } else {
-    item = this._createItem([message, context]);
+    item = this._createItem([message, reason, context]);
     item.stackInfo = _.makeUnhandledStackInfo(
       message,
       '',
@@ -138,7 +138,7 @@ Rollbar.prototype.handleUnhandledRejection = function(reason, promise) {
   item.level = this.options.uncaughtErrorLevel;
   item._isUncaught = true;
   item._originalArgs = item._originalArgs || [];
-  item._originalArgs.push(reason, promise);
+  item._originalArgs.push(promise);
   this.client.log(item);
 };
 

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -137,6 +137,8 @@ Rollbar.prototype.handleUnhandledRejection = function(reason, promise) {
   }
   item.level = this.options.uncaughtErrorLevel;
   item._isUncaught = true;
+  item._originalArgs = item._originalArgs || [];
+  item._originalArgs.push(reason, promise);
   this.client.log(item);
 };
 


### PR DESCRIPTION
Rejecting with a non-error reason results in `reason.message` or `String(reason)` being set as the message to log. This gets rids of structure that the reason object might have had, so include the reason again to be picked up in custom data. I am not sure I would call it an anti-pattern per se to use non-errors as reasons for rejecting promises, but it is highly non-standard.