### PR TITLE
Enable rate limiting for node/server

### DIFF
--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -7,7 +7,7 @@ var _ = require('../utility');
 var API = require('../api');
 var logger = require('./logger');
 
-var transport = require('./transport');
+var Transport = require('./transport');
 var urllib = require('url');
 var jsonBackup = require('json-stringify-safe');
 
@@ -32,6 +32,7 @@ function Rollbar(options, client) {
   logger.setVerbose(this.options.verbose);
   this.lambdaContext = null;
   this.lambdaTimeoutHandle = null;
+  var transport = new Transport();
   var api = new API(this.options, transport, urllib, jsonBackup);
   this.client = client || new Client(this.options, api, logger, 'server');
   addTransformsToNotifier(this.client.notifier);


### PR DESCRIPTION
Uses response headers from the Rollbar API to avoid transmitting while rate limiting is in effect.

If an API response returns statusCode: 429, and 'x-rate-limit-remaining': 0, API requests will be dropped until x-rate-limit-remaining-seconds have elapsed.

Because the user may change rate limit settings in the Rollbar dashboard, it has been requested to poll every 60 seconds to see if the rate limit status has changed. This implementation sets its remaining seconds to a maximum of 60. This accomplishes the same end as continuous polling, but only attempts to send when there is an actual event to transmit.

