### PR TITLE
Fix Rollbar types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,7 @@
  *~ file should be 'super-greeter/index.d.ts'
  */
 
-const rollbar: Rollbar;
+declare const rollbar: Rollbar;
 export = rollbar;
 
 declare class Rollbar {

--- a/index.d.ts
+++ b/index.d.ts
@@ -7,7 +7,8 @@
  *~ file should be 'super-greeter/index.d.ts'
  */
 
-export = Rollbar;
+const rollbar: Rollbar;
+export = rollbar;
 
 declare class Rollbar {
     constructor(options?: Rollbar.Configuration);

--- a/index.d.ts
+++ b/index.d.ts
@@ -12,7 +12,7 @@ export = rollbar;
 
 declare class Rollbar {
     constructor(options?: Rollbar.Configuration);
-    static init(options: Rollbar.Configuration): Rollbar;
+    public init(options: Rollbar.Configuration): Rollbar;
 
     public global(options: Rollbar.Configuration): Rollbar;
     public configure(options: Rollbar.Configuration): Rollbar;


### PR DESCRIPTION
Rollbar version 2.3.3 

TypeScript

```js
import * as Rollbar from 'rollbar'
```
`Rollbar` does not have the methods `error/warning/info`, so calling it returns a type error.
` Property error does not exist on type 'typeof Rollbar'`

![image](https://user-images.githubusercontent.com/16782417/34225855-98749506-e5a6-11e7-8a79-35fc6ec78819.png)

This exports all this methods as 'rollbar', so we can use it without calling Rollbar.init instance. 🎸 