### PR TITLE
Add environment to options type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -37,6 +37,7 @@ declare namespace Rollbar {
     export interface Configuration {
         accessToken?: string;
         version?: string;
+        environment?: string;
         scrubFields?: string[];
         logLevel?: Level;
         reportLevel?: Level;


### PR DESCRIPTION
I found while writing a Typescript project that it's a type error to specify the environment while creating a rollbar object. This adds that specific option.

Are there any other options that are missing from this type? Just looking at [`Rollbar.defaultOptions`](https://github.com/rollbar/rollbar.js/blob/05a043a26ab5184c0a7b9aeaedf92845c23db025/src/server/rollbar.js#L506), it looks like these are missing:

- `host`
- `framework`
- `showReportedMessageTraces`
- `notifier`
- `scrubHeaders`
- `addRequestData`

There might be others, I haven't scrubbed the whole codebase for usages of this object.