### PR TITLE
Add diagnostic key for anonymous errors

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -307,6 +307,9 @@ Rollbar.prototype.handleAnonymousErrors = function() {
           return;
         }
 
+        // Allow this to be tracked later.
+        error._isAnonymous = true;
+
         // url, lineno, colno shouldn't be needed for these errors.
         // If that changes, update this accordingly, using the unused
         // _stack param as needed (rather than parse error.toString()).
@@ -475,6 +478,7 @@ function addTransformsToNotifier(notifier, gWindow) {
     .addTransform(transforms.scrubPayload)
     .addTransform(sharedTransforms.userTransform(logger))
     .addTransform(sharedTransforms.addConfiguredOptions)
+    .addTransform(sharedTransforms.addDiagnosticKeys)
     .addTransform(sharedTransforms.itemToPayload);
 }
 

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -81,11 +81,22 @@ function addConfiguredOptions(item, options, callback) {
   callback(null, item);
 }
 
+function addDiagnosticKeys(item, options, callback) {
+  var diagnostic = {}
+
+  if (_.get(item, 'err._isAnonymous')) {
+    diagnostic.isAnonymous = true;
+  }
+  item.data.notifier.diagnostic = _.merge(item.data.notifier.diagnostic, diagnostic);
+  callback(null, item);
+}
+
 module.exports = {
   itemToPayload: itemToPayload,
   addTelemetryData: addTelemetryData,
   addMessageWithError: addMessageWithError,
   userTransform: userTransform,
   addConfigToPayload: addConfigToPayload,
-  addConfiguredOptions: addConfiguredOptions
+  addConfiguredOptions: addConfiguredOptions,
+  addDiagnosticKeys: addDiagnosticKeys
 };

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -303,6 +303,7 @@ describe('options.captureUncaught', function() {
 
     expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
     expect(body.data.body.trace.exception.message).to.eql('test error');
+    expect(body.data.notifier.diagnostic.isAnonymous).to.not.be.ok();
 
     server.requests.length = 0;
 
@@ -350,6 +351,7 @@ describe('options.captureUncaught', function() {
 
     expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
     expect(body.data.body.trace.exception.message).to.eql('anon error');
+    expect(body.data.notifier.diagnostic.isAnonymous).to.eql(true);
 
     // karma doesn't unload the browser between tests, so the onerror handler
     // will remain installed. Unset captureUncaught so the onerror handler


### PR DESCRIPTION
Adds a diagnostic key to the payload, so during any troubleshooting we can see how the error was generated.