### PR TITLE
fixes errMsg.match is not a function error

### DIFF
--- a/src/browser/errorParser.js
+++ b/src/browser/errorParser.js
@@ -63,7 +63,7 @@ function parse(e) {
 
 
 function guessErrorClass(errMsg) {
-  if (!errMsg) {
+  if (!errMsg || !errMsg.match) {
     return ['Unknown error. There was no error message to display.', ''];
   }
   var errClassMatch = errMsg.match(ERR_CLASS_REGEXP);


### PR DESCRIPTION
I'm getting errMsg.match is not a function error from https://cdnjs.cloudflare.com/ajax/libs/rollbar.js/2.3.1/rollbar.min.js