### PR TITLE
we should not be storing the props for every request, only the prototype one

### DIFF
--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -113,7 +113,7 @@ Instrumenter.prototype.instrumentNetwork = function() {
     if (prop in xhr && _.isFunction(xhr[prop])) {
       replace(xhr, prop, function(orig) {
         return self.rollbar.wrap(orig);
-      }, self.replacements, 'network');
+      });
     }
   }
 


### PR DESCRIPTION
Fixes #413 

There is something like a memory leak, at least it has the same effect if it is not classically a leak. We were storing wrapped properties for every network request rather than just the wrapped properties on the XHR prototype. While this is maybe technically correct in some abstract sense as it allows us to properly unwrap everything if the configuration changes, we don't really need to unwrap those for things to still work. Also storing them will result in a growing memory footprint without any real cleanup mechanism. The alternative to this fix is to have the onreadystatechange handler do some cleanup when the request is done, but this is fix is adequate.