### PR TITLE
Added support for tracking people on ExpressJS using user.sub instead of user.id

### DIFF
--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -139,7 +139,7 @@ function addRequestData(item, options, callback) {
     }
     item.data.person = person;
   } else if (req.user) {
-    item.data.person = {id: req.user.id};
+    item.data.person = {id: req.user.id || req.user.sub};
     if (req.user.username && captureUsername) {
       item.data.person.username = req.user.username;
     }

--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -139,7 +139,9 @@ function addRequestData(item, options, callback) {
     }
     item.data.person = person;
   } else if (req.user) {
+    console.log('debugging this:', req.user)
     item.data.person = {id: req.user.id || req.user.sub};
+    console.log('debugging this2:', item.data.person)
     if (req.user.username && captureUsername) {
       item.data.person.username = req.user.username;
     }


### PR DESCRIPTION
Hey guys,

I just patched this. The req.user.sub is very common these days due to JSON Web Token, so I think it also makes sense that rollbar tries to identify the user by the sub attribute if the id attribute is not present.

Thanks,