### PR TITLE
s/._rollbar_wrapped/_rollbar_wrapped/

### DIFF
--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -173,7 +173,7 @@ function addBodyTrace(item, options, callback) {
         method: (!stackFrame.func || stackFrame.func === '?') ? '[anonymous]' : stackFrame.func,
         colno: stackFrame.column
       };
-      if (frame.method && frame.method.endsWith && frame.method.endsWith('._rollbar_wrapped')) {
+      if (frame.method && frame.method.endsWith && frame.method.endsWith('_rollbar_wrapped')) {
         continue;
       }
 


### PR DESCRIPTION
Sometimes the method shows up as just the method, not as the enclosing object `.` the method, so handle those cases as well.