### PR TITLE
Add filterTelemetry callback configuration parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -461,6 +461,18 @@ store only the smallest amount of information necessary to aid in understanding.
 have concerns about memory usage, you can turn the collection of some or all events off, or limit
 the size of the queue of events that we store.
 
+Also you can filter out telemetry events with an optional test function `filterTelemetry`. Telemetry event gets passed as the first argument and boolean return value is expected. Any event that matches the test is not added to the queue. One common use case is to filter out spammy XHR requests:
+
+```js
+{
+  filterTelemetry: function(e) {
+    return e.type === 'network'
+      && (e.body.subtype === 'xhr' || e.body.subtype === 'fetch')
+      && e.body.url.indexOf('https://spammer.com') === 0;
+  }
+}
+```
+
 The data that is collected is included in the payload and also goes through the same scrubbing
 process described elsewhere. However, we also provide two additional options for scrubbing of
 telemetry specific data related to inputs in the dom. The first options is `scrubTelemetryInputs`.

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -37,6 +37,15 @@ Telemeter.prototype.capture = function(type, metadata, level, rollbarUUID, times
   if (rollbarUUID) {
     e.uuid = rollbarUUID;
   }
+
+  try {
+    if (_.isFunction(this.options.filterTelemetry) && this.options.filterTelemetry(e)) {
+      return false;
+    }
+  } catch (e) {
+    this.options.filterTelemetry = null;
+  }
+
   this.push(e);
   return e;
 };

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -34,6 +34,24 @@ describe('capture', function() {
   });
 });
 
+
+describe('filterTelemetry', function() {
+  it('should filter out events that don\'t match the test', function(done) {
+    var options = {
+      filterTelemetry: function(e) {
+        return e.type === 'network'
+          && (e.body.subtype === 'xhr' || e.body.subtype === 'fetch')
+          && e.body.url.indexOf('https://spammer.com') === 0;
+      }
+    };
+    var t = new Telemeter(options);
+    var event = t.capture('network', {url: 'https://spammer.com'}, 'debug');
+    expect(event).to.be.false;
+
+    done();
+  });
+});
+
 describe('configure', function() {
   it('should truncate events to new max', function(done) {
     var options = {maxTelemetryEvents: 5};


### PR DESCRIPTION
Adds the capability to filter out any telemetry event with custom filter function.
Resolves #519.

