### PR TITLE
Use curry provided by Prototype if it exists

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -43,7 +43,7 @@ module.exports = function (config) {
 
     // run the bundle through the webpack and sourcemap plugins
     preprocessors: {
-      'test/!(requirejs).test.js': ['webpack'],
+      'test/!(requirejs).test.js': ['webpack', 'sourcemap'],
     },
 
     proxies: {
@@ -63,6 +63,7 @@ module.exports = function (config) {
         configFile: path.resolve(__dirname, ".eslintrc")
       },
       plugins: [defaultsPlugin],
+      devtool: 'inline-source-map',
       module: {
         preLoaders: [
           {

--- a/src/browser/shim.js
+++ b/src/browser/shim.js
@@ -31,7 +31,12 @@ var Wrapper = require('./rollbarWrapper');
 var ShimImpl = function(options, wrap) {
   return new Shim(options, wrap);
 };
-var Rollbar = Wrapper.bind(null, ShimImpl);
+var Rollbar;
+if (Wrapper.curry) {
+  Rollbar = Wrapper.curry(ShimImpl);
+} else {
+  Rollbar = Wrapper.bind(null, ShimImpl);
+}
 
 function setupShim(window, options) {
   if (!window) {


### PR DESCRIPTION
Prototype redefines bind in a broken way for the purposes of partial function application. Luckily they provide `curry` which does the right thing for this use case. So if `curry` exists on Function.prototype we can use that instead of `bind` otherwise just use `bind`.

Fixes #344 