### PR TITLE
Replace extend with our own implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "console-polyfill": "0.3.0",
     "error-stack-parser": "1.3.3",
-    "extend": "3.0.0",
     "async": "~1.2.1",
     "debug": "2.6.9",
     "json-stringify-safe": "~5.0.0",

--- a/src/api.js
+++ b/src/api.js
@@ -51,7 +51,7 @@ Api.prototype.postItem = function(data, callback) {
 
 Api.prototype.configure = function(options) {
   var oldOptions = this.oldOptions;
-  this.options = _.extend(true, {}, oldOptions, options);
+  this.options = _.merge(oldOptions, options);
   this.transportOptions = _getTransport(this.options, this.url);
   if (this.options.accessToken !== undefined) {
     this.accessToken = this.options.accessToken;

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -15,7 +15,7 @@ var errorParser = require('./errorParser');
 var Instrumenter = require('./telemetry');
 
 function Rollbar(options, client) {
-  this.options = _.extend({}, defaultOptions, options);
+  this.options = _.merge(defaultOptions, options);
   var api = new API(this.options, transport, urllib);
   this.client = client || new Client(this.options, api, logger, 'browser');
 
@@ -70,7 +70,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
   if (payloadData) {
     payload = {payload: payloadData};
   }
-  this.options = _.extend({}, oldOptions, options, payload);
+  this.options = _.merge(oldOptions, options, payload);
   this.client.configure(options, payloadData);
   this.instrumenter.configure(options);
   return this;

--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -37,7 +37,7 @@ function Instrumenter(options, telemeter, rollbar, _window, _document) {
     if (!_.isType(autoInstrument, 'object')) {
       autoInstrument = defaults;
     }
-    this.autoInstrument = _.extend(true, {}, defaults, autoInstrument);
+    this.autoInstrument = _.merge(defaults, autoInstrument);
   }
   this.scrubTelemetryInputs = !!options.scrubTelemetryInputs;
   this.telemetryScrubber = options.telemetryScrubber;
@@ -62,14 +62,14 @@ function Instrumenter(options, telemeter, rollbar, _window, _document) {
 
 Instrumenter.prototype.configure = function(options) {
   var autoInstrument = options.autoInstrument;
-  var oldSettings = _.extend(true, {}, this.autoInstrument);
+  var oldSettings = _.merge(this.autoInstrument);
   if (options.enabled === false || autoInstrument === false) {
     this.autoInstrument = {};
   } else {
     if (!_.isType(autoInstrument, 'object')) {
       autoInstrument = defaults;
     }
-    this.autoInstrument = _.extend(true, {}, defaults, autoInstrument);
+    this.autoInstrument = _.merge(defaults, autoInstrument);
   }
   this.instrument(oldSettings);
   if (options.scrubTelemetryInputs !== undefined) {

--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -27,7 +27,7 @@ function ensureItemHasSomethingToSay(item, options, callback) {
 
 function addBaseInfo(item, options, callback) {
   var environment = (options.payload && options.payload.environment) || options.environment;
-  item.data = _.extend(true, {}, item.data, {
+  item.data = _.merge(item.data, {
     environment: environment,
     level: item.level,
     endpoint: options.endpoint,
@@ -131,7 +131,7 @@ function addBodyMessage(item, options, callback) {
   };
 
   if (custom) {
-    result.extra = _.extend(true, {}, custom);
+    result.extra = _.merge(custom);
   }
 
   _.set(item, 'data.body', {message: result});
@@ -223,7 +223,7 @@ function addBodyTrace(item, options, callback) {
     trace.frames.reverse();
 
     if (custom) {
-      trace.extra = _.extend(true, {}, custom);
+      trace.extra = _.merge(custom);
     }
     _.set(item, 'data.body', {trace: trace});
     callback(null, item);

--- a/src/merge.js
+++ b/src/merge.js
@@ -1,0 +1,54 @@
+'use strict';
+
+var hasOwn = Object.prototype.hasOwnProperty;
+var toStr = Object.prototype.toString;
+
+var isPlainObject = function isPlainObject(obj) {
+	if (!obj || toStr.call(obj) !== '[object Object]') {
+		return false;
+	}
+
+	var hasOwnConstructor = hasOwn.call(obj, 'constructor');
+	var hasIsPrototypeOf = obj.constructor && obj.constructor.prototype && hasOwn.call(obj.constructor.prototype, 'isPrototypeOf');
+	// Not own constructor property must be Object
+	if (obj.constructor && !hasOwnConstructor && !hasIsPrototypeOf) {
+		return false;
+	}
+
+	// Own properties are enumerated firstly, so to speed up,
+	// if last one is own, then all properties are own.
+	var key;
+	for (key in obj) {/**/}
+
+	return typeof key === 'undefined' || hasOwn.call(obj, key);
+};
+
+function merge() {
+  var i, src, copy, clone, name,
+      result = {},
+     current = null,
+      length = arguments.length;
+
+  for (i=0; i < length; i++) {
+    current = arguments[i];
+    if (current == null) {
+      continue;
+    }
+
+    for (name in current) {
+      src = result[name];
+      copy = current[name];
+      if (result !== copy) {
+        if (copy && isPlainObject(copy)) {
+          clone = src && isPlainObject(src) ? src : {};
+          result[name] = merge(clone, copy);
+        } else if (typeof copy !== 'undefined') {
+          result[name] = copy
+        }
+      }
+    }
+  }
+  return result;
+}
+
+module.exports = merge;

--- a/src/notifier.js
+++ b/src/notifier.js
@@ -24,7 +24,7 @@ function Notifier(queue, options) {
 Notifier.prototype.configure = function(options) {
   this.queue && this.queue.configure(options);
   var oldOptions = this.options;
-  this.options = _.extend({}, oldOptions, options);
+  this.options = _.merge(oldOptions, options);
   return this;
 };
 

--- a/src/queue.js
+++ b/src/queue.js
@@ -35,7 +35,7 @@ function Queue(rateLimiter, api, logger, options) {
 Queue.prototype.configure = function(options) {
   this.api && this.api.configure(options);
   var oldOptions = this.options;
-  this.options = _.extend(true, {}, oldOptions, options);
+  this.options = _.merge(oldOptions, options);
   return this;
 };
 

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -17,7 +17,7 @@ function Rollbar(options, client) {
     options = {};
     options.accessToken = accessToken;
   }
-  this.options = _.extend({}, Rollbar.defaultOptions, options);
+  this.options = _.merge(Rollbar.defaultOptions, options);
   // This makes no sense in a long running app
   delete this.options.maxItems;
   this.options.environment = this.options.environment || 'unspecified';
@@ -62,7 +62,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
   if (payloadData) {
     payload = {payload: payloadData};
   }
-  this.options = _.extend(true, {}, oldOptions, options, payload);
+  this.options = _.merge(oldOptions, options, payload);
   this.client.configure(options, payloadData);
   return this;
 };

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -12,7 +12,7 @@ var _ = require('./utility');
  * @param logger
  */
 function Rollbar(options, api, logger, platform) {
-  this.options = _.extend(true, {}, options);
+  this.options = _.merge(options);
   this.logger = logger;
   Rollbar.rateLimiter.configureGlobal(this.options);
   Rollbar.rateLimiter.setPlatformOptions(platform, this.options);
@@ -42,7 +42,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
   if (payloadData) {
     payload = {payload: payloadData};
   }
-  this.options = _.extend(true, {}, oldOptions, options, payload);
+  this.options = _.merge(oldOptions, options, payload);
   this.global(this.options);
   return this;
 };

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -25,7 +25,7 @@ function Rollbar(options, client) {
     options.reportLevel = options.minimumLevel;
     delete options.minimumLevel;
   }
-  this.options = _.extend({}, Rollbar.defaultOptions, options);
+  this.options = _.merge(Rollbar.defaultOptions, options);
   // On the server we want to ignore any maxItems setting
   delete this.options.maxItems;
   this.options.environment = this.options.environment || 'unspecified';
@@ -62,7 +62,7 @@ function handleUninitialized(maybeCallback) {
 }
 
 Rollbar.prototype.global = function(options) {
-  options = _.extend(true, {}, options);
+  options = _.merge(options);
   // On the server we want to ignore any maxItems setting
   delete options.maxItems;
   this.client.global(options);
@@ -82,7 +82,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
   if (payloadData) {
     payload = {payload: payloadData};
   }
-  this.options = _.extend(true, {}, oldOptions, options, payload);
+  this.options = _.merge(oldOptions, options, payload);
   // On the server we want to ignore any maxItems setting
   delete this.options.maxItems;
   logger.setVerbose(this.options.verbose);

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -4,14 +4,14 @@ var MAX_EVENTS = 100;
 
 function Telemeter(options) {
   this.queue = [];
-  this.options = _.extend(true, {}, options);
+  this.options = _.merge(options);
   var maxTelemetryEvents = this.options.maxTelemetryEvents || MAX_EVENTS;
   this.maxQueueSize = Math.max(0, Math.min(maxTelemetryEvents, MAX_EVENTS));
 }
 
 Telemeter.prototype.configure = function(options) {
   var oldOptions = this.options;
-  this.options = _.extend(true, {}, oldOptions, options);
+  this.options = _.merge(oldOptions, options);
   var maxTelemetryEvents = this.options.maxTelemetryEvents || MAX_EVENTS;
   var newMaxEvents = Math.max(0, Math.min(maxTelemetryEvents, MAX_EVENTS));
   var deleteCount = 0;

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -6,7 +6,7 @@ function itemToPayload(item, options, callback) {
     delete payloadOptions.body;
   }
 
-  var data = _.extend(true, {}, item.data, payloadOptions);
+  var data = _.merge(item.data, payloadOptions);
   if (item._isUncaught) {
     data._isUncaught = true;
   }
@@ -41,7 +41,7 @@ function addMessageWithError(item, options, callback) {
       return;
     }
     var extra = _.get(item, tracePath+'.extra') || {};
-    var newExtra =  _.extend(true, {}, extra, {message: item.message});
+    var newExtra =  _.merge(extra, {message: item.message});
     _.set(item, tracePath+'.extra', newExtra);
   }
   callback(null, item);
@@ -49,7 +49,7 @@ function addMessageWithError(item, options, callback) {
 
 function userTransform(logger) {
   return function(item, options, callback) {
-    var newItem = _.extend(true, {}, item);
+    var newItem = _.merge(item);
     try {
       if (_.isFunction(options.transform)) {
         options.transform(newItem.data);

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,4 +1,4 @@
-var extend = require('extend');
+var merge = require('./merge');
 
 var RollbarJSON = {};
 var __initRollbarJSON = false;
@@ -421,7 +421,7 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
 
   if (extraArgs.length > 0) {
     // if custom is an array this turns it into an object with integer keys
-    custom = extend(true, {}, custom);
+    custom = merge(custom);
     custom.extraArgs = extraArgs;
   }
 
@@ -625,6 +625,7 @@ function filterIp(requestData, captureIp) {
   requestData['user_ip'] = newIp;
 }
 
+
 module.exports = {
   isType: isType,
   typeName: typeName,
@@ -632,7 +633,7 @@ module.exports = {
   isNativeFunction: isNativeFunction,
   isIterable: isIterable,
   isError: isError,
-  extend: extend,
+  merge: merge,
   traverse: traverse,
   redact: redact,
   uuid4: uuid4,

--- a/test/notifier.test.js
+++ b/test/notifier.test.js
@@ -3,8 +3,6 @@
 /* globals it */
 /* globals sinon */
 
-var extend = require('extend');
-
 var Notifier = require('../src/notifier');
 
 var rollbarConfig = {

--- a/test/server.transforms.test.js
+++ b/test/server.transforms.test.js
@@ -85,7 +85,7 @@ vows.describe('transforms')
         },
         'with values': {
           topic: function() {
-            return _.extend(true, {}, rollbar.defaultOptions, {
+            return _.merge(rollbar.defaultOptions, {
               payload: {
                 environment: 'payload-prod',
               },


### PR DESCRIPTION
Create a custom version of object merging which does exactly what we want rather than working around extend.

extend merged arrays as if they were objects with integer keys, i.e.

`extend({a: [1, 2, 3]}, {a: [42, 9]}) -> {a: [42, 9, 3]}`

If you don't want that behaviour then you also have to give up deep merging.

This PR implements a function `merge` which:

1. treats array values as primitives and does not recurse within them
2. deep merges objects
3. always returns an object which is independent of any of the arguments

This means to get your own copy of an object you can call `merge(yourObject)` rather than the usual `extend({}, yourObject)`. This gets rid of the extra `{}` first argument in almost all calls to extend. This implementation might not be exactly what one might want for general object merging, but for our use case in merging configuration options this is the behaviour we want.

Fixes #614 
