### PR TITLE
Use JSON polyfill if the detected JSON.* arent native funtions

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -9,10 +9,10 @@ function setupJSON() {
   __initRollbarJSON = true;
 
   if (isDefined(JSON)) {
-    if (isFunction(JSON.stringify)) {
+    if (isNativeFunction(JSON.stringify)) {
       RollbarJSON.stringify = JSON.stringify;
     }
-    if (isFunction(JSON.parse)) {
+    if (isNativeFunction(JSON.parse)) {
       RollbarJSON.parse = JSON.parse;
     }
   }
@@ -69,6 +69,19 @@ function typeName(x) {
  */
 function isFunction(f) {
   return isType(f, 'function');
+}
+
+/* isNativeFunction - a convenience function for checking if a value is a native JS function
+ *
+ * @param f - any value
+ * @returns true if f is a native JS function, otherwise false
+ */
+function isNativeFunction(f) {
+  if (!isFunction(f)) {
+    return false;
+  }
+  var functionString = Function.prototype.toString.call(f);
+  return /\{\s+\[native code\]/.test(functionString);
 }
 
 /*
@@ -563,6 +576,7 @@ module.exports = {
   isType: isType,
   typeName: typeName,
   isFunction: isFunction,
+  isNativeFunction: isNativeFunction,
   isIterable: isIterable,
   isError: isError,
   extend: extend,

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -90,6 +90,24 @@ describe('isFunction', function() {
     expect(_.isFunction(g)).to.be.ok();
     done();
   });
+
+});
+describe('isNativeFunction', function() {
+  it('should work for all native functions', function(done) {
+    var f = function() { return; };
+    var g = function(x) {
+      return f(x);
+    };
+    var h = String.prototype.substr;
+    var i = Array.prototype.indexOf;
+    expect(_.isNativeFunction({})).to.not.be.ok();
+    expect(_.isNativeFunction(null)).to.not.be.ok();
+    expect(_.isNativeFunction(f)).to.not.be.ok();
+    expect(_.isNativeFunction(g)).to.not.be.ok();
+    expect(_.isNativeFunction(h)).to.be.ok();
+    expect(_.isNativeFunction(i)).to.be.ok();
+    done();
+  });
 });
 
 describe('isIterable', function() {


### PR DESCRIPTION
The prototype framework (and probably more) apply JSON polyfills which arent standards compliant leading to API rejections. If the JSON.* arnt native, use our own polyfill.  