### PR TITLE
add some intervals to keep the event loop running when wait is called

### DIFF
--- a/src/queue.js
+++ b/src/queue.js
@@ -101,8 +101,7 @@ Queue.prototype.wait = function(callback) {
     return;
   }
   this.waitCallback = callback;
-  if (this.pendingRequests.length == 0) {
-    this.waitCallback();
+  if (this._maybeCallWait()) {
     return;
   }
   if (this.waitIntervalID) {
@@ -216,9 +215,7 @@ Queue.prototype._dequeuePendingRequest = function(item) {
   for (var i = this.pendingRequests.length; i >= 0; i--) {
     if (this.pendingRequests[i] == item) {
       this.pendingRequests.splice(i, 1);
-      if (shouldCallWaitOnRemove && _.isFunction(this.waitCallback)) {
-        this.waitCallback();
-      }
+      this._maybeCallWait();
       return;
     }
   }
@@ -246,7 +243,9 @@ Queue.prototype._maybeCallWait = function() {
       this.waitIntervalID = clearInterval(this.waitIntervalID);
     }
     this.waitCallback();
+    return true;
   }
+  return false;
 };
 
 module.exports = Queue;

--- a/src/queue.js
+++ b/src/queue.js
@@ -211,7 +211,6 @@ Queue.prototype._retryApiRequest = function(item, callback) {
  * @param item - the item previously added to the pending request queue
  */
 Queue.prototype._dequeuePendingRequest = function(item) {
-  var shouldCallWaitOnRemove = this.pendingRequests.length == 1;
   for (var i = this.pendingRequests.length; i >= 0; i--) {
     if (this.pendingRequests[i] == item) {
       this.pendingRequests.splice(i, 1);

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -397,11 +397,14 @@ Rollbar.prototype.handleUncaughtExceptions = function() {
         logger.error('Encountered error while handling an uncaught exception.');
         logger.error(err);
       }
-
-      if (exitOnUncaught) {
-        process.exit(1);
-      }
     });
+    if (exitOnUncaught) {
+      setImmediate(function() {
+        this.wait(function() {
+          process.exit(1);
+        });
+      }.bind(this));
+    }
   }.bind(this));
 };
 


### PR DESCRIPTION
It is possible that calling wait does not actually keep the event loop spinning while all events are processing. The proper use of interval timers in the queue will keep things open until all the pending requests have actually gone out.