### PR TITLE
Telemetry rework

### DIFF
--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -180,7 +180,7 @@ Instrumenter.prototype.instrumentNetwork = function() {
         var xhr = this;
 
         function onreadystatechangeHandler() {
-          if (xhr.__rollbar_xhr && (xhr.readyState === 1 || xhr.readyState === 4)) {
+          if (xhr.__rollbar_xhr) {
             if (xhr.__rollbar_xhr.status_code === null) {
               xhr.__rollbar_xhr.status_code = 0;
               var requestData = null;
@@ -189,9 +189,10 @@ Instrumenter.prototype.instrumentNetwork = function() {
               }
               xhr.__rollbar_event = self.telemeter.captureNetwork(xhr.__rollbar_xhr, 'xhr', undefined, requestData);
             }
-            if (xhr.readyState === 1) {
+            if (xhr.readyState < 2) {
               xhr.__rollbar_xhr.start_time_ms = _.now();
-            } else {
+            }
+            if (xhr.readyState > 3) {
               xhr.__rollbar_xhr.end_time_ms = _.now();
 
               var headers = null;
@@ -244,14 +245,14 @@ Instrumenter.prototype.instrumentNetwork = function() {
               if (response) {
                 xhr.__rollbar_xhr.response = response;
               }
-            }
-            try {
-              var code = xhr.status;
-              code = code === 1223 ? 204 : code;
-              xhr.__rollbar_xhr.status_code = code;
-              xhr.__rollbar_event.level = self.telemeter.levelFromStatus(code);
-            } catch (e) {
-              /* ignore possible exception from xhr.status */
+              try {
+                var code = xhr.status;
+                code = code === 1223 ? 204 : code;
+                xhr.__rollbar_xhr.status_code = code;
+                xhr.__rollbar_event.level = self.telemeter.levelFromStatus(code);
+              } catch (e) {
+                /* ignore possible exception from xhr.status */
+              }
             }
           }
         }

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -23,7 +23,20 @@ Telemeter.prototype.configure = function(options) {
 };
 
 Telemeter.prototype.copyEvents = function() {
-  return Array.prototype.slice.call(this.queue, 0);
+  var events = Array.prototype.slice.call(this.queue, 0);
+  if (_.isFunction(this.options.filterTelemetry)) {
+    try {
+      var i = events.length;
+      while (i--) {
+        if (this.options.filterTelemetry(events[i])) {
+          events.splice(i, 1);
+        }
+      }
+    } catch (e) {
+      this.options.filterTelemetry = null;
+    }
+  }
+  return events;
 };
 
 Telemeter.prototype.capture = function(type, metadata, level, rollbarUUID, timestamp) {
@@ -42,7 +55,7 @@ Telemeter.prototype.capture = function(type, metadata, level, rollbarUUID, times
     if (_.isFunction(this.options.filterTelemetry) && this.options.filterTelemetry(e)) {
       return false;
     }
-  } catch (e) {
+  } catch (exc) {
     this.options.filterTelemetry = null;
   }
 


### PR DESCRIPTION
Fixes #678 
Maybe does something for #667 

1. We do our monkey patch of the onreadystatechage handler inside send which implies that we will never actually see readyState == 1 because of the semantics of readyState. This change makes it so we actually start tracking network requests sooner which means that an error while the request is in-flight will contain telemetry data about the request. The previous behaviour was that we only saw the request in the telemetry data if the request completed before the error.

2. Run the telemetry filter at capture time to handle the majority of cases, but re-run on the way out of copy to handle network telemetry event race conditions