### PR TITLE
fix telemetry network bug

### DIFF
--- a/examples/universal-browser/test.html
+++ b/examples/universal-browser/test.html
@@ -45,6 +45,11 @@
         xhr.onload = function() {
           console.log('Got: ', xhr.response);
         };
+        xhr.onreadystatechange = function() {
+          if (this.readyState === 4) {
+            console.log('Done!');
+          }
+        };
         xhr.send(null);
       }
     </script>

--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -129,7 +129,7 @@ Instrumenter.prototype.instrumentNetwork = function() {
 
         if ('onreadystatechange' in xhr && _.isFunction(xhr.onreadystatechange)) {
           replace(xhr, 'onreadystatechange', function(orig) {
-            self.rollbar.wrap(orig, undefined, onreadystatechangeHandler);
+            return self.rollbar.wrap(orig, undefined, onreadystatechangeHandler);
           });
         } else {
           xhr.onreadystatechange = onreadystatechangeHandler;


### PR DESCRIPTION
The third argument to replace is a function that is required to return a function which becomes the new function for a given property on an object. If you don't return a function then the property on the object gets replaced with undefined, breaking everything.

This only manifests if onreadystatechange is defined on an xhr request, which was not something I did during manual or automated testing. I added it to the manual test page and verified that before this diff things were broken, and afterwards everything works as expected.