### PR TITLE
Do not throw on bad input to parseUri

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -185,6 +185,10 @@ var LEVELS = {
 
 function sanitizeUrl(url) {
   var baseUrlParts = parseUri(url);
+  if (!baseUrlParts) {
+    return '(unknown)';
+  }
+
   // remove a trailing # if there is no anchor
   if (baseUrlParts.anchor === '') {
     baseUrlParts.source = baseUrlParts.source.replace('#', '');
@@ -224,7 +228,7 @@ var parseUriOptions = {
 
 function parseUri(str) {
   if (!isType(str, 'string')) {
-    throw new Error('received invalid input');
+    return undefined;
   }
 
   var o = parseUriOptions;


### PR DESCRIPTION
This should never happen, I still don't understand how it is possible to get this function called with a non-string, but apparently it has happened. Such is Javascript. So we should not throw, instead have a default unknown value.