### PR TITLE
add back lastError on the rollbar instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ sauce_connect.log
 coverage
 .DS_Store
 *.swp
+npm-debug.log

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -24,6 +24,7 @@ function Rollbar(options, client) {
   if (this.options.captureUnhandledRejections) {
     globals.captureUnhandledRejections(window, this);
   }
+  this.lastError = null;
 }
 
 var _instance = null;
@@ -72,6 +73,9 @@ Rollbar.configure = function(options) {
 Rollbar.prototype.log = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.log(item);
   return {uuid: uuid};
 };
@@ -87,6 +91,9 @@ Rollbar.log = function() {
 Rollbar.prototype.debug = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.debug(item);
   return {uuid: uuid};
 };
@@ -102,6 +109,9 @@ Rollbar.debug = function() {
 Rollbar.prototype.info = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.info(item);
   return {uuid: uuid};
 };
@@ -117,6 +127,9 @@ Rollbar.info = function() {
 Rollbar.prototype.warn = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.warn(item);
   return {uuid: uuid};
 };
@@ -132,6 +145,9 @@ Rollbar.warn = function() {
 Rollbar.prototype.warning = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.warning(item);
   return {uuid: uuid};
 };
@@ -147,6 +163,9 @@ Rollbar.warning = function() {
 Rollbar.prototype.error = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.error(item);
   return {uuid: uuid};
 };
@@ -162,6 +181,9 @@ Rollbar.error = function() {
 Rollbar.prototype.critical = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.critical(item);
   return {uuid: uuid};
 };
@@ -198,6 +220,9 @@ Rollbar.prototype.handleUncaughtException = function(message, url, lineno, colno
   }
   item.level = this.options.uncaughtErrorLevel;
   item._isUncaught = true;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.log(item);
 };
 
@@ -226,6 +251,9 @@ Rollbar.prototype.handleUnhandledRejection = function(reason, promise) {
   item._isUncaught = true;
   item._originalArgs = item._originalArgs || [];
   item._originalArgs.push(promise);
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.log(item);
 };
 
@@ -369,6 +397,14 @@ Rollbar.prototype._createItem = function(args) {
   };
   item._originalArgs = args;
   return item;
+};
+
+Rollbar.prototype._sameAsLastError = function(item) {
+  if (this.lastError === item.err && this.lastError) {
+    return true;
+  }
+  this.lastError = item.err;
+  return false;
 };
 
 function _getFirstFunction(args) {

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -400,7 +400,7 @@ Rollbar.prototype._createItem = function(args) {
 };
 
 Rollbar.prototype._sameAsLastError = function(item) {
-  if (this.lastError === item.err && this.lastError) {
+  if (this.lastError && this.lastError === item.err) {
     return true;
   }
   this.lastError = item.err;

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -15,6 +15,7 @@ function Rollbar(options, api, logger) {
   this.logger = logger;
   this.queue = new Queue(Rollbar.rateLimiter, api, logger, this.options);
   this.notifier = new Notifier(this.queue, this.options);
+  this.lastError = null;
 }
 
 var defaultOptions = {
@@ -72,6 +73,9 @@ Rollbar.prototype.wait = function(callback) {
 /* Internal */
 
 Rollbar.prototype._log = function(defaultLevel, item) {
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   _.wrapRollbarFunction(this.logger, function() {
     var callback = null;
     if (item.callback) {
@@ -85,6 +89,14 @@ Rollbar.prototype._log = function(defaultLevel, item) {
 
 Rollbar.prototype._defaultLogLevel = function() {
   return this.options.logLevel || 'debug';
+};
+
+Rollbar.prototype._sameAsLastError = function(item) {
+  if (this.lastError && this.lastError === item.err) {
+    return true;
+  }
+  this.lastError = item.err;
+  return false;
 };
 
 module.exports = Rollbar;

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -37,7 +37,6 @@ function Rollbar(options, client) {
   if (this.options.handleUnhandledRejections) {
     this.handleUnhandledRejections();
   }
-  this.lastError = null;
 }
 
 var _instance = null;
@@ -83,12 +82,20 @@ Rollbar.configure = function(options) {
   }
 };
 
+Rollbar.prototype.lastError = function() {
+  return this.client.lastError;
+};
+Rollbar.lastError = function() {
+  if (_instance) {
+    return _instance.lastError();
+  } else {
+    handleUninitialized();
+  }
+};
+
 Rollbar.prototype.log = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
-  if (this._sameAsLastError(item)) {
-    return;
-  }
   this.client.log(item);
   return {uuid: uuid};
 };
@@ -104,9 +111,6 @@ Rollbar.log = function() {
 Rollbar.prototype.debug = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
-  if (this._sameAsLastError(item)) {
-    return;
-  }
   this.client.debug(item);
   return {uuid: uuid};
 };
@@ -122,9 +126,6 @@ Rollbar.debug = function() {
 Rollbar.prototype.info = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
-  if (this._sameAsLastError(item)) {
-    return;
-  }
   this.client.info(item);
   return {uuid: uuid};
 };
@@ -140,9 +141,6 @@ Rollbar.info = function() {
 Rollbar.prototype.warn = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
-  if (this._sameAsLastError(item)) {
-    return;
-  }
   this.client.warn(item);
   return {uuid: uuid};
 };
@@ -159,9 +157,6 @@ Rollbar.warn = function() {
 Rollbar.prototype.warning = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
-  if (this._sameAsLastError(item)) {
-    return;
-  }
   this.client.warning(item);
   return {uuid: uuid};
 };
@@ -178,9 +173,6 @@ Rollbar.warning = function() {
 Rollbar.prototype.error = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
-  if (this._sameAsLastError(item)) {
-    return;
-  }
   this.client.error(item);
   return {uuid: uuid};
 };
@@ -197,9 +189,6 @@ Rollbar.error = function() {
 Rollbar.prototype.critical = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
-  if (this._sameAsLastError(item)) {
-    return;
-  }
   this.client.critical(item);
   return {uuid: uuid};
 };
@@ -424,14 +413,6 @@ Rollbar.prototype._createItem = function(args) {
   }
   item.custom = custom;
   return item;
-};
-
-Rollbar.prototype._sameAsLastError = function(item) {
-  if (this.lastError && this.lastError === item.err) {
-    return true;
-  }
-  this.lastError = item.err;
-  return false;
 };
 
 function _getFirstFunction(args) {

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -427,7 +427,7 @@ Rollbar.prototype._createItem = function(args) {
 };
 
 Rollbar.prototype._sameAsLastError = function(item) {
-  if (this.lastError === item.err && this.lastError) {
+  if (this.lastError && this.lastError === item.err) {
     return true;
   }
   this.lastError = item.err;

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -37,6 +37,7 @@ function Rollbar(options, client) {
   if (this.options.handleUnhandledRejections) {
     this.handleUnhandledRejections();
   }
+  this.lastError = null;
 }
 
 var _instance = null;
@@ -85,6 +86,9 @@ Rollbar.configure = function(options) {
 Rollbar.prototype.log = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.log(item);
   return {uuid: uuid};
 };
@@ -100,6 +104,9 @@ Rollbar.log = function() {
 Rollbar.prototype.debug = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.debug(item);
   return {uuid: uuid};
 };
@@ -115,6 +122,9 @@ Rollbar.debug = function() {
 Rollbar.prototype.info = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.info(item);
   return {uuid: uuid};
 };
@@ -130,6 +140,9 @@ Rollbar.info = function() {
 Rollbar.prototype.warn = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.warn(item);
   return {uuid: uuid};
 };
@@ -146,6 +159,9 @@ Rollbar.warn = function() {
 Rollbar.prototype.warning = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.warning(item);
   return {uuid: uuid};
 };
@@ -162,6 +178,9 @@ Rollbar.warning = function() {
 Rollbar.prototype.error = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.error(item);
   return {uuid: uuid};
 };
@@ -178,6 +197,9 @@ Rollbar.error = function() {
 Rollbar.prototype.critical = function() {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
+  if (this._sameAsLastError(item)) {
+    return;
+  }
   this.client.critical(item);
   return {uuid: uuid};
 };
@@ -402,6 +424,14 @@ Rollbar.prototype._createItem = function(args) {
   }
   item.custom = custom;
   return item;
+};
+
+Rollbar.prototype._sameAsLastError = function(item) {
+  if (this.lastError === item.err && this.lastError) {
+    return true;
+  }
+  this.lastError = item.err;
+  return false;
 };
 
 function _getFirstFunction(args) {

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -105,31 +105,6 @@ describe('Rollbar()', function() {
 
     done();
   });
-
-  it('should not log the same error twice in a row', function(done) {
-    var client = new (TestClientGen())();
-    var options = {};
-    var rollbar = new Rollbar(options, client);
-
-    var args = [new Error('Whoa'), 'first', 'second'];
-    var methods = 'log,debug,info,warn,warning,error,critical'.split(',');
-    for (var i=0; i < methods.length; i++) {
-      var msgA = 'Amessage:' + i;
-      var msgB = 'Bmessage:' + i;
-      rollbar[methods[i]](msgA);
-      rollbar[methods[i]].apply(rollbar, args);
-      rollbar[methods[i]].apply(rollbar, args);
-      rollbar[methods[i]](msgB);
-      for (var j=0; j<3; j++) {
-        expect(client.logCalls[j+3*i].func).to.eql(methods[i]);
-      }
-      expect(client.logCalls[0+3*i].item.message).to.eql(msgA);
-      expect(client.logCalls[1+3*i].item.err).to.be.ok();
-      expect(client.logCalls[2+3*i].item.message).to.eql(msgB);
-    }
-
-    done();
-  });
 });
 
 describe('createItem', function() {

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -105,6 +105,31 @@ describe('Rollbar()', function() {
 
     done();
   });
+
+  it('should not log the same error twice in a row', function(done) {
+    var client = new (TestClientGen())();
+    var options = {};
+    var rollbar = new Rollbar(options, client);
+
+    var args = [new Error('Whoa'), 'first', 'second'];
+    var methods = 'log,debug,info,warn,warning,error,critical'.split(',');
+    for (var i=0; i < methods.length; i++) {
+      var msgA = 'Amessage:' + i;
+      var msgB = 'Bmessage:' + i;
+      rollbar[methods[i]](msgA);
+      rollbar[methods[i]].apply(rollbar, args);
+      rollbar[methods[i]].apply(rollbar, args);
+      rollbar[methods[i]](msgB);
+      for (var j=0; j<3; j++) {
+        expect(client.logCalls[j+3*i].func).to.eql(methods[i]);
+      }
+      expect(client.logCalls[0+3*i].item.message).to.eql(msgA);
+      expect(client.logCalls[1+3*i].item.err).to.be.ok();
+      expect(client.logCalls[2+3*i].item.message).to.eql(msgB);
+    }
+
+    done();
+  });
 });
 
 describe('createItem', function() {

--- a/test/server.rollbar.test.js
+++ b/test/server.rollbar.test.js
@@ -181,24 +181,6 @@ vows.describe('rollbar')
             var item = r.client.logCalls[r.client.logCalls.length - 1].item
             assert.equal(item.err, err)
           },
-          'should not log same one twice': function(r) {
-            var err = new Error('hello!')
-            r.client.clearLogCalls();
-            var msgA = 'some message A';
-            var msgB = 'some message B';
-            r.log(msgA);
-            r.log(err)
-            r.log(err)
-            r.log(msgB);
-            var len = r.client.logCalls.length;
-            assert.equal(len, 3);
-            var msgItemA = r.client.logCalls[0].item
-            var errItem = r.client.logCalls[1].item
-            var msgItemB = r.client.logCalls[2].item
-            assert.equal(msgItemA.message, msgA);
-            assert.equal(errItem.err, err)
-            assert.equal(msgItemB.message, msgB);
-          },
           'should work with callback': function(r) {
             var err = new Error('hello!')
             var callback = function cb() {}

--- a/test/server.rollbar.test.js
+++ b/test/server.rollbar.test.js
@@ -22,6 +22,9 @@ function TestClientGen() {
         this.logCalls.push({func: fn, item: item});
       }.bind(this, fn)
     }
+    this.clearLogCalls = function() {
+      this.logCalls = [];
+    };
   };
 
   return TestClient;
@@ -177,6 +180,24 @@ vows.describe('rollbar')
             r.log(err)
             var item = r.client.logCalls[r.client.logCalls.length - 1].item
             assert.equal(item.err, err)
+          },
+          'should not log same one twice': function(r) {
+            var err = new Error('hello!')
+            r.client.clearLogCalls();
+            var msgA = 'some message A';
+            var msgB = 'some message B';
+            r.log(msgA);
+            r.log(err)
+            r.log(err)
+            r.log(msgB);
+            var len = r.client.logCalls.length;
+            assert.equal(len, 3);
+            var msgItemA = r.client.logCalls[0].item
+            var errItem = r.client.logCalls[1].item
+            var msgItemB = r.client.logCalls[2].item
+            assert.equal(msgItemA.message, msgA);
+            assert.equal(errItem.err, err)
+            assert.equal(msgItemB.message, msgB);
           },
           'should work with callback': function(r) {
             var err = new Error('hello!')


### PR DESCRIPTION
`lastError` used to be a property that was stored on the notifier instance, this was used for a very simple form of deduping of errors; add this functionality back.