### PR TITLE
Fix browser detection inside web workers

### DIFF
--- a/src/browser/detection.js
+++ b/src/browser/detection.js
@@ -7,7 +7,7 @@
 // Will return undefined otherwise
 function getIEVersion() {
 	var undef;
-	if (!document) {
+	if (typeof document === 'undefined') {
 		return undef;
 	}
 


### PR DESCRIPTION
Web workers don't have document at all, so this was failing with "document is not defined".