### PR TITLE
Enable RollbarProxy for sending Rollbar events

### DIFF
--- a/src/browser/transport.js
+++ b/src/browser/transport.js
@@ -71,7 +71,23 @@ function _makeZoneRequest(accessToken, url, method, data, callback, requestFacto
   }
 }
 
+/* global RollbarProxy */
+function _proxyRequest(json, callback) {
+  var rollbarProxy = new RollbarProxy();
+  rollbarProxy.sendJsonPayload(
+    json,
+    function(_msg) { /* do nothing */ }, // eslint-disable-line no-unused-vars
+    function(err) {
+      callback(new Error(err));
+    }
+  );
+}
+
 function _makeRequest(accessToken, url, method, data, callback, requestFactory) {
+  if (typeof RollbarProxy !== 'undefined') {
+    return _proxyRequest(data, callback);
+  }
+
   var request;
   if (requestFactory) {
     request = requestFactory();


### PR DESCRIPTION
Cordova support is driving the need for this, but it can be used by anyone who makes a `RollbarProxy` object available.