### PR TITLE
Use the constructor name on the error if there is one

### DIFF
--- a/src/browser/errorParser.js
+++ b/src/browser/errorParser.js
@@ -61,7 +61,9 @@ function Stack(exception) {
   }
 
   var name = exception.constructor && exception.constructor.name;
-  name = name || exception.name;
+  if (!name || !name.length || name.length < 3) {
+    name = exception.name;
+  }
 
   return {
     stack: getStack(),

--- a/src/browser/errorParser.js
+++ b/src/browser/errorParser.js
@@ -60,10 +60,13 @@ function Stack(exception) {
     return stack;
   }
 
+  var name = exception.constructor && exception.constructor.name;
+  name = name || exception.name;
+
   return {
     stack: getStack(),
     message: exception.message,
-    name: exception.name,
+    name: name,
     rawStack: exception.stack,
     rawException: exception
   };


### PR DESCRIPTION
Fixes #686 