### PR TITLE
Add raw error diagnostic; fix key format for API payload

### DIFF
--- a/src/transforms.js
+++ b/src/transforms.js
@@ -85,8 +85,25 @@ function addDiagnosticKeys(item, options, callback) {
   var diagnostic = {}
 
   if (_.get(item, 'err._isAnonymous')) {
-    diagnostic.isAnonymous = true;
+    diagnostic.is_anonymous = true;
   }
+
+  if (item.err) {
+    try {
+      diagnostic.raw_error = {
+        message: item.err.message,
+        name: item.err.name,
+        constructor_name: item.err.constructor && item.err.constructor.name,
+        filename: item.err.fileName,
+        line: item.err.lineNumber,
+        column: item.err.columnNumber,
+        stack: item.err.stack
+      };
+    } catch (e) {
+      diagnostic.raw_error = { failed: String(e) };
+    }
+  }
+
   item.data.notifier.diagnostic = _.merge(item.data.notifier.diagnostic, diagnostic);
   callback(null, item);
 }

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -264,6 +264,7 @@ describe('options.captureUncaught', function() {
 
     expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
     expect(body.data.body.trace.exception.message).to.eql('test error');
+    expect(body.data.notifier.diagnostic.raw_error.message).to.eql('test error');
 
     // karma doesn't unload the browser between tests, so the onerror handler
     // will remain installed. Unset captureUncaught so the onerror handler
@@ -303,7 +304,7 @@ describe('options.captureUncaught', function() {
 
     expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
     expect(body.data.body.trace.exception.message).to.eql('test error');
-    expect(body.data.notifier.diagnostic.isAnonymous).to.not.be.ok();
+    expect(body.data.notifier.diagnostic.is_anonymous).to.not.be.ok();
 
     server.requests.length = 0;
 
@@ -351,7 +352,7 @@ describe('options.captureUncaught', function() {
 
     expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
     expect(body.data.body.trace.exception.message).to.eql('anon error');
-    expect(body.data.notifier.diagnostic.isAnonymous).to.eql(true);
+    expect(body.data.notifier.diagnostic.is_anonymous).to.eql(true);
 
     // karma doesn't unload the browser between tests, so the onerror handler
     // will remain installed. Unset captureUncaught so the onerror handler


### PR DESCRIPTION
1. When `item.err` is present, store the raw error in the `notifier.diagnostic` key.

2. Fix the key name format for `is_anonymous` to be snake case like the rest of the API request payload.