### PR TITLE
Add cvc as a scrub field

### DIFF
--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
         "card#",
         "card #",
         "cc-csc",
+        "cvc",
         "cvc2",
         "cvv2",
         "ccv2",


### PR DESCRIPTION
# Summary
Added `cvc` as a scrub field.

# Detail
As [google document](https://developers.google.com/web/fundamentals/design-and-ux/input/forms/#recommended_input_name_and_autocomplete_attribute_values) says, "cvc" could be used as a name attribute to create credit card number form. To do this, we can allow users to use auto-completion when they fill the form. Therefore, I think it's reasonable to add "cvc" to scrub list.