### PR TITLE
Handle Firefox Exception type like Error

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -124,7 +124,8 @@ function isIterable(i) {
  * @returns true if e is an error
  */
 function isError(e) {
-  return isType(e, 'error');
+  // Detect both Error and Firefox Exception type
+  return isType(e, 'error') || isType(e, 'exception');
 }
 
 function traverse(obj, func, seen) {
@@ -394,6 +395,7 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
         break;
       case 'error':
       case 'domexception':
+      case 'exception': // Firefox Exception type
         err ? extraArgs.push(arg) : err = arg;
         break;
       case 'object':


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar.js/issues/712

In some cases, Firefox throws with `Exception` type rather than `Error`. The object conforms to the same expectations, and we can successfully build the backtrace from it. This change recognizes the Exception type as a kind of Error.