### PR TITLE
Workaround webpack/webpack issue #6642, #6677

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -96,7 +96,8 @@ var UMDConfigBase = {
   output: {
     path: outputPath,
     library: 'rollbar',
-    libraryTarget: 'umd'
+    libraryTarget: 'umd',
+    globalObject: 'this'
   },
   devtool: 'source-map',
   module: {


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar.js/issues/732

Workaround for webpack issue described here:
https://github.com/webpack/webpack/issues/6677
https://github.com/webpack/webpack/issues/6642

With a proposed fix here, but no ETA: https://github.com/webpack/webpack/issues/6525

There are various suggestions on how to set `globalObject`. This PR produces the same UMD code as before the update to webpack 4.