### PR TITLE
Use better message when rollbar.log is called with null or missing arguments

### DIFF
--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -120,13 +120,7 @@ function addBodyMessage(item, options, callback) {
   var custom = item.custom;
 
   if (!message) {
-    if (custom) {
-      var scrubFields = options.scrubFields;
-      var messageResult = _.stringify(_.scrub(custom, scrubFields));
-      message = messageResult.error || messageResult.value || '';
-    } else {
-      message = '';
-    }
+    message = 'Item sent with null or missing arguments.';
   }
   var result = {
     body: message

--- a/src/react-native/transforms.js
+++ b/src/react-native/transforms.js
@@ -33,7 +33,7 @@ function baseData(item, options, callback) {
 function addMessageData(item, options, callback) {
   item.data = item.data || {};
   item.data.body = item.data.body || {};
-  var message = item.message || '';
+  var message = item.message || 'Item sent with null or missing arguments.';
   item.data.body.message = {
     body: message
   };

--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -49,7 +49,7 @@ function baseData(item, options, callback) {
 function addMessageData(item, options, callback) {
   item.data = item.data || {};
   item.data.body = item.data.body || {};
-  var message = item.message || '';
+  var message = item.message || 'Item sent with null or missing arguments.';
   item.data.body.message = {
     body: message
   };

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -553,6 +553,48 @@ describe('options.captureUnhandledRejections', function() {
   })
 });
 
+describe('log', function() {
+  before(function (done) {
+    window.server = sinon.createFakeServer();
+    done();
+  });
+
+  after(function () {
+    window.server.restore();
+  });
+
+  function stubResponse(server) {
+    server.respondWith('POST', 'api/1/item',
+      [
+        200,
+        { 'Content-Type': 'application/json' },
+        '{"err": 0, "result":{ "uuid": "d4c7acef55bf4c9ea95e4fe9428a8287"}}'
+      ]
+    );
+  }
+
+  it('should send message when called with only null arguments', function(done) {
+    var server = window.server;
+    stubResponse(server);
+    server.requests.length = 0;
+
+    var options = {
+      accessToken: 'POST_CLIENT_ITEM_TOKEN',
+      captureUnhandledRejections: true
+    };
+    var rollbar = new Rollbar(options);
+
+    rollbar.log(null);
+
+    server.respond();
+
+    var body = JSON.parse(server.requests[0].requestBody);
+
+    expect(body.data.body.message.body).to.eql('Item sent with null or missing arguments.');
+
+    done();
+  })
+});
 describe('captureEvent', function() {
   it('should handle missing/default type and level', function(done) {
     var options = {};

--- a/test/browser.transforms.test.js
+++ b/test/browser.transforms.test.js
@@ -287,31 +287,12 @@ describe('addBody', function() {
         done(e);
       });
     });
-    it('should use custom as message without a message', function(done) {
+    it('should send message when sent without a message', function(done) {
       var args = [{custom: 'stuff'}];
       var item = itemFromArgs(args);
       var options = {};
       t.addBody(item, options, function(e, i) {
-        expect(i.data.body.message.body).to.be.ok();
-        done(e);
-      });
-    });
-    it('should use scrubbed custom as message without a message', function(done) {
-      var args = [{password: 'stuff'}];
-      var item = itemFromArgs(args);
-      var options = {scrubFields: ['password']};
-      t.addBody(item, options, function(e, i) {
-        expect(i.data.body.message.body).to.not.match(/stuff/);
-        expect(i.data.body.message.body).to.match(/\*+/);
-        done(e);
-      });
-    });
-    it('should have blank message without a message or custom', function(done) {
-      var args = [new Error('bork')];
-      var item = itemFromArgs(args);
-      var options = {};
-      t.addBody(item, options, function(e, i) {
-        expect(i.data.body.message.body).to.eql('');
+        expect(i.data.body.message.body).to.eql('Item sent with null or missing arguments.');
         done(e);
       });
     });

--- a/test/server.rollbar.test.js
+++ b/test/server.rollbar.test.js
@@ -225,6 +225,39 @@ vows.describe('rollbar')
           }
         }
       },
+      'info': {
+        topic: function() {
+          // Uses real client and stubs queue.addItem so transforms can run.
+          var rollbar = new Rollbar({
+            accessToken: 'abc123',
+            captureUncaught: false
+          });
+          var notifier = rollbar.client.notifier;
+          rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+          return rollbar;
+        },
+        'should send message when called with only null argument': function(r) {
+          var addItemStub = r.addItemStub;
+
+          r.info(null);
+          assert.isTrue(addItemStub.called);
+          if (addItemStub.called) {
+            assert.equal(addItemStub.getCall(0).args[3].data.body.message.body, 'Item sent with null or missing arguments.');
+          }
+          addItemStub.reset();
+        },
+        'should send message when called with no arguments': function(r) {
+          var addItemStub = r.addItemStub;
+
+          r.info();
+          assert.isTrue(addItemStub.called);
+          if (addItemStub.called) {
+            assert.equal(addItemStub.getCall(0).args[3].data.body.message.body, 'Item sent with null or missing arguments.');
+          }
+          addItemStub.reset();
+        }
+      },
       'error': {
         'with unordered options': {
           'should work with custom, request, callback, message ': function(r) {


### PR DESCRIPTION
Adds a more meaningful message when a Rollbar message is blank. This typically occurs when an argument is intended to be non-null, but is actually null or missing.

The most odd case is when calling something like `Rollbar.error(null)` in browser js. The message that shows up in the dashboard is:
`{"extraArgs":[null]}`

These cases will now use the message 'Item sent with null or missing arguments.', which should be more helpful to both the user and Rollbar customer support.
