### PR TITLE
Options should override not merge

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -15,7 +15,7 @@ var errorParser = require('./errorParser');
 var Instrumenter = require('./telemetry');
 
 function Rollbar(options, client) {
-  this.options = _.extend(true, defaultOptions, options);
+  this.options = _.extend({}, defaultOptions, options);
   var api = new API(this.options, transport, urllib);
   this.client = client || new Client(this.options, api, logger, 'browser');
 
@@ -70,7 +70,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
   if (payloadData) {
     payload = {payload: payloadData};
   }
-  this.options = _.extend(true, {}, oldOptions, options, payload);
+  this.options = _.extend({}, oldOptions, options, payload);
   this.client.configure(options, payloadData);
   this.instrumenter.configure(options);
   return this;

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -24,7 +24,7 @@ function Notifier(queue, options) {
 Notifier.prototype.configure = function(options) {
   this.queue && this.queue.configure(options);
   var oldOptions = this.options;
-  this.options = _.extend(true, {}, oldOptions, options);
+  this.options = _.extend({}, oldOptions, options);
   return this;
 };
 

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -17,7 +17,7 @@ function Rollbar(options, client) {
     options = {};
     options.accessToken = accessToken;
   }
-  this.options = _.extend(true, {}, Rollbar.defaultOptions, options);
+  this.options = _.extend({}, Rollbar.defaultOptions, options);
   // This makes no sense in a long running app
   delete this.options.maxItems;
   this.options.environment = this.options.environment || 'unspecified';

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -25,7 +25,7 @@ function Rollbar(options, client) {
     options.reportLevel = options.minimumLevel;
     delete options.minimumLevel;
   }
-  this.options = _.extend(true, {}, Rollbar.defaultOptions, options);
+  this.options = _.extend({}, Rollbar.defaultOptions, options);
   // On the server we want to ignore any maxItems setting
   delete this.options.maxItems;
   this.options.environment = this.options.environment || 'unspecified';

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -72,6 +72,29 @@ describe('Rollbar()', function() {
     done();
   });
 
+  it ('should have some default options', function(done) {
+    var client = new (TestClientGen())();
+    var options = {};
+    var rollbar = new Rollbar(options, client);
+
+    expect(rollbar.options.scrubFields).to.contain('password');
+    done();
+  });
+
+  it ('should override the defaults options', function(done) {
+    var client = new (TestClientGen())();
+    var options = {
+      scrubFields: [
+        'foobar'
+      ]
+    };
+    var rollbar = new Rollbar(options, client);
+
+    expect(rollbar.options.scrubFields).to.contain('foobar');
+    expect(rollbar.options.scrubFields).to.not.contain('password');
+    done();
+  });
+
   it('should return a uuid when logging', function(done) {
     var client = new (TestClientGen())();
     var options = {};


### PR DESCRIPTION
Fixes #582

We use the `node-extend` package for merging objects. This treats arrays
as objects with integer keys when it attempts to deep merge objects.
This is problematic for configuration options which are arrays because
what happens is that setting a configuration option to an array value
will just overwrite part of the array (depending on the sizes of the
arrays involved).

We do not actually require deep merging for the places that we were
using it, so instead I switch to using shallow merging for configuration
data, this allows arrays (like scrubFields) to become overwriteable.