### PR TITLE
unify configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,17 +768,17 @@ constructor.
 var Rollbar = require('rollbar');
 var rollbar = new Rollbar({
   accessToken: 'POST_SERVER_ITEM_ACCESS_TOKEN',
-  handleUncaughtExceptions: true,
-  handleUnhandledRejections: true
+  captureUncaught: true,
+  captureUnhandledRejections: true
 });
 
 // log a generic message and send to rollbar
 rollbar.log('Hello world!');
 ```
-Setting the ```handleUncaughtExceptions``` option to true will register Rollbar as a handler for
+Setting the ```captureUncaught``` option to true will register Rollbar as a handler for
 any uncaught exceptions in your Node process.
 
-Similarly, setting the ```handleUnhandledRejections``` option to true will register Rollbar as a
+Similarly, setting the ```captureUnhandledRejections``` option to true will register Rollbar as a
 handler for any unhandled Promise rejections in your Node process.
 
 <!-- RemoveNextIfProject -->
@@ -1066,8 +1066,8 @@ New:
 ```js
 var rollbar = new Rollbar({
   accessToken: "POST_SERVER_ITEM_ACCESS_TOKEN",
-  handleUncaughtExceptions: true,
-  handleUnhandledRejections: true
+  captureUncaught: true,
+  captureUnhandledRejections: true
 });
 
 ```
@@ -1085,7 +1085,7 @@ const Rollbar = require('rollbar');
 
 const rollbar = Rollbar.init({
   accessToken: "POST_SERVER_ITEM_ACCESS_TOKEN",
-  handleUncaughtExceptions: true
+  captureUncaught: true
 });
 ```
 

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -18,11 +18,11 @@ function Rollbar(options, client) {
   this.client = client || new Client(this.options, api, logger, 'browser');
   addTransformsToNotifier(this.client.notifier);
   addPredicatesToQueue(this.client.queue);
-  if (this.options.captureUncaught) {
+  if (this.options.captureUncaught || this.options.handleUncaughtExceptions) {
     globals.captureUncaughtExceptions(window, this);
     globals.wrapGlobals(window, this);
   }
-  if (this.options.captureUnhandledRejections) {
+  if (this.options.captureUnhandledRejections || this.options.handleUnhandledRejections) {
     globals.captureUnhandledRejections(window, this);
   }
 }

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -32,10 +32,10 @@ function Rollbar(options, client) {
   addTransformsToNotifier(this.client.notifier);
   addPredicatesToQueue(this.client.queue);
 
-  if (this.options.handleUncaughtExceptions) {
+  if (this.options.captureUncaught || this.options.handleUncaughtExceptions) {
     this.handleUncaughtExceptions();
   }
-  if (this.options.handleUnhandledRejections) {
+  if (this.options.captureUnhandledRejections || this.options.handleUnhandledRejections) {
     this.handleUnhandledRejections();
   }
 }


### PR DESCRIPTION
The configuration options for capturing unhandled exceptions and rejections should be the same on the browser and server