### PR TITLE
Proper scrubbing

### DIFF
--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -223,7 +223,7 @@ function addBodyTrace(item, options, callback) {
 
 function scrubPayload(item, options, callback) {
   var scrubFields = options.scrubFields;
-  _.scrub(item.data, scrubFields);
+  item.data = _.scrub(item.data, scrubFields);
   callback(null, item);
 }
 

--- a/src/react-native/transforms.js
+++ b/src/react-native/transforms.js
@@ -83,7 +83,7 @@ function scrubPayload(item, options, callback) {
   var scrubHeaders = options.scrubHeaders || [];
   var scrubFields = options.scrubFields || [];
   scrubFields = scrubHeaders.concat(scrubFields);
-  _.scrub(item.data, scrubFields);
+  item.data = _.scrub(item.data, scrubFields);
   callback(null, item);
 }
 

--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -172,7 +172,7 @@ function scrubPayload(item, options, callback) {
   var scrubHeaders = options.scrubHeaders || [];
   var scrubFields = options.scrubFields || [];
   scrubFields = scrubHeaders.concat(scrubFields);
-  _.scrub(item.data, scrubFields);
+  item.data = _.scrub(item.data, scrubFields);
   callback(null, item);
 }
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -547,7 +547,7 @@ function _getScrubFieldRegexs(scrubFields) {
   var ret = [];
   var pat;
   for (var i = 0; i < scrubFields.length; ++i) {
-    pat = '\\[?(%5[bB])?' + scrubFields[i] + '\\[?(%5[bB])?\\]?(%5[dD])?';
+    pat = '^\\[?(%5[bB])?' + scrubFields[i] + '\\[?(%5[bB])?\\]?(%5[dD])?$';
     ret.push(new RegExp(pat, 'i'));
   }
   return ret;

--- a/src/utility.js
+++ b/src/utility.js
@@ -150,13 +150,14 @@ function traverse(obj, func, seen) {
     }
   }
 
+  var result = isObj ? {} : [];
   for (i = 0; i < keys.length; ++i) {
     k = keys[i];
     v = obj[k];
-    obj[k] = func(k, v, seen);
+    result[k] = func(k, v, seen);
   }
 
-  return obj;
+  return (keys.length != 0) ? result : obj;
 }
 
 function redact() {
@@ -539,8 +540,7 @@ function scrub(data, scrubFields) {
     }
   }
 
-  traverse(data, scrubber, []);
-  return data;
+  return traverse(data, scrubber, []);
 }
 
 function _getScrubFieldRegexs(scrubFields) {

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -451,13 +451,15 @@ describe('scrub', function() {
   it('should not redact fields that are okay', function() {
     var data = {
       a: 'somestring',
-      password: 'abc123'
+      password: 'abc123',
+      tempWorker: 'cool'
     };
-    var scrubFields = ['password', 'b'];
+    var scrubFields = ['password', 'b', 'pw'];
 
     var result = _.scrub(data, scrubFields);
 
     expect(result.a).to.eql('somestring');
+    expect(result.tempWorker).to.eql('cool');
   });
   it('should redact fields that are in the field list', function() {
     var data = {

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -493,6 +493,7 @@ describe('scrub', function() {
     expect(result.a.c).to.eql('bork');
     expect(result.a.password).to.not.eql('abc123');
     expect(result.secret).to.not.eql('blahblah');
+    expect(data.secret).to.eql('blahblah');
   });
   it('should do something sane for recursive objects', function() {
     var inner = {
@@ -512,6 +513,7 @@ describe('scrub', function() {
     expect(result.thing).to.eql('stuff');
     expect(result.password).to.not.eql('abc123');
     expect(result.inner.a).to.not.eql('what');
+    expect(result.inner.a).to.be.ok();
     expect(result.inner.b).to.eql('yes');
   });
 });


### PR DESCRIPTION
Fixes #508 
Fixes #509 

We should not modify an object in-place to scrub it.
We should not use an unanchored regular expression for testing whether to scrub a key.