### PR TITLE
Send a more useful trace when reason=null

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ coverage
 .DS_Store
 *.swp
 npm-debug.log
+config.nix
+.provisioned

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,58 @@
+let pkgs  = import <nixpkgs> {};
+    pkgs' = import pkgs.path { overlays = [ (import ../vagrant-dev-vm/nix) ]; };
+in pkgs'.callPackage ({
+  nodejs-6_x,
+  stdenv,
+  writeScriptBin,
+  bash,
+  devEnvs,
+  moxLib,
+  darwin,
+}:
+
+let
+node = nodejs-6_x;
+config = moxLib.projectConfig ./. {
+  env = {
+  };
+};
+
+in
+
+stdenv.mkDerivation rec {
+  name = "rollbar.js-env";
+
+  buildInputs = [
+    node darwin.apple_sdk.frameworks.CoreServices
+    moxUpdate
+  ];
+
+  projectDir = toString ./.;
+  hardeningDisable = [ "all" ];
+
+  moxUpdate = writeScriptBin "mox-update" ''
+    #!${bash}/bin/bash
+    set -x
+
+    cd ${projectDir}
+    unset NIX_ENFORCE_PURITY
+
+    git submodule update --init
+
+    npm install
+  '';
+
+  provision = devEnvs.ensureProvisioned ''
+    mox-update
+  '';
+
+  shellHook = ''
+    cd ${projectDir}
+
+    ${provision}
+
+    ${devEnvs.withNodeBin}
+  '';
+} // config.env
+
+) {}

--- a/shell.nix
+++ b/shell.nix
@@ -1,58 +1,12 @@
-let pkgs  = import <nixpkgs> {};
-    pkgs' = import pkgs.path { overlays = [ (import ../vagrant-dev-vm/nix) ]; };
-in pkgs'.callPackage ({
-  nodejs-6_x,
-  stdenv,
-  writeScriptBin,
-  bash,
-  devEnvs,
-  moxLib,
-  darwin,
-}:
+{ pkgs ? import <nixpkgs> {}, nodejs-6_x ? pkgs.nodejs-6_x, stdenv ? pkgs.stdenv }:
 
 let
 node = nodejs-6_x;
-config = moxLib.projectConfig ./. {
-  env = {
-  };
-};
 
 in
 
 stdenv.mkDerivation rec {
   name = "rollbar.js-env";
 
-  buildInputs = [
-    node darwin.apple_sdk.frameworks.CoreServices
-    moxUpdate
-  ];
-
-  projectDir = toString ./.;
-  hardeningDisable = [ "all" ];
-
-  moxUpdate = writeScriptBin "mox-update" ''
-    #!${bash}/bin/bash
-    set -x
-
-    cd ${projectDir}
-    unset NIX_ENFORCE_PURITY
-
-    git submodule update --init
-
-    npm install
-  '';
-
-  provision = devEnvs.ensureProvisioned ''
-    mox-update
-  '';
-
-  shellHook = ''
-    cd ${projectDir}
-
-    ${provision}
-
-    ${devEnvs.withNodeBin}
-  '';
-} // config.env
-
-) {}
+  buildInputs = [ node ];
+}

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -56,6 +56,24 @@ describe('Rollbar()', function() {
     done();
   });
 
+  describe('handleUnhandledRejection', function() {
+    describe('with a null reason', function() {
+      it('should produce a trace of the call for debugging purposes', function() {
+        var client = new (TestClientGen())();
+        var options = {};
+        var rollbar = new Rollbar(options, client);
+
+        rollbar.handleUnhandledRejection(null, { _rollbarContext: 1 });
+        var loggedItem = client.logCalls[0].item;
+
+        expect(client.logCalls.length).to.equal(1);
+
+        expect(loggedItem.err instanceof Error).to.equal(true);
+        expect(loggedItem.message).to.equal('Error: unhandled rejection was null or undefined!');
+      });
+    });
+  });
+
   it('should have all of the expected methods', function(done) {
     var client = new (TestClientGen())();
     var options = {};


### PR DESCRIPTION
Related:
https://github.com/rollbar/rollbar.js/issues/486

From the rollbar unhandled rejection code paths, reason should, in the worst case, be a string, and not null.  It seems that something (extensions?  particular browser builds?  bad actors?) may be calling this internal method directly without the reason param.  This change ensures we send a full trace in that scenario.