### PR TITLE
arguments to args to allow TS alwaysStrict

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -52,7 +52,7 @@ declare namespace Rollbar {
         scrubTelemetryInputs?: boolean;
         sendConfig?: boolean;
         transform?: (data: object) => void;
-        checkIgnore?: (isUncaught: boolean, arguments: LogArgument[], item: object) => boolean;
+        checkIgnore?: (isUncaught: boolean, args: LogArgument[], item: object) => boolean;
     }
     export type Callback = (err: MaybeError, response: object) => void;
     export type LogArgument = string | Error | object | Callback | Date | any[];


### PR DESCRIPTION
TypeScript's alwaysStrict triggers a `TS1215: Invalid use of 'arguments'. Modules are automatically in strict mode.`.

Changing `arguments` to `args` fixes this.