### PR TITLE
Chrome 76 uses return value of prepareStackTrace

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -322,9 +322,7 @@ Rollbar.prototype.handleAnonymousErrors = function() {
     }
 
     // Workaround to ensure stack is preserved for normal errors.
-    error.stack;
-
-    return error.toString();
+    return error.stack;
   }
 
   // https://v8.dev/docs/stack-trace-api


### PR DESCRIPTION
In Chrome 76, the return value of `prepareStackTrace` is used and needs to be the full stack string.