### PR TITLE
Require JSON3 dependency with absolute path

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -1,4 +1,5 @@
 var extend = require('extend');
+var path = require('path');
 
 var RollbarJSON = {};
 var __initRollbarJSON = false;
@@ -17,7 +18,7 @@ function setupJSON() {
     }
   }
   if (!isFunction(RollbarJSON.stringify) || !isFunction(RollbarJSON.parse)) {
-    var setupCustomJSON = require('../vendor/JSON-js/json3.js');
+    var setupCustomJSON = require(path.resolve('../vendor/JSON-js/json3.js'));
     setupCustomJSON(RollbarJSON);
   }
 }


### PR DESCRIPTION
Cannot bundle Rollbar with Webpack 3 since it cannot require `json3.js` ✨ .

```
ERROR in ./node_modules/rollbar/src/utility.js
Module not found: Error: Can't resolve '../vendor/JSON-js/json3.js' in '__ABS_PATH__/node_modules/rollbar/src'
 @ ./node_modules/rollbar/src/utility.js 21:26-63
 @ ./node_modules/rollbar/src/server/rollbar.js
 @ ./src/rollbar.ts
 @ ./src/handlers.ts
```

![giphy-downsized 1](https://user-images.githubusercontent.com/1334474/30882125-f48d1f50-a2ff-11e7-8dae-b32ae668d05e.gif)
