### PR TITLE
Add ignoreDuplicateErrors config flag

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -529,7 +529,8 @@ var defaultOptions = {
   sendConfig: false,
   includeItemsInTelemetry: true,
   captureIp: true,
-  inspectAnonymousErrors: true
+  inspectAnonymousErrors: true,
+  ignoreDuplicateErrors: true
 };
 
 module.exports = Rollbar;

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -319,7 +319,8 @@ Rollbar.defaultOptions = {
   enabled: true,
   transmit: true,
   sendConfig: false,
-  includeItemsInTelemetry: true
+  includeItemsInTelemetry: true,
+  ignoreDuplicateErrors: true
 };
 
 module.exports = Rollbar;

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -110,7 +110,7 @@ Rollbar.prototype._log = function(defaultLevel, item) {
     callback = item.callback;
     delete item.callback;
   }
-  if (!this.options.transmitDuplicateErrors && this._sameAsLastError(item)) {
+  if (this.options.ignoreDuplicateErrors && this._sameAsLastError(item)) {
     if (callback) {
       var error = new Error('ignored identical item');
       error.item = item;

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -110,7 +110,7 @@ Rollbar.prototype._log = function(defaultLevel, item) {
     callback = item.callback;
     delete item.callback;
   }
-  if (this._sameAsLastError(item)) {
+  if (!this.options.transmitDuplicateErrors && this._sameAsLastError(item)) {
     if (callback) {
       var error = new Error('ignored identical item');
       error.item = item;

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -624,7 +624,8 @@ Rollbar.defaultOptions = {
   captureEmail: false,
   captureUsername: false,
   captureIp: true,
-  captureLambdaTimeouts: true
+  captureLambdaTimeouts: true,
+  ignoreDuplicateErrors: true
 };
 
 module.exports = Rollbar;

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -407,7 +407,7 @@ describe('options.captureUncaught', function() {
     var options = {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
       captureUncaught: true,
-      transmitDuplicateErrors: true
+      ignoreDuplicateErrors: false
     };
     var rollbar = new Rollbar(options);
 

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -362,6 +362,79 @@ describe('options.captureUncaught', function() {
 
     done();
   });
+
+  it('should ignore duplicate errors by default', function(done) {
+    var server = window.server;
+    stubResponse(server);
+    server.requests.length = 0;
+
+    var options = {
+      accessToken: 'POST_CLIENT_ITEM_TOKEN',
+      captureUncaught: true
+    };
+    var rollbar = new Rollbar(options);
+
+    var element = document.getElementById('throw-error');
+
+    // generate same error twice
+    element.click();
+    element.click();
+    server.respond();
+
+    // transmit only once
+    expect(server.requests.length).to.eql(1);
+
+    var body = JSON.parse(server.requests[0].requestBody);
+
+    expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
+    expect(body.data.body.trace.exception.message).to.eql('test error');
+
+    // karma doesn't unload the browser between tests, so the onerror handler
+    // will remain installed. Unset captureUncaught so the onerror handler
+    // won't affect other tests.
+    rollbar.configure({
+      captureUncaught: false
+    });
+
+    done();
+  });
+
+    it('should transmit duplicate errors when set in config', function(done) {
+    var server = window.server;
+    stubResponse(server);
+    server.requests.length = 0;
+
+    var options = {
+      accessToken: 'POST_CLIENT_ITEM_TOKEN',
+      captureUncaught: true,
+      transmitDuplicateErrors: true
+    };
+    var rollbar = new Rollbar(options);
+
+    var element = document.getElementById('throw-error');
+
+    // generate same error twice
+    element.click();
+    element.click();
+    server.respond();
+
+    // transmit both errors
+    expect(server.requests.length).to.eql(2);
+
+    var body = JSON.parse(server.requests[0].requestBody);
+
+    expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
+    expect(body.data.body.trace.exception.message).to.eql('test error');
+
+    // karma doesn't unload the browser between tests, so the onerror handler
+    // will remain installed. Unset captureUncaught so the onerror handler
+    // won't affect other tests.
+    rollbar.configure({
+      captureUncaught: false
+    });
+
+    done();
+  })
 });
 
 describe('options.captureUnhandledRejections', function() {


### PR DESCRIPTION
Rollbar.js discards consecutive identical uncaught errors after sending the first error. This new flag allows overriding that behavior and transmitting all duplicate errors. 