### PR TITLE
don't package .git file in npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,6 +2,7 @@ node_modules
 bower_components
 .idea
 vendor/*.min.js
+vendor/JSON-js/.git
 test/*.bundle.js*
 sauce_connect.log
 release


### PR DESCRIPTION
2.2.7 breaks our jenkins build because we do a git clean on our own git dir during checkout which fails because rollbar has dropped a `vendor/JSON-js/.git` file into `node_modules/rollbar`.

I don't have a whole lot of experience with git submodules, so I opted with the simple solution of excluding the .git file from the npm package.