### PR TITLE
Allow telemetry captureEvent to specify optional event type

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -327,12 +327,13 @@ Rollbar.wrap = function(f, context) {
   }
 };
 
-Rollbar.prototype.captureEvent = function(metadata, level) {
-  return this.client.captureEvent(metadata, level);
+Rollbar.prototype.captureEvent = function() {
+  var event = _.createTelemetryEvent(arguments);
+  return this.client.captureEvent(event.type, event.metadata, event.level);
 };
-Rollbar.captureEvent = function(metadata, level) {
+Rollbar.captureEvent = function() {
   if (_instance) {
-    return _instance.captureEvent(metadata, level);
+    return _instance.captureEvent.apply(_instance, arguments);
   } else {
     handleUninitialized();
   }

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -212,12 +212,13 @@ Rollbar.wait = function(callback) {
   }
 };
 
-Rollbar.prototype.captureEvent = function(metadata, level) {
-  return this.client.captureEvent(metadata, level);
+Rollbar.prototype.captureEvent = function() {
+  var event = _.createTelemetryEvent(arguments);
+  return this.client.captureEvent(event.type, event.metadata, event.level);
 };
-Rollbar.captureEvent = function(metadata, level) {
+Rollbar.captureEvent = function() {
   if (_instance) {
-    return _instance.captureEvent(metadata, level);
+    return _instance.captureEvent.apply(_instance, arguments);
   } else {
     handleUninitialized();
   }

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -81,8 +81,8 @@ Rollbar.prototype.wait = function(callback) {
   this.queue.wait(callback);
 };
 
-Rollbar.prototype.captureEvent = function(metadata, level) {
-  return this.telemeter.captureEvent(metadata, level);
+Rollbar.prototype.captureEvent = function(type, metadata, level) {
+  return this.telemeter.captureEvent(type, metadata, level);
 };
 
 Rollbar.prototype.captureDomContentLoaded = function(ts) {

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -364,12 +364,13 @@ Rollbar.wrapCallback = function(f) {
   }
 };
 
-Rollbar.prototype.captureEvent = function(metadata, level) {
-  return this.client.captureEvent(metadata, level);
+Rollbar.prototype.captureEvent = function() {
+  var event = _.createTelemetryEvent(arguments);
+  return this.client.captureEvent(event.type, event.metadata, event.level);
 };
-Rollbar.captureEvent = function(metadata, level) {
+Rollbar.captureEvent = function() {
   if (_instance) {
-    return _instance.captureEvent(metadata, level);
+    return _instance.captureEvent.apply(_instance, arguments);
   } else {
     handleUninitialized();
   }

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -63,8 +63,8 @@ Telemeter.prototype.capture = function(type, metadata, level, rollbarUUID, times
   return e;
 };
 
-Telemeter.prototype.captureEvent = function(metadata, level, rollbarUUID) {
-  return this.capture('manual', metadata, level, rollbarUUID);
+Telemeter.prototype.captureEvent = function(type, metadata, level, rollbarUUID) {
+  return this.capture(type, metadata, level, rollbarUUID);
 };
 
 Telemeter.prototype.captureError = function(err, level, rollbarUUID, timestamp) {

--- a/src/utility.js
+++ b/src/utility.js
@@ -236,9 +236,8 @@ function parseUri(str) {
   var o = parseUriOptions;
   var m = o.parser[o.strictMode ? 'strict' : 'loose'].exec(str);
   var uri = {};
-  var i = o.key.length;
 
-  while (i--) {
+  for (var i = 0, l = o.key.length; i < l; ++i) {
     uri[o.key[i]] = m[i] || '';
   }
 
@@ -457,14 +456,10 @@ var TELEMETRY_TYPES = ['log', 'network', 'dom', 'navigation', 'error', 'manual']
 var TELEMETRY_LEVELS = ['critical', 'error', 'warning', 'info', 'debug'];
 
 function arrayIncludes(arr, val) {
-  var len = arr.length;
-  var k = 0;
-
-  while (k < len) {
+  for (var k = 0; k < arr.length; ++k) {
     if (arr[k] === val) {
       return true;
     }
-    k++;
   }
 
   return false;

--- a/src/utility.js
+++ b/src/utility.js
@@ -453,6 +453,55 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
   return item;
 }
 
+var TELEMETRY_TYPES = ['log', 'network', 'dom', 'navigation', 'error', 'manual'];
+var TELEMETRY_LEVELS = ['critical', 'error', 'warning', 'info', 'debug'];
+
+function arrayIncludes(arr, val) {
+  var len = arr.length;
+  var k = 0;
+
+  while (k < len) {
+    if (arr[k] === val) {
+      return true;
+    }
+    k++;
+  }
+
+  return false;
+}
+
+function createTelemetryEvent(args) {
+  var type, metadata, level;
+  var arg;
+
+  for (var i = 0, l = args.length; i < l; ++i) {
+    arg = args[i];
+
+    var typ = typeName(arg);
+    switch (typ) {
+      case 'string':
+        if (arrayIncludes(TELEMETRY_TYPES, arg)) {
+          type = arg;
+        } else if (arrayIncludes(TELEMETRY_LEVELS, arg)) {
+          level = arg;
+        }
+        break;
+      case 'object':
+        metadata = arg;
+        break;
+      default:
+        break;
+    }
+  }
+  var event = {
+    type: type || 'manual',
+    metadata: metadata || {},
+    level: level
+  };
+
+  return event;
+}
+
 /*
  * get - given an obj/array and a keypath, return the value at that keypath or
  *       undefined if not possible.
@@ -655,6 +704,7 @@ function handleOptions(current, input, payload) {
 module.exports = {
   addParamsAndAccessTokenToPath: addParamsAndAccessTokenToPath,
   createItem: createItem,
+  createTelemetryEvent: createTelemetryEvent,
   filterIp: filterIp,
   formatArgsAsString: formatArgsAsString,
   formatUrl: formatUrl,

--- a/src/utility.js
+++ b/src/utility.js
@@ -537,7 +537,7 @@ function set(obj, path, value) {
   try {
     var temp = obj[keys[0]] || {};
     var replacement = temp;
-    for (var i = 1; i < len-1; i++) {
+    for (var i = 1; i < len - 1; ++i) {
       temp[keys[i]] = temp[keys[i]] || {};
       temp = temp[keys[i]];
     }
@@ -617,7 +617,7 @@ function _getScrubQueryParamRegexs(scrubFields) {
 function formatArgsAsString(args) {
   var i, len, arg;
   var result = [];
-  for (i = 0, len = args.length; i < len; i++) {
+  for (i = 0, len = args.length; i < len; ++i) {
     arg = args[i];
     switch (typeName(arg)) {
       case 'object':

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -204,6 +204,42 @@ describe('configure', function() {
   });
 });
 
+describe('captureEvent', function() {
+  it('should handle missing/default type and level', function(done) {
+    var options = {};
+    var rollbar = new Rollbar(options);
+
+    var event = rollbar.captureEvent({foo: 'bar'});
+    expect(event.type).to.eql('manual');
+    expect(event.level).to.eql('info');
+    expect(event.body.foo).to.eql('bar');
+
+    done();
+  });
+  it('should handle specified type and level', function(done) {
+    var options = {};
+    var rollbar = new Rollbar(options);
+
+    var event = rollbar.captureEvent('log', {foo: 'bar'}, 'debug');
+    expect(event.type).to.eql('log');
+    expect(event.level).to.eql('debug');
+    expect(event.body.foo).to.eql('bar');
+
+    done();
+  });
+  it('should handle extra args', function(done) {
+    var options = {};
+    var rollbar = new Rollbar(options);
+
+    var event = rollbar.captureEvent('meaningless', {foo: 'bar'}, 23);
+    expect(event.type).to.eql('manual');
+    expect(event.level).to.eql('info');
+    expect(event.body.foo).to.eql('bar');
+
+    done();
+  });
+});
+
 describe('createItem', function() {
   it('should handle multiple strings', function(done) {
     var client = new (TestClientGen())();

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -14,6 +14,7 @@ describe('Telemetry()', function() {
     expect(t).to.have.property('captureLog');
     expect(t).to.have.property('captureError');
     expect(t).to.have.property('captureNetwork');
+    expect(t).to.have.property('captureEvent');
 
     done();
   });
@@ -29,6 +30,18 @@ describe('capture', function() {
     expect(event.type).to.equal('network');
     expect(event.level).to.equal('debug');
     expect(event.body.url).to.equal('a.com');
+
+    done();
+  });
+});
+
+describe('captureEvent', function() {
+  it('should return a valid telemetry event', function(done) {
+    var t = new Telemeter();
+    var event = t.captureEvent('log', {message: 'bar'}, 'info');
+    expect(event.type).to.equal('log');
+    expect(event.level).to.equal('info');
+    expect(event.body.message).to.equal('bar');
 
     done();
   });


### PR DESCRIPTION
Fixes https://github.com/rollbar/rollbar.js/issues/659

Allows `captureEvent()` to be used as before with default event type `'manual'` or to specify an event type, by allowing flexible argument order similar to the way `log()` works.

Example:
```
captureEvent({foo: 'bar}, 'info'); // defaults to 'manual' event type

captureEvent('log', {message: 'bar}, 'info'); // Flexible argument ordering allows event type to be first argument
```
