### PR TITLE
Migrate from debug to binding console

### DIFF
--- a/src/server/logger.js
+++ b/src/server/logger.js
@@ -1,18 +1,10 @@
 'use strict';
 
-var debug = require('debug');
 var name = 'Rollbar';
 
 var logger = {
-  log: debug(name + ':log'),
-  error: debug(name + ':error')
+  log: console.log.bind(console),
+  error: console.error.bind(console)
 };
-
-/* eslint-disable no-console */
-
-// Make logger.log log to stdout rather than stderr
-logger.log.log = console.log.bind(console);
-
-/* eslint-enable no-console */
 
 module.exports = logger;

--- a/src/server/logger.js
+++ b/src/server/logger.js
@@ -3,8 +3,10 @@
 var name = 'Rollbar';
 
 var logger = {
+  /* eslint-disable no-console */
   log: console.log.bind(console),
   error: console.error.bind(console)
+  /* eslint-enable no-console */
 };
 
 module.exports = logger;


### PR DESCRIPTION
As discussed in issue [#470](https://github.com/rollbar/rollbar.js/issues/470) this PR tries to keep verbose logging without the debug module