### PR TITLE
fix(setPerson): configure notifier and telemeter with payload params

### DIFF
--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -36,13 +36,13 @@ Rollbar.prototype.global = function(options) {
 };
 
 Rollbar.prototype.configure = function(options, payloadData) {
-  this.notifier && this.notifier.configure({...options, payload: payloadData});
-  this.telemeter && this.telemeter.configure({...options, payload: payloadData});
   var oldOptions = this.options;
   var payload = {};
   if (payloadData) {
     payload = {payload: payloadData};
   }
+  this.notifier && this.notifier.configure(_.merge(options, payload));
+  this.telemeter && this.telemeter.configure(_.merge(options, payload));
   this.options = _.merge(oldOptions, options, payload);
   this.global(this.options);
   return this;

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -36,8 +36,8 @@ Rollbar.prototype.global = function(options) {
 };
 
 Rollbar.prototype.configure = function(options, payloadData) {
-  this.notifier && this.notifier.configure(options);
-  this.telemeter && this.telemeter.configure(options);
+  this.notifier && this.notifier.configure({...options, payload: payloadData});
+  this.telemeter && this.telemeter.configure({...options, payload: payloadData});
   var oldOptions = this.options;
   var payload = {};
   if (payloadData) {

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -41,9 +41,9 @@ Rollbar.prototype.configure = function(options, payloadData) {
   if (payloadData) {
     payload = {payload: payloadData};
   }
-  this.notifier && this.notifier.configure(_.merge(options, payload));
-  this.telemeter && this.telemeter.configure(_.merge(options, payload));
   this.options = _.merge(oldOptions, options, payload);
+  this.notifier && this.notifier.configure(this.options);
+  this.telemeter && this.telemeter.configure(this.options);
   this.global(this.options);
   return this;
 };


### PR DESCRIPTION
People Tracking does not work on the rollbar-react-native project. As talked about in [this](https://github.com/rollbar/rollbar-react-native/issues/39) closed issue. I have tracked down the issue to this JS library, where the configure method does not merge in the configured payload data into the notifier and telemeter. 