### PR TITLE
Fix #331 Verbose logging was using the wrong key structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -994,6 +994,18 @@ If you're using the [Passport](http://passportjs.org/) authentication library, t
 
 Note: in Rollbar, the `id` is used to uniquely identify a person; `email` and `username` are supplemental and will be overwritten whenever a new value is received for an existing `id`. The `id` is a string up to 40 characters long.
 
+## Verbose Option
+
+If you would like to see what is being sent to Rollbar in your console, use the
+`verbose` option. Set `verbose: true` in your configuration, and we will output certain information
+via the [debug](https://www.npmjs.com/package/debug) package. This package uses the `DEBUG`
+environment variable to configure what to output. We use the namespace `Rollbar` for our
+log messages, so for example, to see everything you need to do something like this:
+
+```
+DEBUG=Rollbar:* node app.js
+```
+
 ## Upgrading from node_rollbar
 
 The upgrade path from `node_rollbar` version 0.6.4 to version 2.0.0 of this library is not

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -68,11 +68,12 @@ Notifier.prototype.log = function(item, callback) {
     return callback(new Error('Rollbar is not enabled'));
   }
 
+  var originalError = item.err;
   this._applyTransforms(item, function(err, i) {
     if (err) {
       return callback(err, null);
     }
-    this.queue.addItem(i, callback);
+    this.queue.addItem(i, callback, originalError);
   }.bind(this));
 };
 
@@ -108,7 +109,7 @@ Notifier.prototype._applyTransforms = function(item, callback) {
 
     transforms[transformIndex](i, options, cb);
   };
-  
+
   cb(null, item);
 };
 

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -174,7 +174,7 @@ describe('addItem', function() {
         var options = {verbose: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
-        var item = {data: {body: {trace: {exception: {message: 'hello'}}}}};
+        var item = {body: {trace: {exception: {message: 'hello'}}}};
         var serverResponse = {success: true};
 
         rateLimiter.handler = function(i) {
@@ -198,7 +198,7 @@ describe('addItem', function() {
         var options = {verbose: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
-        var item = {data: {body: {message: {body: 'hello'}}}};
+        var item = {body: {message: {body: 'hello'}}};
         var serverResponse = {success: true};
 
         rateLimiter.handler = function(i) {
@@ -222,7 +222,7 @@ describe('addItem', function() {
         var options = {verbose: false};
         var queue = new Queue(rateLimiter, api, logger, options);
 
-        var item = {data: {body: {message: {body: 'hello'}}}};
+        var item = {body: {message: {body: 'hello'}}};
         var serverResponse = {success: true};
 
         rateLimiter.handler = function(i) {


### PR DESCRIPTION
The queue gets the item to log that represents the data in the final payload structure of
```
{
  "access_token": "abc123",
  "data": { ... }
}
```

rather than the whole payload itself. The API object is responsible for wrapping that data object up
inside a structure like the above and then sending it. Thus the body of the item is a top level key
rather than nested under the data key.

Secondly, everyone wants the original error to be output if there is one isntead of just the
exception message, so make it so.