### PR TITLE
Fix for Prototypejs

### DIFF
--- a/src/browser/shim.js
+++ b/src/browser/shim.js
@@ -31,12 +31,9 @@ var Wrapper = require('./rollbarWrapper');
 var ShimImpl = function(options, wrap) {
   return new Shim(options, wrap);
 };
-var Rollbar;
-if (Wrapper.curry) {
-  Rollbar = Wrapper.curry(ShimImpl);
-} else {
-  Rollbar = Wrapper.bind(null, ShimImpl);
-}
+var Rollbar = function(options) {
+  return new Wrapper(ShimImpl, options);
+};
 
 function setupShim(window, options) {
   if (!window) {


### PR DESCRIPTION
Don't use curry or bind, it is unnecessary and curry is still not the
same as `.bind(null, ...)` even though it makes it seem like it is. We
can just create a new constructor that does what we want.