### PR TITLE
Add configured options to payload notifier object

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -16,6 +16,7 @@ var Instrumenter = require('./telemetry');
 
 function Rollbar(options, client) {
   this.options = _.handleOptions(defaultOptions, options);
+  this.options._configuredOptions = options;
   var api = new API(this.options, transport, urllib);
   this.client = client || new Client(this.options, api, logger, 'browser');
 
@@ -66,6 +67,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
     payload = {payload: payloadData};
   }
   this.options = _.handleOptions(oldOptions, options, payload);
+  this.options._configuredOptions = _.handleOptions(oldOptions._configuredOptions, options, payload);
   this.client.configure(this.options, payloadData);
   this.instrumenter.configure(this.options);
   this.setupUnhandledCapture();
@@ -472,6 +474,7 @@ function addTransformsToNotifier(notifier, gWindow) {
     .addTransform(sharedTransforms.addConfigToPayload)
     .addTransform(transforms.scrubPayload)
     .addTransform(sharedTransforms.userTransform(logger))
+    .addTransform(sharedTransforms.addConfiguredOptions)
     .addTransform(sharedTransforms.itemToPayload);
 }
 

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -18,6 +18,7 @@ function Rollbar(options, client) {
     options.accessToken = accessToken;
   }
   this.options = _.handleOptions(Rollbar.defaultOptions, options);
+  this.options._configuredOptions = options;
   // This makes no sense in a long running app
   delete this.options.maxItems;
   this.options.environment = this.options.environment || 'unspecified';
@@ -63,6 +64,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
     payload = {payload: payloadData};
   }
   this.options = _.handleOptions(oldOptions, options, payload);
+  this.options._configuredOptions = _.handleOptions(oldOptions._configuredOptions, options, payload);
   this.client.configure(options, payloadData);
   return this;
 };
@@ -278,6 +280,7 @@ function addTransformsToNotifier(notifier) {
     .addTransform(sharedTransforms.addTelemetryData)
     .addTransform(sharedTransforms.addConfigToPayload)
     .addTransform(transforms.scrubPayload)
+    .addTransform(sharedTransforms.addConfiguredOptions)
     .addTransform(sharedTransforms.itemToPayload);
 }
 

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -26,6 +26,7 @@ function Rollbar(options, client) {
     delete options.minimumLevel;
   }
   this.options = _.handleOptions(Rollbar.defaultOptions, options);
+  this.options._configuredOptions = options;
   // On the server we want to ignore any maxItems setting
   delete this.options.maxItems;
   this.options.environment = this.options.environment || 'unspecified';
@@ -79,6 +80,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
     payload = {payload: payloadData};
   }
   this.options = _.handleOptions(oldOptions, options, payload);
+  this.options._configuredOptions = _.handleOptions(oldOptions._configuredOptions, options, payload);
   // On the server we want to ignore any maxItems setting
   delete this.options.maxItems;
   logger.setVerbose(this.options.verbose);
@@ -496,6 +498,7 @@ function addTransformsToNotifier(notifier) {
     .addTransform(sharedTransforms.addConfigToPayload)
     .addTransform(transforms.scrubPayload)
     .addTransform(sharedTransforms.userTransform(logger))
+    .addTransform(sharedTransforms.addConfiguredOptions)
     .addTransform(sharedTransforms.itemToPayload);
 }
 

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -75,10 +75,17 @@ function addConfigToPayload(item, options, callback) {
   callback(null, item);
 }
 
+function addConfiguredOptions(item, options, callback) {
+  delete options._configuredOptions.accessToken;
+  item.data.notifier.configured_options = options._configuredOptions;
+  callback(null, item);
+}
+
 module.exports = {
   itemToPayload: itemToPayload,
   addTelemetryData: addTelemetryData,
   addMessageWithError: addMessageWithError,
   userTransform: userTransform,
-  addConfigToPayload: addConfigToPayload
+  addConfigToPayload: addConfigToPayload,
+  addConfiguredOptions: addConfiguredOptions
 };

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -202,6 +202,24 @@ describe('configure', function() {
     expect(client.payloadData.b).to.eql(97);
     done();
   });
+  it('should store configured options', function(done) {
+    var client = new (TestClientGen())();
+    var options = {
+      captureUncaught: true,
+      payload: {
+        a: 42,
+        environment: 'testtest'
+      }
+    };
+    var rollbar = new Rollbar(options, client);
+    expect(rollbar.options._configuredOptions.payload.environment).to.eql('testtest');
+    expect(rollbar.options._configuredOptions.captureUncaught).to.eql(true);
+
+    rollbar.configure({ captureUncaught: false, payload: {environment: 'borkbork'}});
+    expect(rollbar.options._configuredOptions.payload.environment).to.eql('borkbork');
+    expect(rollbar.options._configuredOptions.captureUncaught).to.eql(false);
+    done();
+  });
 });
 
 describe('options.captureUncaught', function() {

--- a/test/react-native.rollbar.test.js
+++ b/test/react-native.rollbar.test.js
@@ -243,6 +243,24 @@ describe('configure', function() {
     expect(client.payloadData.b).to.eql(97);
     done();
   });
+  it('should store configured options', function(done) {
+    var client = new (TestClientGen())();
+    var options = {
+      captureUncaught: true,
+      payload: {
+        a: 42,
+        environment: 'testtest'
+      }
+    };
+    var rollbar = new Rollbar(options, client);
+    expect(rollbar.options._configuredOptions.payload.environment).to.eql('testtest');
+    expect(rollbar.options._configuredOptions.captureUncaught).to.eql(true);
+
+    rollbar.configure({ captureUncaught: false, payload: {environment: 'borkbork'}});
+    expect(rollbar.options._configuredOptions.payload.environment).to.eql('borkbork');
+    expect(rollbar.options._configuredOptions.captureUncaught).to.eql(false);
+    done();
+  });
 });
 
 describe('captureEvent', function() {

--- a/test/server.rollbar.test.js
+++ b/test/server.rollbar.test.js
@@ -112,6 +112,22 @@ vows.describe('rollbar')
         },
         'should set environment based on options': function(r) {
           assert.equal('fake-env', r.options.environment);
+        },
+        'should set configured options': function(r) {
+          assert.equal('fake-env', r.options._configuredOptions.environment);
+        }
+      }
+    },
+    'configure': {
+      'with updated options': {
+        topic: function() {
+          var rollbar = new Rollbar({captureUncaught: true, environment: 'fake-env'});
+          rollbar.configure({captureUncaught: false, environment: 'new-env'});
+          return rollbar;
+        },
+        'should set configured options': function(r) {
+          assert.equal('new-env', r.options._configuredOptions.environment);
+          assert.equal(false, r.options._configuredOptions.captureUncaught);
         }
       }
     },

--- a/test/transforms.test.js
+++ b/test/transforms.test.js
@@ -83,6 +83,34 @@ describe('addTelemetryData', function() {
   });
 });
 
+describe('addConfiguredOptions', function() {
+  it('adds the configured options', function(done) {
+    var item = {
+      data: {
+        body: {
+          message: 'hello world'
+        },
+        notifier: {
+          name: 'rollbar-js',
+        }
+      }
+    };
+    var options = {
+      accessToken: 'abc123',
+      foo: 'bar',
+      captureUncaught: true,
+      _configuredOptions: {
+        accessToken: 'abc123',
+        captureUncaught: true
+      }
+    };
+    t.addConfiguredOptions(item, options, function(e, i) {
+      expect(i.data.notifier.configured_options).to.eql({ captureUncaught: true });
+      done(e);
+    });
+  });
+});
+
 describe('userTransform', function() {
   it('calls user transform if is present and a function', function(done) {
     var args = ['a message'];
@@ -144,4 +172,3 @@ describe('userTransform', function() {
     });
   });
 });
-


### PR DESCRIPTION
For internal support team diagnosis, stores the user configured options in the payload notifier object.