### PR TITLE
Improved LambdaHandler event typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,7 @@ declare class Rollbar {
 
     public captureEvent(metadata: object, level: Rollbar.Level): Rollbar.TelemetryEvent;
 
-    public lambdaHandler(handler: Rollbar.LambdaHandler): Rollbar.LambdaHandler;
+    public lambdaHandler<T = object>(handler: Rollbar.LambdaHandler<T>): Rollbar.LambdaHandler<T>;
 
     public errorHandler(): Rollbar.ExpressErrorHandler;
 
@@ -31,7 +31,7 @@ declare class Rollbar {
 }
 
 declare namespace Rollbar {
-    export type LambdaHandler = (event: object, context: object, callback: Callback) => void;
+    export type LambdaHandler<E = object> = (event: E, context: object, callback: Callback) => void;
     export type MaybeError = Error | undefined | null;
     export type Level = "debug" | "info" | "warning" | "error" | "critical";
     export interface Configuration {


### PR DESCRIPTION
`@types/aws-lambda` allows the event to be typed as shown here: https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/index.d.ts#L1028

Wrapping the handler with `lambdaHandler()` removed the `@types/aws-lambda` typing. Forcing the `event` to always be of type `object` breaks the expected type of `event` in the handler. This change would enable you to type `lambdaHandler()` similarly to `Handler` from `@types/aws-lambda`. It would reinstate the desired type of `event` for the handler.

It should also be considered to enable typing of the result and to use the `Context` type from `@types/aws-lambda` instead of `object`.