### PR TITLE
no matter what Date.now() returns, make it a number

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -557,7 +557,7 @@ function formatArgsAsString(args) {
 
 function now() {
   if (Date.now) {
-    return Date.now();
+    return +Date.now();
   }
   return +new Date();
 }


### PR DESCRIPTION
Fixes #388 

If `Date.now()` returns `new Date()` which is what Date.js does for some crazy reason, then `+Date.now()` is the same as `+new Date()` which is the same fallback we have when `Date.now` is undefined. Otherwise, if `Date.now()` returns a timestamp like it should, then `+Date.now()` is just the same as `Date.now()` through the magic of Javascript operators.