### PR TITLE
Scrub request body

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -70,6 +70,7 @@ module.exports = function (config) {
     webpack: {
       plugins: [defaultsPlugin],
       devtool: 'inline-source-map',
+      performance: { hints: false },
       module: {
         rules: [
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollbar",
-  "version": "2.10.0",
+  "version": "2.11.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -625,7 +625,8 @@ Rollbar.defaultOptions = {
   captureUsername: false,
   captureIp: true,
   captureLambdaTimeouts: true,
-  ignoreDuplicateErrors: true
+  ignoreDuplicateErrors: true,
+  scrubRequestBody: true
 };
 
 module.exports = Rollbar;

--- a/src/utility.js
+++ b/src/utility.js
@@ -95,6 +95,15 @@ function isObject(value) {
   return value != null && (type == 'object' || type == 'function');
 }
 
+/* isString - Checks if the argument is a string
+ *
+ * @param value - any value
+ * @returns true if value is a string
+*/
+function isString(value) {
+  return typeof value === 'string' || value instanceof String
+}
+
 /*
  * isDefined - a convenience function for checking if a value is not equal to undefined
  *
@@ -712,6 +721,8 @@ module.exports = {
   isIterable: isIterable,
   isNativeFunction: isNativeFunction,
   isType: isType,
+  isObject: isObject,
+  isString: isString,
   jsonParse: jsonParse,
   LEVELS: LEVELS,
   makeUnhandledStackInfo: makeUnhandledStackInfo,

--- a/test/server.transforms.test.js
+++ b/test/server.transforms.test.js
@@ -731,7 +731,8 @@ vows.describe('transforms')
                 'access_token',
                 'request.cookie',
                 'sauce'
-              ]
+              ],
+              scrubRequestBody: true
             };
           },
           'item': {
@@ -785,6 +786,98 @@ vows.describe('transforms')
                 assert.match(item.data.sauce, /\**/);
                 assert.equal(item.data.other, 'thing');
                 assert.match(item.data.someParams, /foo=okay&passwd=\**/);
+              }
+            },
+            'with a json request body': {
+              topic: function(options) {
+                var requestBody = JSON.stringify({
+                  token: 'abc123',
+                  something: 'else',
+                  passwd: '123456'
+                });
+                var item = {
+                  request: {
+                    headers: {
+                      host: 'example.com',
+                      'content-type': 'application/json',
+                      'x-auth-token': '12345'
+                    },
+                    protocol: 'https',
+                    url: '/some/endpoint',
+                    ip: '192.192.192.192',
+                    method: 'GET',
+                    body: requestBody,
+                    user: {
+                      id: 42,
+                      email: 'fake@example.com'
+                    }
+                  },
+                  stuff: 'hey',
+                  data: {
+                    other: 'thing',
+                    sauce: 'secrets',
+                    someParams: 'foo=okay&passwd=iamhere'
+                  }
+                };
+                t.addRequestData(item, options, function(e, i) {
+                  if (e) {
+                    this.callback(e);
+                    return;
+                  }
+                  t.scrubPayload(i, options, this.callback)
+                }.bind(this));
+              },
+              'should not error': function(err, item) {
+                assert.ifError(err);
+              },
+              'should have a request object inside data': function(err, item) {
+                assert.ok(item.data.request);
+              },
+              'should scrub based on the options': function(err, item) {
+                var r = item.data.request;
+                assert.match(r.headers['x-auth-token'], /\**/);
+                assert.equal(r.headers['host'], 'example.com');
+                assert.match(item.data.sauce, /\**/);
+                assert.equal(item.data.other, 'thing');
+                assert.match(item.data.someParams, /foo=okay&passwd=\**/);
+
+                var requestBody = JSON.parse(item.data.request.body);
+                assert.match(requestBody.passwd, /\*+/);
+              }
+            },
+            'with a bad json request body': {
+              topic: function(options) {
+                var requestBody = 'not valid json';
+                var item = {
+                  request: {
+                    headers: {
+                      'content-type': 'application/json'
+                    },
+                    protocol: 'https',
+                    url: '/some/endpoint',
+                    ip: '192.192.192.192',
+                    method: 'GET',
+                    body: requestBody
+                  }
+                };
+                t.addRequestData(item, options, function(e, i) {
+                  if (e) {
+                    this.callback(e);
+                    return;
+                  }
+                  t.scrubPayload(i, options, this.callback)
+                }.bind(this));
+              },
+              'should not error': function(err, item) {
+                assert.ifError(err);
+              },
+              'should have a request object inside data': function(err, item) {
+                assert.ok(item.data.request);
+              },
+              'should delete the body and add a diagnostic error': function(err, item) {
+                var requestBody = JSON.parse(item.data.request.body);
+                assert.equal(requestBody, null);
+                assert.match(item.data.request.error, /request.body parse failed/);
               }
             }
           }

--- a/test/server.transforms.test.js
+++ b/test/server.transforms.test.js
@@ -692,7 +692,7 @@ vows.describe('transforms')
       'options': {
         'without scrub fields': {
           topic: function() {
-            return {nothing: 'here'};
+            return rollbar.defaultOptions;
           },
           'item': {
             topic: function(options) {
@@ -714,8 +714,8 @@ vows.describe('transforms')
               assert.equal(item.data.body.message, 'hey');
             },
             'should scrub key/value based on defaults': function(err, item) {
-              assert.matches(item.data.body.password, /\**/);
-              assert.matches(item.data.body.secret, /\**/);
+              assert.matches(item.data.body.password, /\*+/);
+              assert.matches(item.data.body.secret, /\*+/);
             }
           }
         },
@@ -781,11 +781,11 @@ vows.describe('transforms')
               'should scrub based on the options': function(err, item) {
                 var r = item.data.request;
                 assert.equal(r.GET.token, 'abc123');
-                assert.match(r.headers['x-auth-token'], /\**/);
+                assert.match(r.headers['x-auth-token'], /\*+/);
                 assert.equal(r.headers['host'], 'example.com');
-                assert.match(item.data.sauce, /\**/);
+                assert.match(item.data.sauce, /\*+/);
                 assert.equal(item.data.other, 'thing');
-                assert.match(item.data.someParams, /foo=okay&passwd=\**/);
+                assert.match(item.data.someParams, /foo=okay&passwd=\*+/);
               }
             },
             'with a json request body': {
@@ -835,11 +835,11 @@ vows.describe('transforms')
               },
               'should scrub based on the options': function(err, item) {
                 var r = item.data.request;
-                assert.match(r.headers['x-auth-token'], /\**/);
+                assert.match(r.headers['x-auth-token'], /\*+/);
                 assert.equal(r.headers['host'], 'example.com');
-                assert.match(item.data.sauce, /\**/);
+                assert.match(item.data.sauce, /\*+/);
                 assert.equal(item.data.other, 'thing');
-                assert.match(item.data.someParams, /foo=okay&passwd=\**/);
+                assert.match(item.data.someParams, /foo=okay&passwd=\*+/);
 
                 var requestBody = JSON.parse(item.data.request.body);
                 assert.match(requestBody.passwd, /\*+/);


### PR DESCRIPTION
If `request.body` in the payload is JSON, parse and scrub it. Node/server env only.

The intent is to ensure sensitive data in the request body isn't leaked. Therefore, if there is any error parsing the JSON, the body will be set to null and a diagnostic error will be added.

The new config option `scrubRequestBody` is true by default. Set false to skip parsing and scrubbing.

Also in this PR:
- [x] update rollbar version in package-lock.json
- [x] Disable webpack perf warnings for *.test.js files
- [x] Change all `/\**/` regex to `/\*+/` that will actually fail correctly. 