### PR TITLE
Support web workers by passing gWindow instead of window

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -21,7 +21,7 @@ function Rollbar(options, client) {
 
   var gWindow = ((typeof window != 'undefined') && window) || ((typeof self != 'undefined') && self);
   var gDocument = (typeof document != 'undefined') && document;
-  addTransformsToNotifier(this.client.notifier);
+  addTransformsToNotifier(this.client.notifier, gWindow);
   addPredicatesToQueue(this.client.queue);
   if (this.options.captureUncaught || this.options.handleUncaughtExceptions) {
     globals.captureUncaughtExceptions(gWindow, this);
@@ -355,14 +355,14 @@ Rollbar.prototype.captureLoad = function(e, ts) {
 
 /* Internal */
 
-function addTransformsToNotifier(notifier) {
+function addTransformsToNotifier(notifier, gWindow) {
   notifier
     .addTransform(transforms.handleItemWithError)
     .addTransform(transforms.ensureItemHasSomethingToSay)
     .addTransform(transforms.addBaseInfo)
-    .addTransform(transforms.addRequestInfo(window))
-    .addTransform(transforms.addClientInfo(window))
-    .addTransform(transforms.addPluginInfo(window))
+    .addTransform(transforms.addRequestInfo(gWindow))
+    .addTransform(transforms.addClientInfo(gWindow))
+    .addTransform(transforms.addPluginInfo(gWindow))
     .addTransform(transforms.addBody)
     .addTransform(sharedTransforms.addMessageWithError)
     .addTransform(sharedTransforms.addTelemetryData)


### PR DESCRIPTION
In #549, support was added for using `self` in web workers, instead of `window`. This was called `gWindow`. However, `addTransformsToNotifier` continued to use `window`. 

Before this, if I called `Rollbar.init` inside a web worker, it would throw an exception. Now it does not.

I tried to rebuild using `npm run-script build` and I got an unrelated-seeming error:

```
ERROR in ./src/utility.js
Module not found: Error: Cannot resolve 'file' or 'directory' ../vendor/JSON-js/json3.js in /Users/paulbiggar/projects/rollbar.js/src
 @ ./src/utility.js 22:26-63
Warning: Task "webpack:2" failed. Use --force to continue.
```

Also, the generated files had lots of unrelated changes, so I didn't include them. Presumably there's some process that updates them.