### PR TITLE
Clear timer to avoid unexpected "Function timed out" errors

### DIFF
--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -309,7 +309,10 @@ Rollbar.prototype.asyncLambdaHandler = function(handler, timeoutHandler) {
         self.lambdaTimeoutHandle = setTimeout(timeoutCb, context.getRemainingTimeInMillis() - 1000);
       }
       handler(event, context)
-        .then(function(resp) { resolve(resp); })
+        .then(function(resp) {
+          clearTimeout(self.lambdaTimeoutHandle);
+          resolve(resp);
+        })
         .catch(function(err) {
           self.error(err);
           self.wait(function() {


### PR DESCRIPTION
AWS Lambda allows this timer to run and execute its function after the Lambda function has exited successfully. This results in spurious and unexpected "Function timed out" errors in the Rollbar dashboard. Clearing the timer on exit solves the issue.