### PR TITLE
Proper global checks

### DIFF
--- a/src/browser/bundles/rollbar.js
+++ b/src/browser/bundles/rollbar.js
@@ -1,10 +1,10 @@
 var rollbar = require('../rollbar');
 
-var options = window && window._rollbarConfig;
+var options = (typeof window !== 'undefined') && window._rollbarConfig;
 var alias = options && options.globalAlias || 'Rollbar';
-var shimRunning = window && window[alias] && typeof window[alias].shimId === 'function' && window[alias].shimId() !== undefined;
+var shimRunning = (typeof window !== 'undefined') && window[alias] && typeof window[alias].shimId === 'function' && window[alias].shimId() !== undefined;
 
-if (window && !window._rollbarStartTime) {
+if ((typeof window !== 'undefined') && !window._rollbarStartTime) {
   window._rollbarStartTime = (new Date()).getTime();
 }
 
@@ -12,8 +12,13 @@ if (!shimRunning && options) {
   var Rollbar = new rollbar(options);
   window[alias] = Rollbar;
 } else {
-  window.rollbar = rollbar;
-  window._rollbarDidLoad = true;
+  if (typeof window !== 'undefined') {
+    window.rollbar = rollbar;
+    window._rollbarDidLoad = true;
+  } else if (typeof self !== 'undefined') {
+    self.rollbar = rollbar;
+    self._rollbarDidLoad = true;
+  }
 }
 
 module.exports = rollbar;

--- a/src/browser/bundles/rollbar.js
+++ b/src/browser/bundles/rollbar.js
@@ -11,14 +11,12 @@ if ((typeof window !== 'undefined') && !window._rollbarStartTime) {
 if (!shimRunning && options) {
   var Rollbar = new rollbar(options);
   window[alias] = Rollbar;
-} else {
-  if (typeof window !== 'undefined') {
-    window.rollbar = rollbar;
-    window._rollbarDidLoad = true;
-  } else if (typeof self !== 'undefined') {
-    self.rollbar = rollbar;
-    self._rollbarDidLoad = true;
-  }
+} else if (typeof window !== 'undefined') {
+  window.rollbar = rollbar;
+  window._rollbarDidLoad = true;
+} else if (typeof self !== 'undefined') {
+  self.rollbar = rollbar;
+  self._rollbarDidLoad = true;
 }
 
 module.exports = rollbar;

--- a/src/browser/bundles/rollbar.noconflict.js
+++ b/src/browser/bundles/rollbar.noconflict.js
@@ -1,6 +1,6 @@
 var rollbar = require('../rollbar');
 
-if (window && !window._rollbarStartTime) {
+if ((typeof window !== 'undefined') && !window._rollbarStartTime) {
   window._rollbarStartTime = (new Date()).getTime();
 }
 

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -18,17 +18,19 @@ function Rollbar(options, client) {
   var api = new API(this.options, transport, urllib);
   this.client = client || new Client(this.options, api, logger, 'browser');
 
+  var gWindow = ((typeof window != 'undefined') && window) || ((typeof self != 'undefined') && self);
+  var gDocument = (typeof document != 'undefined') && document;
   addTransformsToNotifier(this.client.notifier);
   addPredicatesToQueue(this.client.queue);
   if (this.options.captureUncaught || this.options.handleUncaughtExceptions) {
-    globals.captureUncaughtExceptions(window, this);
-    globals.wrapGlobals(window, this);
+    globals.captureUncaughtExceptions(gWindow, this);
+    globals.wrapGlobals(gWindow, this);
   }
   if (this.options.captureUnhandledRejections || this.options.handleUnhandledRejections) {
-    globals.captureUnhandledRejections(window, this);
+    globals.captureUnhandledRejections(gWindow, this);
   }
 
-  this.instrumenter = new Instrumenter(this.options, this.client.telemeter, this, window, document);
+  this.instrumenter = new Instrumenter(this.options, this.client.telemeter, this, gWindow, gDocument);
   this.instrumenter.instrument();
 }
 

--- a/src/browser/shim.js
+++ b/src/browser/shim.js
@@ -22,7 +22,7 @@ function Shim(options, wrap) {
   this._rollbarOldOnError = null;
   var shimId = _shimIdCounter++;
   this.shimId = function() { return shimId; };
-  if (window && window._rollbarShims) {
+  if ((typeof window !== 'undefined') && window._rollbarShims) {
     window._rollbarShims[shimId] = {handler: wrap, messages: []};
   }
 }
@@ -34,6 +34,9 @@ var ShimImpl = function(options, wrap) {
 var Rollbar = Wrapper.bind(null, ShimImpl);
 
 function setupShim(window, options) {
+  if (!window) {
+    return;
+  }
   var alias = options.globalAlias || 'Rollbar';
   if (typeof window[alias] === 'object') {
     return window[alias];


### PR DESCRIPTION
Fixes #549 

I was stupid, you can't check for existence of a name as truthy check if the name is possibly undefined. You need to use `typeof name !== 'undefined'`. This does that for the uses of window. The code was written to fall back if window is unavailable, but the top level check for window was broken.