### PR TITLE
Fixed tiny React Native issues

### DIFF
--- a/src/react-native/transforms.js
+++ b/src/react-native/transforms.js
@@ -1,6 +1,5 @@
 var async = require('async');
 var requestIp = require('request-ip');
-var url = require('url');
 var _ = require('../utility');
 
 function baseData(item, options, callback) {
@@ -120,7 +119,7 @@ function _parseRawFrame(line) {
     lineno = rest.substring(lineIdx+1);
     rest = rest.substring(0, lineIdx);
   }
-  var iosBundleFilename = new Regexp("^.*/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/[^/]*.app/(.*)$");
+  var iosBundleFilename = new RegExp("^.*/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/[^/]*.app/(.*)$");
   var match = iosBundleFilename.match(rest);
   if (match && match[1]) {
     rest = 'http://reactnativehost/' + match[1];


### PR DESCRIPTION
Two small fixes for React Native support:

- Removed `require('url')` as it's not used at all and is not available in React Native environment at all (another workaround is to `npm i url`), as opposed to nodejs.
- Fixed typo for `RegExp` as JS is case sensitive and this was throwing an `undefined` error.
