### PR TITLE
Include current item in telemetry queue

### DIFF
--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -108,8 +108,8 @@ Rollbar.prototype._log = function(defaultLevel, item) {
       delete item.callback;
     }
     item.level = item.level || defaultLevel;
-    item.telemetryEvents = this.telemeter.copyEvents();
     this.telemeter._captureRollbarItem(item);
+    item.telemetryEvents = this.telemeter.copyEvents();
     this.notifier.log(item, callback);
   } catch (e) {
     this.logger.error(e)


### PR DESCRIPTION
Curently we send an item to rollbar with an array of telemetry events leading up to this specific
item, but that queue does not contain any information about the item it is embedded inside. This was done so that we would not duplicate data being transmitted. The relevant event could just be tacked on to the end of the list by the backend.

This leads to some oddities in the UI based on the way we source information about the related item
to embed in the telemetry data. Rather than further complicate that process, we can simply include
the information about the current item in the telemetry queue and not have to do that extra work on
the backend. The amount of extra data being transmitted is relatively inconsequential.