### PR TITLE
Ensure stack is preserved on chrome

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -321,6 +321,9 @@ Rollbar.prototype.handleAnonymousErrors = function() {
       }
     }
 
+    // Workaround to ensure stack is preserved for normal errors.
+    error.stack;
+
     return error.toString();
   }
 


### PR DESCRIPTION
Touching `error.stack` ensures Chrome preserves the original stack. It looks like Chrome lazy synthesizes the stack, but will not do so after prepareStackTrace returns. 