### PR TITLE
[#262] add a helper for wrapping callbacks

### DIFF
--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -230,6 +230,27 @@ Rollbar.errorHandler = function() {
   }
 };
 
+function wrapCallback(r, f) {
+  return function() {
+    var err = arguments[0];
+    if (err) {
+      r.error(err);
+    }
+    return f.apply(this, arguments);
+  }
+}
+
+Rollbar.prototype.wrapCallbac = function(f) {
+  return wrapCallback(this, f);
+};
+Rollbar.wrapCallback = function(f) {
+  if (_instance) {
+    return _instance.wrapCallback(f);
+  } else {
+    handleUninitialized();
+  }
+};
+
 
 /** DEPRECATED **/
 

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -240,7 +240,7 @@ function wrapCallback(r, f) {
   };
 }
 
-Rollbar.prototype.wrapCallbac = function(f) {
+Rollbar.prototype.wrapCallback = function(f) {
   return wrapCallback(this, f);
 };
 Rollbar.wrapCallback = function(f) {

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -237,7 +237,7 @@ function wrapCallback(r, f) {
       r.error(err);
     }
     return f.apply(this, arguments);
-  }
+  };
 }
 
 Rollbar.prototype.wrapCallbac = function(f) {


### PR DESCRIPTION
See #262. This adds a `wrapCallback` helper for the server side to automatically report errors returned to callback to Rollbar.