### PR TITLE
Ensure hostBlackList is considered when filtering errors

### DIFF
--- a/src/browser/predicates.js
+++ b/src/browser/predicates.js
@@ -141,7 +141,6 @@ function messageIsIgnored(item, settings) {
 module.exports = {
   checkIgnore: checkIgnore,
   userCheckIgnore: userCheckIgnore,
-  urlIsBlacklisted: urlIsBlacklisted,
   urlIsNotBlacklisted: urlIsNotBlacklisted,
   urlIsWhitelisted: urlIsWhitelisted,
   messageIsIgnored: messageIsIgnored

--- a/src/browser/predicates.js
+++ b/src/browser/predicates.js
@@ -36,6 +36,10 @@ function urlIsBlacklisted(item, settings) {
   return urlIsOnAList(item, settings, 'blacklist');
 }
 
+function urlIsNotBlacklisted(item, settings) {
+  return !urlIsBlacklisted(item, settings);
+}
+
 function urlIsWhitelisted(item, settings) {
   return urlIsOnAList(item, settings, 'whitelist');
 }
@@ -142,6 +146,7 @@ module.exports = {
   checkIgnore: checkIgnore,
   userCheckIgnore: userCheckIgnore,
   urlIsBlacklisted: urlIsBlacklisted,
+  urlIsNotBlacklisted: urlIsNotBlacklisted,
   urlIsWhitelisted: urlIsWhitelisted,
   messageIsIgnored: messageIsIgnored
 };

--- a/src/browser/predicates.js
+++ b/src/browser/predicates.js
@@ -32,12 +32,8 @@ function userCheckIgnore(item, settings) {
   return true;
 }
 
-function urlIsBlacklisted(item, settings) {
-  return urlIsOnAList(item, settings, 'blacklist');
-}
-
 function urlIsNotBlacklisted(item, settings) {
-  return !urlIsBlacklisted(item, settings);
+  return !urlIsOnAList(item, settings, 'blacklist');
 }
 
 function urlIsWhitelisted(item, settings) {

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -360,8 +360,8 @@ function addPredicatesToQueue(queue) {
   queue
     .addPredicate(predicates.checkIgnore)
     .addPredicate(predicates.userCheckIgnore)
-    .addPredicate(predicates.urlIsWhitelisted)
     .addPredicate(predicates.urlIsNotBlacklisted)
+    .addPredicate(predicates.urlIsWhitelisted)
     .addPredicate(predicates.messageIsIgnored);
 }
 

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -361,6 +361,7 @@ function addPredicatesToQueue(queue) {
     .addPredicate(predicates.checkIgnore)
     .addPredicate(predicates.userCheckIgnore)
     .addPredicate(predicates.urlIsWhitelisted)
+    .addPredicate(predicates.urlIsNotBlacklisted)
     .addPredicate(predicates.messageIsIgnored);
 }
 

--- a/test/browser.predicates.test.js
+++ b/test/browser.predicates.test.js
@@ -211,8 +211,8 @@ describe('urlIsWhitelisted', function() {
   });
 });
 
-describe('urlIsBlacklisted', function() {
-  it('should return true with no blacklist', function() {
+describe('urlIsNotBlacklisted', function() {
+  it('should return false with no blacklist', function() {
     var item = {
       level: 'critical',
       body: {trace: {frames: [
@@ -224,9 +224,9 @@ describe('urlIsBlacklisted', function() {
     var settings = {
       reportLevel: 'debug'
     };
-    expect(p.urlIsBlacklisted(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlacklisted(item, settings)).to.not.be.ok();
   });
-  it('should return true with no trace', function() {
+  it('should return false with no trace', function() {
     var item = {
       level: 'critical',
       body: {message: 'hey'}
@@ -235,9 +235,9 @@ describe('urlIsBlacklisted', function() {
       reportLevel: 'debug',
       hostBlackList: ['fake.com', 'other.com']
     };
-    expect(p.urlIsBlacklisted(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlacklisted(item, settings)).to.not.be.ok();
   });
-  it('should return false if any regex matches at least one filename in the trace', function() {
+  it('should return true if any regex matches at least one filename in the trace', function() {
     var item = {
       level: 'critical',
       body: {trace: {frames: [
@@ -250,9 +250,9 @@ describe('urlIsBlacklisted', function() {
       reportLevel: 'debug',
       hostBlackList: ['example.com', 'other.com']
     };
-    expect(p.urlIsBlacklisted(item, settings)).to.not.be.ok();
+    expect(p.urlIsNotBlacklisted(item, settings)).to.be.ok();
   });
-  it('should return true if the filename is not a string', function() {
+  it('should return false if the filename is not a string', function() {
     var item = {
       level: 'critical',
       body: {trace: {frames: [
@@ -265,9 +265,9 @@ describe('urlIsBlacklisted', function() {
       reportLevel: 'debug',
       hostBlackList: ['example.com', 'other.com']
     };
-    expect(p.urlIsBlacklisted(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlacklisted(item, settings)).to.not.be.ok();
   });
-  it('should return true if there is no frames key', function() {
+  it('should return false if there is no frames key', function() {
     var item = {
       level: 'critical',
       body: {trace: {notframes: []}}
@@ -276,9 +276,9 @@ describe('urlIsBlacklisted', function() {
       reportLevel: 'debug',
       hostBlackList: ['nope.com']
     };
-    expect(p.urlIsBlacklisted(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlacklisted(item, settings)).to.not.be.ok();
   });
-  it('should return true if there are no frames', function() {
+  it('should return false if there are no frames', function() {
     var item = {
       level: 'critical',
       body: {trace: {frames: []}}
@@ -287,9 +287,9 @@ describe('urlIsBlacklisted', function() {
       reportLevel: 'debug',
       hostBlackList: ['nope.com']
     };
-    expect(p.urlIsBlacklisted(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlacklisted(item, settings)).to.not.be.ok();
   });
-  it('should return true if nothing in the blacklist matches', function() {
+  it('should return false if nothing in the blacklist matches', function() {
     var item = {
       level: 'critical',
       body: {trace: {frames: [
@@ -302,7 +302,7 @@ describe('urlIsBlacklisted', function() {
       reportLevel: 'debug',
       hostBlackList: ['baz\.com', 'foo\.com']
     };
-    expect(p.urlIsBlacklisted(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlacklisted(item, settings)).to.not.be.ok();
   });
 });
 


### PR DESCRIPTION
The ability to black list hostnames was [added recently](https://github.com/rollbar/rollbar.js/pull/319) but doesn't appear to actually be used.

I'm not overly familiar with the Rollbar source, but from what I can see it simply needs to be added to the list of predicates (in the inverse form, so it returned true if not blacklisted).
