### PR TITLE
[Fixes #269] get rid of rollbar wrapper stack frames

### DIFF
--- a/src/browser/globalSetup.js
+++ b/src/browser/globalSetup.js
@@ -92,7 +92,7 @@ function _extendListenerPrototype(handler, prototype, shim) {
       oldRemoveEventListener = oldRemoveEventListener._rollbarOldRemove;
     }
     var removeFn = function(event, callback, bubble) {
-      oldRemoveEventListener.call(this, event, callback && callback._wrapped || callback, bubble);
+      oldRemoveEventListener.call(this, event, callback && callback._rollbar_wrapped || callback, bubble);
     };
     removeFn._rollbarOldRemove = oldRemoveEventListener;
     removeFn.belongsToShim = shim;

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -257,8 +257,8 @@ Rollbar.prototype.wrap = function(f, context) {
       return f;
     }
 
-    if (!f._wrapped) {
-      f._wrapped = function () {
+    if (!f._rollbar_wrapped) {
+      f._rollbar_wrapped = function () {
         try {
           return f.apply(this, arguments);
         } catch(exc) {
@@ -274,18 +274,18 @@ Rollbar.prototype.wrap = function(f, context) {
         }
       };
 
-      f._wrapped._isWrap = true;
+      f._rollbar_wrapped._isWrap = true;
 
       if (f.hasOwnProperty) {
         for (var prop in f) {
           if (f.hasOwnProperty(prop)) {
-            f._wrapped[prop] = f[prop];
+            f._rollbar_wrapped[prop] = f[prop];
           }
         }
       }
     }
 
-    return f._wrapped;
+    return f._rollbar_wrapped;
   } catch (e) {
     // Return the original function if the wrap fails.
     return f;

--- a/src/browser/shim.js
+++ b/src/browser/shim.js
@@ -39,7 +39,7 @@ function setupShim(window, options) {
     return window[alias];
   }
 
-  window._rollbarShims = {}; 
+  window._rollbarShims = {};
   window._rollbarWrappedError = null;
 
   var handler = new Rollbar(options);
@@ -129,8 +129,8 @@ Shim.prototype.wrap = function(f, context) {
       return f;
     }
 
-    if (!f._wrapped) {
-      f._wrapped = function () {
+    if (!f._rollbar_wrapped) {
+      f._rollbar_wrapped = function () {
         try {
           return f.apply(this, arguments);
         } catch(exc) {
@@ -146,18 +146,18 @@ Shim.prototype.wrap = function(f, context) {
         }
       };
 
-      f._wrapped._isWrap = true;
+      f._rollbar_wrapped._isWrap = true;
 
       if (f.hasOwnProperty) {
         for (var prop in f) {
           if (f.hasOwnProperty(prop)) {
-            f._wrapped[prop] = f[prop];
+            f._rollbar_wrapped[prop] = f[prop];
           }
         }
       }
     }
 
-    return f._wrapped;
+    return f._rollbar_wrapped;
   } catch (e) {
     // Return the original function if the wrap fails.
     return f;
@@ -173,7 +173,7 @@ function stub(method) {
   });
 }
 
-var _methods = 
+var _methods =
   'log,debug,info,warn,warning,error,critical,global,configure,handleUncaughtException,handleUnhandledRejection'.split(',');
 
 for (var i = 0; i < _methods.length; ++i) {

--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -172,7 +172,7 @@ function addBodyTrace(item, options, callback) {
         method: (!stackFrame.func || stackFrame.func === '?') ? '[anonymous]' : stackFrame.func,
         colno: stackFrame.column
       };
-      if (frame.method && frame.method.indexOf('f._wrapped') != -1) {
+      if (frame.method && frame.method.endsWith && frame.method.endsWith('._rollbar_wrapped')) {
         continue;
       }
 

--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -172,6 +172,9 @@ function addBodyTrace(item, options, callback) {
         method: (!stackFrame.func || stackFrame.func === '?') ? '[anonymous]' : stackFrame.func,
         colno: stackFrame.column
       };
+      if (frame.method && frame.method.indexOf('f._wrapped') != -1) {
+        continue;
+      }
 
       code = pre = post = null;
       contextLength = stackFrame.context ? stackFrame.context.length : 0;


### PR DESCRIPTION
We wrap certain built-ins in the browser and rethrow exceptions. When such an error occurs, our wrapper ends up in the stack trace because technically it is running, but it isn't really part of the error so there is no reason for it to be in the stack trace.

There are a few different ways I looked at fixing this, but in the end just checking for our `f._wrapped` method signature in the frame is the simplest and actually works about as well as any other approach. Threading state around is a bit of a mess, and actually munging the exception at the rethrow site is impossible due to browser differences.