### PR TITLE
use partial cloning in scrubber

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -151,13 +151,15 @@ function traverse(obj, func, seen) {
   }
 
   var result = isObj ? {} : [];
+  var same = true;
   for (i = 0; i < keys.length; ++i) {
     k = keys[i];
     v = obj[k];
     result[k] = func(k, v, seen);
+    same = same && result[k] === obj[k];
   }
 
-  return (keys.length != 0) ? result : obj;
+  return (keys.length != 0 && !same) ? result : obj;
 }
 
 function redact() {


### PR DESCRIPTION
In scrubber, changed cloning to partial cloning (similar to immutable/persistent data structure), to avoid changing how unscrubbed data are stringified when send to server. See #670.