### PR TITLE
Fix: calling Rollbar.configure shouldn't clear telemetry config.

### DIFF
--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -10,7 +10,8 @@ function Telemeter(options) {
 }
 
 Telemeter.prototype.configure = function(options) {
-  this.options = _.extend(true, {}, options);
+  var oldOptions = this.options;
+  this.options = _.extend(true, {}, oldOptions, options);
   var maxTelemetryEvents = this.options.maxTelemetryEvents || MAX_EVENTS;
   var newMaxEvents = Math.max(0, Math.min(maxTelemetryEvents, MAX_EVENTS));
   var deleteCount = 0;

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -65,4 +65,21 @@ describe('configure', function() {
     expect(t.queue.length).to.equal(5);
     done();
   });
+  it('does not drop existing options that are not passed to configure', function(done) {
+    var options = {maxTelemetryEvents: 3};
+    var t = new Telemeter(options);
+
+    for (var i = 0; i < 7; i++) {
+      t.capture('network', {url: 'a.com'}, 'debug');
+    }
+
+    expect(t.queue.length).to.equal(3);
+    t.configure({});
+    expect(t.queue.length).to.equal(3);
+    for (var i = 0; i < 7; i++) {
+      t.capture('network', {url: 'a.com'}, 'debug');
+    }
+    expect(t.queue.length).to.equal(3);
+    done();
+  });
 });


### PR DESCRIPTION
Let me know if this is just a case of me doing it wrong, but here are the repro steps to what I was seeing:

1.) Initially configure Rollbar with `maxTelemetryEvents: 15` or something that isn't `100`.
2.) At some point in the future, call `Rollbar.configure`, e.g.
```javascript
Rollbar.configure({
  payload: {
    person: { id: 1, email: 'me@example.com' }
  }
});
```
__Expected__: `maxTelemetryEvents` is still set to 15.
__Actual__: `maxTelemetryEvents` is reset to the default (100).
