### PR TITLE
Add ccmonth, ccyear, and ccname as a scrubFields

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
         "cardholder",
         "card holder",
         "name des karteninhabers",
+        "ccname",
         "card type",
         "cardtype",
         "cc type",
@@ -160,7 +161,9 @@
         "expiration date",
         "expirationdate",
         "expdate",
-        "cc-exp"
+        "cc-exp",
+        "ccmonth",
+        "ccyear"
       ]
     },
     "server": {


### PR DESCRIPTION
# summary
Added `ccmonth`, `ccyear`, `ccname` as a scrubField.

# details
According to [Google Developers](https://developers.google.com/web/fundamentals/design-and-ux/input/forms/#recommended_input_name_and_autocomplete_attribute_values), in the credit card form the name attribute values `ccmonth` `ccyear` `ccname` are recommended because of autocomplete. This PR allows users to use autocomplete & rollbar.js  without setting `scrubField`.