### PR TITLE
More telemetry options

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,12 @@ var level = 'info'; // Possible values: 'debug', 'info', 'warning', 'error', 'cr
 rollbar.captureEvent(metadata, level);
 ```
 
+We also provide the configuration option `includeItemsInTelemetry` which lives at the top level of
+the configuration object. This is set to `true` by default in the browser and React Native targets
+and to `false` for the server target. When this is true, we include previously logged items to
+Rollbar in the queue of telemetry events. This includes both direct calls and indirect calls via
+uncaught exceptions.
+
 There is an in-memory queue of telemetry events that gets built up over the lifecycle of a user
 interacting with your app. This queue is FIFO and has a fixed size. By default, we store the last
 100 events and send these as part of the item with each manual call to a rollbar method (log/info/warning/error) or with calls caused by an uncaught exception.

--- a/index.d.ts
+++ b/index.d.ts
@@ -49,6 +49,7 @@ declare namespace Rollbar {
         hostBlackList?: string[];
         autoInstrument?: AutoInstrumentOptions;
         telemetryScrubber?: TelemetryScrubber;
+        includeItemsInTelemetry?: boolean;
         scrubTelemetryInputs?: boolean;
         sendConfig?: boolean;
         transform?: (data: object) => void;

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -398,7 +398,8 @@ var defaultOptions = {
   endpoint: __DEFAULT_ENDPOINT__,
   verbose: false,
   enabled: true,
-  sendConfig: false
+  sendConfig: false,
+  includeItemsInTelemetry: true
 };
 
 module.exports = Rollbar;

--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -257,7 +257,7 @@ Instrumenter.prototype.instrumentNetwork = function() {
         var url;
         if (_.isType(input, 'string')) {
           url = input;
-        } else {
+        } else if (input) {
           url = input.url;
           if (input.method) {
             method = input.method;

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -292,7 +292,8 @@ Rollbar.defaultOptions = {
   reportLevel: packageJson.defaults.reportLevel,
   verbose: false,
   enabled: true,
-  sendConfig: false
+  sendConfig: false,
+  includeItemsInTelemetry: true
 };
 
 module.exports = Rollbar;

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -519,7 +519,8 @@ Rollbar.defaultOptions = {
   reportLevel: packageJson.defaults.reportLevel,
   verbose: false,
   enabled: true,
-  sendConfig: false
+  sendConfig: false,
+  includeItemsInTelemetry: false
 };
 
 module.exports = Rollbar;

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -129,6 +129,9 @@ Telemeter.prototype.captureConnectivityChange = function(type, rollbarUUID) {
 
 // Only intended to be used internally by the notifier
 Telemeter.prototype._captureRollbarItem = function(item) {
+  if (!this.options.includeItemsInTelemetry) {
+    return;
+  }
   if (item.err) {
     return this.captureError(item.err, item.level, item.uuid, item.timestamp);
   }


### PR DESCRIPTION
Introduce the `includeItemsInTelemetry` option to allow turning on/off the automatic inclusion of previous items sent to Rollbar. We make this default to false on the server side and true everywhere else.