### PR TITLE
Prevent prepareStackTrace from picking up stray errors

### DIFF
--- a/src/browser/globalSetup.js
+++ b/src/browser/globalSetup.js
@@ -35,9 +35,17 @@ function _rollbarWindowOnError(window, r, old, args) {
     window._rollbarWrappedError = null;
   }
 
-  r.handleUncaughtException.apply(r, args);
+  var ret = r.handleUncaughtException.apply(r, args);
+
   if (old) {
     old.apply(window, args);
+  }
+
+  // Let other chained onerror handlers above run before setting this.
+  // If an error is thrown and caught within a chained onerror handler,
+  // Error.prepareStackTrace() will see that one before the one we want.
+  if (ret === 'anonymous') {
+    r.anonymousErrorsPending += 1; // See Rollbar.prototype.handleAnonymousErrors()
   }
 }
 

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -244,11 +244,10 @@ Rollbar.prototype.handleUncaughtException = function(message, url, lineno, colno
     return;
   }
 
-  // Chrome will always send 5+ arrguments and error will be valid or null, not undefined.
+  // Chrome will always send 5+ arguments and error will be valid or null, not undefined.
   // If error is undefined, we have a different caller.
   if (this.options.inspectAnonymousErrors && this.isChrome && (error === null)) {
-    this.anonymousErrorsPending += 1; // See Rollbar.prototype.handleAnonymousErrors()
-    return;
+    return 'anonymous';
   }
 
   var item;


### PR DESCRIPTION
Interesting edge case where another `onerror` handler throws and catches a dummy error to generate a stack. This interferes with `prepareStackTrace`, so the fix delays waking `prepareStackTrace` until chained `onerror` handlers have run.