### PR TITLE
Allow disable of global event wrappers

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -225,7 +225,9 @@ Rollbar.prototype.setupUnhandledCapture = function() {
   if (!this.unhandledExceptionsInitialized) {
     if (this.options.captureUncaught || this.options.handleUncaughtExceptions) {
       globals.captureUncaughtExceptions(gWindow, this);
-      globals.wrapGlobals(gWindow, this);
+      if (this.options.wrapGlobalEventHandlers) {
+        globals.wrapGlobals(gWindow, this);
+      }
       this.unhandledExceptionsInitialized = true;
     }
   }
@@ -534,7 +536,8 @@ var defaultOptions = {
   includeItemsInTelemetry: true,
   captureIp: true,
   inspectAnonymousErrors: true,
-  ignoreDuplicateErrors: true
+  ignoreDuplicateErrors: true,
+  wrapGlobalEventHandlers: true
 };
 
 module.exports = Rollbar;

--- a/src/browser/shim.js
+++ b/src/browser/shim.js
@@ -52,7 +52,9 @@ function setupShim(window, options) {
     if (options.captureUncaught) {
       handler._rollbarOldOnError = window.onerror;
       globals.captureUncaughtExceptions(window, handler, true);
-      globals.wrapGlobals(window, handler, true);
+      if (this.options.wrapGlobalEventHandlers) {
+        globals.wrapGlobals(window, handler, true);
+      }
     }
 
     if (options.captureUnhandledRejections) {


### PR DESCRIPTION
Several requests for this. These wrappers cause problems in no-conflict scenarios.