### PR TITLE
Update Angular integration guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,6 +189,7 @@ import * as Rollbar from 'rollbar';
 import { BrowserModule } from '@angular/platform-browser';
 import {
   Injectable,
+  Inject,
   Injector,
   InjectionToken,
   NgModule,
@@ -202,21 +203,20 @@ const rollbarConfig = {
   captureUnhandledRejections: true,
 };
 
+export const RollbarService = new InjectionToken<Rollbar>('rollbar');
+
 @Injectable()
 export class RollbarErrorHandler implements ErrorHandler {
-  constructor(private injector: Injector) {}
+  constructor(@Inject(RollbarService) private rollbar: Rollbar) {}
 
   handleError(err:any) : void {
-    var rollbar = this.injector.get(RollbarService);
-    rollbar.error(err.originalError || err);
+    this.rollbar.error(err.originalError || err);
   }
 }
 
 export function rollbarFactory() {
     return new Rollbar(rollbarConfig);
 }
-
-export const RollbarService = new InjectionToken<Rollbar>('rollbar');
 
 @NgModule({
   imports: [ BrowserModule ],


### PR DESCRIPTION
Hey guys!

According to Angular's documentation, service locator pattern should be avoided unless there are no other options. In this case there are other options, we can inject `Rollbar` using `@Inject` decorator.

In former version, if you are not using `RollbarService` in different places of your application, `Rollbar` will be initialized only when error has happend. That's causing lack of telemetry information. `Rollbar` should be initialized on application initialization to collect all telemetry data.

To achieve that, we can inject it into root component of application or we can inject it into `ErrorHandler`, which is a part of Angular's core library and is initialized at the very beginning.

Would be awesome if you consider merging this change. It might help other Angular and Rollbar users.

Cheers!
Matt