### PR TITLE
Add transmit option flag

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -458,6 +458,7 @@ var defaultOptions = {
   endpoint: __DEFAULT_ENDPOINT__,
   verbose: false,
   enabled: true,
+  transmit: true,
   sendConfig: false,
   includeItemsInTelemetry: true,
   captureIp: true

--- a/src/queue.js
+++ b/src/queue.js
@@ -89,6 +89,7 @@ Queue.prototype.addItem = function(item, callback, originalError, originalItem) 
   this._maybeLog(item, originalError);
   this.removePendingItem(originalItem);
   if (!this.options.transmit) {
+    callback(new Error('Transmit disabled'));
     return;
   }
   this.pendingRequests.push(item);

--- a/src/queue.js
+++ b/src/queue.js
@@ -88,6 +88,9 @@ Queue.prototype.addItem = function(item, callback, originalError, originalItem) 
   }
   this._maybeLog(item, originalError);
   this.removePendingItem(originalItem);
+  if (!this.options.transmit) {
+    return;
+  }
   this.pendingRequests.push(item);
   try {
     this._makeApiRequest(item, function(err, resp) {

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -314,6 +314,7 @@ Rollbar.defaultOptions = {
   reportLevel: packageJson.defaults.reportLevel,
   verbose: false,
   enabled: true,
+  transmit: true,
   sendConfig: false,
   includeItemsInTelemetry: true
 };

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -615,6 +615,7 @@ Rollbar.defaultOptions = {
   reportLevel: packageJson.defaults.reportLevel,
   verbose: false,
   enabled: true,
+  transmit: true,
   sendConfig: false,
   includeItemsInTelemetry: false,
   captureEmail: false,

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -514,7 +514,9 @@ describe('addItem', function() {
         var queue = new Queue(rateLimiter, api, logger, options);
         var makeApiRequestStub = sinon.stub(queue, '_makeApiRequest');
 
-        queue.addItem({mykey: 'myvalue'});
+        queue.addItem({mykey: 'myvalue'}, function(err) {
+          expect(err.message).to.eql('Transmit disabled');
+        });
 
         expect(makeApiRequestStub.called).to.eql(0);
 

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -106,7 +106,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -127,7 +127,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -148,7 +148,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -171,7 +171,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {verbose: true};
+        var options = {verbose: true, transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {body: {trace: {exception: {message: 'hello'}}}};
@@ -195,7 +195,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {verbose: true};
+        var options = {verbose: true, transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {body: {message: {body: 'hello'}}};
@@ -219,7 +219,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {verbose: false};
+        var options = {verbose: false, transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {body: {message: {body: 'hello'}}};
@@ -243,7 +243,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -269,7 +269,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -297,7 +297,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -329,7 +329,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -354,7 +354,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -376,7 +376,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -406,7 +406,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -434,7 +434,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {retryInterval: 1};
+        var options = {retryInterval: 1, transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -456,7 +456,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {};
+        var options = {transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -478,7 +478,7 @@ describe('addItem', function() {
         var rateLimiter = new (TestRateLimiterGenerator())();
         var api = new (TestApiGenerator())();
         var logger = new (TestLoggerGenerator())();
-        var options = {retryInterval: 1};
+        var options = {retryInterval: 1, transmit: true};
         var queue = new Queue(rateLimiter, api, logger, options);
 
         var item = {mykey: 'myvalue'};
@@ -505,13 +505,30 @@ describe('addItem', function() {
         });
       });
     });
+    describe('transmit disabled', function() {
+      it('should not attempt to send', function(done) {
+        var rateLimiter = new (TestRateLimiterGenerator())();
+        var api = new (TestApiGenerator())();
+        var logger = new (TestLoggerGenerator())();
+        var options = {transmit: false};
+        var queue = new Queue(rateLimiter, api, logger, options);
+        var makeApiRequestStub = sinon.stub(queue, '_makeApiRequest');
+
+        queue.addItem({mykey: 'myvalue'});
+
+        expect(makeApiRequestStub.called).to.eql(0);
+
+        queue._makeApiRequest.restore();
+        done();
+      });
+    });
   });
   describe('rate limited', function() {
     it('should callback if the rate limiter says not to send and has an error', function(done) {
       var rateLimiter = new (TestRateLimiterGenerator())();
       var api = new (TestApiGenerator())();
       var logger = new (TestLoggerGenerator())();
-      var options = {};
+      var options = {transmit: true};
       var queue = new Queue(rateLimiter, api, logger, options);
 
       var item = {mykey: 'myvalue'};
@@ -539,7 +556,7 @@ describe('addItem', function() {
       var rateLimiter = new (TestRateLimiterGenerator())();
       var api = new (TestApiGenerator())();
       var logger = new (TestLoggerGenerator())();
-      var options = {};
+      var options = {transmit: true};
       var queue = new Queue(rateLimiter, api, logger, options);
 
       var item = {mykey: 'myvalue'};
@@ -567,4 +584,3 @@ describe('addItem', function() {
     });
   });
 });
-


### PR DESCRIPTION
To support SDK dev options, adds the `transmit` option, default `true`. Set to false to fully process events, but not send to Rollbar.