### PR TITLE
Add accessToken to typescript configuration interface

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -30,6 +30,7 @@ declare namespace Rollbar {
     export type MaybeError = Error | undefined | null;
     export type Level = "debug" | "info" | "warning" | "error" | "critical";
     export interface Configuration {
+        accessToken: string;
         version?: string;
         scrubFields?: string[];
         logLevel?: Level;


### PR DESCRIPTION
This seems like it was accidentally left out of the typescript definition?