### PR TITLE
Change default for wrapGlobalEventHandlers

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -537,7 +537,7 @@ var defaultOptions = {
   captureIp: true,
   inspectAnonymousErrors: true,
   ignoreDuplicateErrors: true,
-  wrapGlobalEventHandlers: true
+  wrapGlobalEventHandlers: false
 };
 
 module.exports = Rollbar;


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar.js/issues/765

Changes the default behavior to _not_ wrap global event handlers. The wrappers result in wrong and confusing source locations in Chrome. When the feature was first implemented, it was intended to provide better source locations on older browsers. At this point the number of Chrome installs far outweighs the number of IE10/11 era browsers.