### PR TITLE
Enable tests for examples, and add first test

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -51,6 +51,15 @@ function buildGruntKarmaConfig(singleRun, browsers, tests, reporters) {
           included: false,
           served: true,
           watched: false
+        },
+
+        // Examples HTML, set `included: true`, but they won't be executed or added
+        // to the DOM until loaded explicitly during a test.
+        {
+          pattern: 'examples/**/*.html',
+          included: true,
+          served: true,
+          watched: false
         }
       ]
     },

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ test:
 	@npm run test
 	@echo ""
 
+test-browser:
+	@npm run test-browser
+	@echo ""
+
+test-server:
+	@npm run test-server
+	@echo ""
+
 test_ci:
 	@npm run test_ci
 	@echo ""

--- a/examples/universal-browser/test.html
+++ b/examples/universal-browser/test.html
@@ -25,7 +25,7 @@
 
       var _rollbarConfig = {
         accessToken: "POST_CLIENT_ITEM_TOKEN",
-        rollbarJsUrl: '/rollbar.js',
+        rollbarJsUrl: '/dist/rollbar.js',
         captureUncaught: true,
         //checkIgnore: ignoreFilesUncaught,
         payload: {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -44,10 +44,11 @@ module.exports = function (config) {
     // run the bundle through the webpack and sourcemap plugins
     preprocessors: {
       'test/!(requirejs).test.js': ['webpack', 'sourcemap'],
+      '**/*.html': ['html2js']
     },
 
     proxies: {
-      '/dist/rollbar.js': '/base/dist/rollbar.js'
+      '/dist/': '/base/dist/'
     },
 
     reporters: ['progress'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollbar",
-  "version": "2.5.1",
+  "version": "2.5.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -192,6 +192,58 @@
           "dev": true
         }
       }
+    },
+    "@sinonjs/commons": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.4.0.tgz",
+      "integrity": "sha512-9jHK3YF/8HtJ9wCAbG+j8cD0i0+ATS9A7gXFqS36TblLPNy6rEEc+SB0imo91eCboGaBYGV/MT1/br/J+EE7Tw==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      },
+      "dependencies": {
+        "type-detect": {
+          "version": "4.0.8",
+          "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+          "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.1.tgz",
+      "integrity": "sha512-tsHvOB24rvyvV2+zKMmPkZ7dXX6LSLKZ7aOtXY6Edklp0uRcgGpOsQTTGTcWViFyx4uhWc6GV8QdnALbIbIdeQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^3.1.0"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.1.tgz",
+      "integrity": "sha512-wRSfmyd81swH0hA1bxJZJ57xr22kC07a1N4zuIL47yTS04bDk6AoCkczcqHEjcRPmJ+FruGJ9WBQiJwMtIElFw==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.0.2",
+        "array-from": "^2.1.1",
+        "lodash": "^4.17.11"
+      },
+      "dependencies": {
+        "lodash": {
+          "version": "4.17.11",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+          "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+          "dev": true
+        }
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
     },
     "Base64": {
       "version": "0.2.1",
@@ -386,6 +438,12 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI=",
+      "dev": true
+    },
+    "array-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+      "integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
       "dev": true
     },
     "array-slice": {
@@ -1315,21 +1373,6 @@
       "resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
       "integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
       "dev": true
-    },
-    "buster-core": {
-      "version": "0.6.4",
-      "resolved": "https://registry.npmjs.org/buster-core/-/buster-core-0.6.4.tgz",
-      "integrity": "sha1-J79rrWdCROpyDzEdkAoMoct4YFA=",
-      "dev": true
-    },
-    "buster-format": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/buster-format/-/buster-format-0.5.6.tgz",
-      "integrity": "sha1-K4bDIuz14bCubm55Bev884fSq5U=",
-      "dev": true,
-      "requires": {
-        "buster-core": "=0.6.4"
-      }
     },
     "bytes": {
       "version": "1.0.0",
@@ -8400,6 +8443,12 @@
         "verror": "1.10.0"
       }
     },
+    "just-extend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.0.2.tgz",
+      "integrity": "sha512-FrLwOgm+iXrPV+5zDU6Jqu4gCRXbWEQg2O3SKONsWE4w7AXFRkryS53bpWdaL9cNol+AmR3AEYz6kn+o0fCPnw==",
+      "dev": true
+    },
     "karma": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/karma/-/karma-3.1.3.tgz",
@@ -8922,6 +8971,12 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/karma-firefox-launcher/-/karma-firefox-launcher-0.1.7.tgz",
       "integrity": "sha1-wF3YZTNpHmLzGVJZUJjovTV9OfM=",
+      "dev": true
+    },
+    "karma-html2js-preprocessor": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-1.1.0.tgz",
+      "integrity": "sha1-/Ant8Eu+K7bu6boZaPgmtziAIL0=",
       "dev": true
     },
     "karma-jquery": {
@@ -10600,6 +10655,12 @@
         "object.assign": "^4.1.0"
       }
     },
+    "lolex": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
+      "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
+      "dev": true
+    },
     "longest": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
@@ -11194,6 +11255,42 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-1.4.10.tgz",
+      "integrity": "sha512-sa0RRbj53dovjc7wombHmVli9ZihXbXCQ2uH3TNm03DyvOSIQbxg+pbqDKrk2oxMK1rtLGVlKxcB9rrc6X5YjA==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/formatio": "^3.1.0",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "lolex": "^2.3.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "lolex": {
+          "version": "2.7.5",
+          "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+          "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.7.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+          "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "nock": {
       "version": "9.1.6",
@@ -12137,7 +12234,8 @@
         },
         "lodash": {
           "version": "4.17.4",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
         "node-uuid": {
@@ -13333,12 +13431,41 @@
       "dev": true
     },
     "sinon": {
-      "version": "1.7.3",
-      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.7.3.tgz",
-      "integrity": "sha1-emnWnNApRYbHQyVO7/G1g6UJl/I=",
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-7.3.0.tgz",
+      "integrity": "sha512-0pYvgRv46fODzT/PByqb79MVNpyxsxf38WEiXTABOF8RfIMcIARfZ+1ORuxwAmHkreZ/jST3UDBdKCRhUy/e1A==",
       "dev": true,
       "requires": {
-        "buster-format": "~0.5"
+        "@sinonjs/commons": "^1.4.0",
+        "@sinonjs/formatio": "^3.2.1",
+        "@sinonjs/samsam": "^3.3.0",
+        "diff": "^3.5.0",
+        "lolex": "^3.1.0",
+        "nise": "^1.4.10",
+        "supports-color": "^5.5.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+          "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "slash": {

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
   "browser": "dist/rollbar.umd.min.js",
   "types": "./index.d.ts",
   "dependencies": {
-    "console-polyfill": "0.3.0",
-    "error-stack-parser": "1.3.3",
     "async": "~1.2.1",
+    "console-polyfill": "0.3.0",
     "debug": "2.6.9",
+    "error-stack-parser": "1.3.3",
     "json-stringify-safe": "~5.0.0",
     "lru-cache": "~2.2.1",
     "request-ip": "~2.0.1",
@@ -62,6 +62,7 @@
     "karma-chrome-launcher": "^0.2.0",
     "karma-expect": "^1.1.0",
     "karma-firefox-launcher": "^0.1.6",
+    "karma-html2js-preprocessor": "^1.1.0",
     "karma-jquery": "^0.1.0",
     "karma-mocha": "^0.2.0",
     "karma-mocha-reporter": "^1.1.1",
@@ -79,7 +80,7 @@
     "request": "^2.88.0",
     "requirejs": "^2.1.20",
     "script-loader": "0.6.1",
-    "sinon": "~1.7.3",
+    "sinon": "^7.3.0",
     "stackframe": "^0.2.2",
     "strict-loader": "^0.1.2",
     "time-grunt": "^1.0.0",
@@ -93,6 +94,8 @@
   "scripts": {
     "build": "./node_modules/.bin/grunt",
     "test": "./node_modules/.bin/grunt test",
+    "test-browser": "./node_modules/.bin/grunt test-browser",
+    "test-server": "./node_modules/.bin/grunt test-server",
     "test_ci": "./node_modules/.bin/grunt test",
     "lint": "./node_modules/.bin/eslint"
   },

--- a/test/examples/universalBrowser.test.js
+++ b/test/examples/universalBrowser.test.js
@@ -1,0 +1,46 @@
+/* globals expect */
+/* globals describe */
+/* globals it */
+/* globals sinon */
+
+describe('Rollbar loaded by snippet', function() {
+  before(function (done) {
+    // Load the HTML page.
+    document.write(window.__html__['examples/universal-browser/test.html']);
+
+    // Stub the xhr interface.
+    server = sinon.createFakeServer();
+
+    // Give the snippet time to load and init.
+    setTimeout(function() {
+      done();
+    }, 1000);
+  });
+
+  after(function () {
+    server.restore();
+  });
+
+  it('should send a valid log event', function(done) {
+    var rollbar = document.defaultView.Rollbar;
+
+    server.respondWith('POST', 'api/1/item',
+      [
+        200,
+        { 'Content-Type': 'application/json' },
+        '{"err": 0, "result":{ "uuid": "d4c7acef55bf4c9ea95e4fe9428a8287"}}'
+      ]
+    );
+
+    var ret = rollbar.info('test');
+    server.respond();
+
+    body = JSON.parse(server.requests[0].requestBody);
+
+    expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
+    expect(body.data.uuid).to.eql(ret.uuid);
+    expect(body.data.body.message.body).to.eql('test');
+
+    done();
+  });
+});

--- a/test/notifier.test.js
+++ b/test/notifier.test.js
@@ -172,8 +172,9 @@ describe('log', function() {
     var notifier = new Notifier(queue, options);
 
     var initialItem = {a: 123, b: 'a string'};
+    var error = new Error('fizz buzz');
     notifier.addTransform(function(i, o, cb) {
-      cb(new Error('fizz buzz'), null);
+      cb(error, null);
     }).addTransform(function(i, o, cb) {
       expect(false).to.be.ok(); // assert this is not called
       cb(null, {a: 42, b: i.b});
@@ -182,7 +183,7 @@ describe('log', function() {
     notifier.log(initialItem, spy);
 
     expect(spy.called).to.be.ok();
-    expect(spy.calledWithExactly(new Error('fizz buzz'), null)).to.be.ok();
+    expect(spy.calledWithExactly(error, null)).to.be.ok();
     expect(queue.items.length).to.eql(0);
 
     done();


### PR DESCRIPTION
I looked at a few different ways of doing this. WebDriver/Selenium and other e2e frameworks for example. 

My criteria was:
* Able to load the HTML as in a browser, loading all assets, etc.
* Able to load rollbar.js in any of the ways available and/or recommended.
* Able to work with all of the front end frameworks.
* Able to verify successful and working rollbar.js load and ability to send an event.

In the end, Karma was able to do everything needed, and was already 90% configured for what we need here. 

Initially I expected each example app might need its own Karma config, and therefore separate entries in the Travis matrix. However, the changes to the root config aren't that bad and so far I expect everything will work under one config just fine.