### PR TITLE
Send DOMException as trace_chain; allow nested errors in browser SDK

### DIFF
--- a/examples/error.html
+++ b/examples/error.html
@@ -11,6 +11,11 @@
       // is true in the config.
       throw new Error('test error');
     };
+    window.throwDomException = function throwDomException() {
+      // Example error, which will be reported to rollbar when `captureUncaught`
+      // is true in the config.
+      throw new DOMException('test DOMException');
+    };
   </script>
 </head>
 <body>
@@ -20,4 +25,5 @@
     </h1>
   </div>
   <button id="throw-error" onclick="throwError()">Throw Error</button>
+  <button id="throw-dom-exception" onclick="throwDomException()">Throw DOMException</button>
 </html>

--- a/src/browser/errorParser.js
+++ b/src/browser/errorParser.js
@@ -76,7 +76,21 @@ function Stack(exception) {
 
 
 function parse(e) {
-  return new Stack(e);
+  var err = e;
+
+  if (err.nested) {
+    var traceChain = [];
+    while (err) {
+      traceChain.push(new Stack(err));
+      err = err.nested;
+    }
+
+    // Return primary error with full trace chain attached.
+    traceChain[0].traceChain = traceChain;
+    return traceChain[0];
+  } else {
+    return new Stack(err);
+  }
 }
 
 

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -468,6 +468,7 @@ Rollbar.prototype.captureLoad = function(e, ts) {
 
 function addTransformsToNotifier(notifier, gWindow) {
   notifier
+    .addTransform(transforms.handleDomException)
     .addTransform(transforms.handleItemWithError)
     .addTransform(transforms.ensureItemHasSomethingToSay)
     .addTransform(transforms.addBaseInfo)

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -399,7 +399,7 @@ describe('options.captureUncaught', function() {
     done();
   });
 
-    it('should transmit duplicate errors when set in config', function(done) {
+  it('should transmit duplicate errors when set in config', function(done) {
     var server = window.server;
     stubResponse(server);
     server.requests.length = 0;
@@ -434,7 +434,37 @@ describe('options.captureUncaught', function() {
     });
 
     done();
-  })
+  });
+  it('should send DOMException as trace_chain', function(done) {
+    var server = window.server;
+    stubResponse(server);
+    server.requests.length = 0;
+
+    var options = {
+      accessToken: 'POST_CLIENT_ITEM_TOKEN',
+      captureUncaught: true
+    };
+    var rollbar = new Rollbar(options);
+
+    var element = document.getElementById('throw-dom-exception');
+    element.click();
+    server.respond();
+
+    var body = JSON.parse(server.requests[0].requestBody);
+
+    expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
+    expect(body.data.body.trace_chain[0].exception.message).to.eql('test DOMException');
+
+    // karma doesn't unload the browser between tests, so the onerror handler
+    // will remain installed. Unset captureUncaught so the onerror handler
+    // won't affect other tests.
+    rollbar.configure({
+      captureUncaught: false
+    });
+
+    done();
+  });
+
 });
 
 describe('options.captureUnhandledRejections', function() {


### PR DESCRIPTION
1. Enables nested errors, and `trace_chain` payloads in the browser environment.

2. Converts DOMException to a trace chain event by creating an error object for the DOMException's error name.