### PR TITLE
Allow enable/disable uncaught errors/rejections in .configure

### DIFF
--- a/examples/error.html
+++ b/examples/error.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Generate errors for test automation</title>
+  <!-- Throwing inside karma test files won't work,
+    but you can do it here and let karma load this file. -->
+  <script>
+    window.throwError = function throwError() {
+      // Example error, which will be reported to rollbar when `captureUncaught`
+      // is true in the config.
+      throw new Error('test error');
+    };
+  </script>
+</head>
+<body>
+  <div style="text-align:center">
+    <h1>
+      Generate errors for test automation
+    </h1>
+  </div>
+  <button id="throw-error" onclick="throwError()">Throw Error</button>
+</html>

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -36,13 +36,7 @@ function Rollbar(options, client) {
   this.client = client || new Client(this.options, api, logger, 'server');
   addTransformsToNotifier(this.client.notifier);
   addPredicatesToQueue(this.client.queue);
-
-  if (this.options.captureUncaught || this.options.handleUncaughtExceptions) {
-    this.handleUncaughtExceptions();
-  }
-  if (this.options.captureUnhandledRejections || this.options.handleUnhandledRejections) {
-    this.handleUnhandledRejections();
-  }
+  this.setupUnhandledCapture();
 }
 
 var _instance = null;
@@ -88,6 +82,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
   delete this.options.maxItems;
   logger.setVerbose(this.options.verbose);
   this.client.configure(options, payloadData);
+  this.setupUnhandledCapture();
   return this;
 };
 Rollbar.configure = function(options, payloadData) {
@@ -523,11 +518,24 @@ function _getFirstFunction(args) {
   return undefined;
 }
 
+Rollbar.prototype.setupUnhandledCapture = function() {
+  if (this.options.captureUncaught || this.options.handleUncaughtExceptions) {
+    this.handleUncaughtExceptions();
+  }
+  if (this.options.captureUnhandledRejections || this.options.handleUnhandledRejections) {
+    this.handleUnhandledRejections();
+  }
+};
+
 Rollbar.prototype.handleUncaughtExceptions = function() {
   var exitOnUncaught = !!this.options.exitOnUncaughtException;
   delete this.options.exitOnUncaughtException;
 
   addOrReplaceRollbarHandler('uncaughtException', function(err) {
+    if (!this.options.captureUncaught && !this.options.handleUncaughtExceptions) {
+      return;
+    }
+
     this._uncaughtError(err, function(err) {
       if (err) {
         logger.error('Encountered error while handling an uncaught exception.');
@@ -546,6 +554,10 @@ Rollbar.prototype.handleUncaughtExceptions = function() {
 
 Rollbar.prototype.handleUnhandledRejections = function() {
   addOrReplaceRollbarHandler('unhandledRejection', function(reason) {
+    if (!this.options.captureUnhandledRejections && !this.options.handleUnhandledRejections) {
+      return;
+    }
+
     this._uncaughtError(reason, function(err) {
       if (err) {
         logger.error('Encountered error while handling an uncaught exception.');


### PR DESCRIPTION
Fixes https://github.com/rollbar/rollbar.js/issues/726

Previously, updating `captureUncught` or `captureUnhandledRejections` in `Rollbar.configure` would have no effect. This PR allows both enabling and disabling via `configure` in both the browser and server/node environments.

This PR also adds browser and server tests for unhandled error and rejection behavior, as well as tests for enabling/disabling via the constructor and configure.