### PR TITLE
updated typescript type declarations from 2.3.3 to 2.4.2

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-// Type definitions for rollbar 2.3.3
+// Type definitions for rollbar 2.4.2
 // Project: Rollbar
 
 export = Rollbar;
@@ -30,11 +30,13 @@ declare namespace Rollbar {
     export type LambdaHandler = (event: object, context: object, callback: Callback) => void;
     export type MaybeError = Error | undefined | null;
     export type Level = "debug" | "info" | "warning" | "error" | "critical";
+    export type CaptureIp = boolean | "anonymize";
     export interface Configuration {
         accessToken?: string;
         version?: string;
         environment?: string;
         codeVersion?: string;
+        code_version?: string;
         scrubFields?: string[];
         scrubHeaders?: string[];
         logLevel?: Level;
@@ -58,7 +60,7 @@ declare namespace Rollbar {
         sendConfig?: boolean;
         captureEmail?: boolean;
         captureUsername?: boolean;
-        captureIp?: boolean;
+        captureIp?: CaptureIp;
         transform?: (data: object) => void;
         checkIgnore?: (isUncaught: boolean, args: LogArgument[], item: object) => boolean;
         onSendCallback?: (isUncaught: boolean, args: LogArgument[], item: object) => void;


### PR DESCRIPTION
added CaptureIp type (boolean plus string "anonymize") and allow code_version top level config key to avoid typescript compiler errors.

The changes are hand-crafted - I hope I got everything right.

Please note that you might need to add a type hint in your config object literal:

```
{
  captureIp: <CaptureIp>'anonymize'
}
```

instead of

```
{
  captureIp: 'anonymize'
}
```