### PR TITLE
Handle Symbols in formatArgsAsString

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -573,13 +573,23 @@ function formatArgsAsString(args) {
   var result = [];
   for (i = 0, len = args.length; i < len; i++) {
     arg = args[i];
-    if (typeof arg === 'object') {
-      arg = stringify(arg);
-      arg = arg.error || arg.value;
-      if (arg.length > 500)
-        arg = arg.substr(0,500)+'...';
-    } else if (typeof arg === 'undefined') {
-      arg = 'undefined';
+    switch (typeName(arg)) {
+      case 'object':
+        arg = stringify(arg);
+        arg = arg.error || arg.value;
+        if (arg.length > 500) {
+          arg = arg.substr(0, 497) + '...';
+        }
+        break;
+      case 'null':
+        arg = 'null';
+        break;
+      case 'undefined':
+        arg = 'undefined';
+        break;
+      case 'symbol':
+        arg = arg.toString();
+        break;
     }
     result.push(arg);
   }

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -702,3 +702,45 @@ describe('scrub', function() {
     expect(result.inner.b).to.eql('yes');
   });
 });
+
+describe('formatArgsAsString', function() {
+  it('should handle null', function() {
+    var args = [null, 1];
+    var result = _.formatArgsAsString(args);
+
+    expect(result).to.eql('null 1');
+  });
+  it('should handle undefined', function() {
+    var args = [null, 1, undefined];
+    var result = _.formatArgsAsString(args);
+
+    expect(result).to.eql('null 1 undefined');
+  });
+  it('should handle objects', function() {
+    var args = [1, {a: 42}];
+    var result = _.formatArgsAsString(args);
+
+    expect(result).to.eql('1 {"a":42}');
+  });
+  it('should handle strings', function() {
+    var args = [1, 'foo'];
+    var result = _.formatArgsAsString(args);
+
+    expect(result).to.eql('1 foo');
+  });
+  it('should handle empty args', function() {
+    var args = [];
+    var result = _.formatArgsAsString(args);
+
+    expect(result).to.eql('');
+  });
+  /*
+   * PhantomJS does not support Symbol yet
+  it('should handle symbols', function() {
+    var args = [1, Symbol('hello')];
+    var result = _.formatArgsAsString(args);
+
+    expect(result).to.eql('1 symbol(\'hello\')');
+  });
+  */
+});


### PR DESCRIPTION
Fixes #592 

Calling `someArray.join(' ')` where `someArray` contains a `Symbol` throws an error. We instead call `toString()` on the symbol before putting it in the array.