### PR TITLE
Recover from read-only window.console object

### DIFF
--- a/src/notifier.js
+++ b/src/notifier.js
@@ -13,6 +13,7 @@ function Notifier(queue, options) {
   this.queue = queue;
   this.options = options;
   this.transforms = [];
+  this.diagnostic = {};
 }
 
 /*

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -82,7 +82,7 @@ function addConfiguredOptions(item, options, callback) {
 }
 
 function addDiagnosticKeys(item, options, callback) {
-  var diagnostic = {}
+  var diagnostic = _.merge(item.notifier.client.notifier.diagnostic, item.diagnostic);
 
   if (_.get(item, 'err._isAnonymous')) {
     diagnostic.is_anonymous = true;

--- a/src/utility.js
+++ b/src/utility.js
@@ -385,6 +385,7 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
   var message, err, custom, callback, request;
   var arg;
   var extraArgs = [];
+  var diagnostic = {};
 
   for (var i = 0, l = args.length; i < l; ++i) {
     arg = args[i];
@@ -447,6 +448,8 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
     custom: custom,
     timestamp: now(),
     callback: callback,
+    notifier: notifier,
+    diagnostic: diagnostic,
     uuid: uuid4()
   };
   if (custom && custom.level !== undefined) {

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -41,9 +41,13 @@ function TestClientGen() {
 }
 
 describe('Rollbar()', function() {
+  afterEach(function () {
+    window.rollbar.configure({ autoInstrument: false });
+  });
+
   it('should have all of the expected methods with a real client', function(done) {
     var options = {};
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     expect(rollbar).to.have.property('log');
     expect(rollbar).to.have.property('debug');
@@ -59,7 +63,7 @@ describe('Rollbar()', function() {
   it('should have all of the expected methods', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     expect(rollbar).to.have.property('log');
     expect(rollbar).to.have.property('debug');
@@ -75,7 +79,7 @@ describe('Rollbar()', function() {
   it ('should have some default options', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     expect(rollbar.options.scrubFields).to.contain('password');
     done();
@@ -88,7 +92,7 @@ describe('Rollbar()', function() {
         'foobar'
       ]
     };
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     expect(rollbar.options.scrubFields).to.contain('foobar');
     expect(rollbar.options.scrubFields).to.contain('password');
@@ -103,7 +107,7 @@ describe('Rollbar()', function() {
       ],
       overwriteScrubFields: true,
     };
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     expect(rollbar.options.scrubFields).to.contain('foobar');
     expect(rollbar.options.scrubFields).to.not.contain('password');
@@ -113,7 +117,7 @@ describe('Rollbar()', function() {
   it('should return a uuid when logging', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var result = rollbar.log('a messasge', 'another one');
     expect(result.uuid).to.be.ok();
@@ -124,7 +128,7 @@ describe('Rollbar()', function() {
   it('should package up the inputs', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var result = rollbar.log('a message', 'another one');
     var loggedItem = client.logCalls[0].item;
@@ -137,7 +141,7 @@ describe('Rollbar()', function() {
   it('should call the client with the right method', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var methods = 'log,debug,info,warn,warning,error,critical'.split(',');
     for (var i=0; i < methods.length; i++) {
@@ -152,6 +156,10 @@ describe('Rollbar()', function() {
 });
 
 describe('configure', function() {
+  afterEach(function () {
+    window.rollbar.configure({ autoInstrument: false });
+  });
+
   it('should configure client', function(done) {
     var client = new (TestClientGen())();
     var options = {
@@ -160,7 +168,7 @@ describe('configure', function() {
         environment: 'testtest'
       }
     };
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
     expect(rollbar.options.payload.environment).to.eql('testtest');
 
     rollbar.configure({payload: {environment: 'borkbork'}});
@@ -176,7 +184,7 @@ describe('configure', function() {
         environment: 'testtest'
       }
     };
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
     expect(rollbar.options.payload.environment).to.eql('testtest');
 
     rollbar.configure({somekey: 'borkbork'}, {b: 97});
@@ -193,7 +201,7 @@ describe('configure', function() {
         environment: 'testtest'
       }
     };
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
     expect(rollbar.options.payload.environment).to.eql('testtest');
 
     rollbar.configure({somekey: 'borkbork', payload: {b: 101}}, {b: 97});
@@ -211,7 +219,7 @@ describe('configure', function() {
         environment: 'testtest'
       }
     };
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
     expect(rollbar.options._configuredOptions.payload.environment).to.eql('testtest');
     expect(rollbar.options._configuredOptions.captureUncaught).to.eql(true);
 
@@ -223,7 +231,7 @@ describe('configure', function() {
 });
 
 describe('options.captureUncaught', function() {
-  before(function (done) {
+  beforeEach(function (done) {
     // Load the HTML page, so errors can be generated.
     document.write(window.__html__['examples/error.html']);
 
@@ -231,7 +239,8 @@ describe('options.captureUncaught', function() {
     done();
   });
 
-  after(function () {
+  afterEach(function () {
+    window.rollbar.configure({ autoInstrument: false });
     window.server.restore();
   });
 
@@ -254,7 +263,7 @@ describe('options.captureUncaught', function() {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
       captureUncaught: true
     };
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     var element = document.getElementById('throw-error');
     element.click();
@@ -286,7 +295,7 @@ describe('options.captureUncaught', function() {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
       captureUncaught: false
     };
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     element.click();
     server.respond();
@@ -335,7 +344,7 @@ describe('options.captureUncaught', function() {
       captureUncaught: true,
       inspectAnonymousErrors: true
     };
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     // Simulate receiving onerror without an error object.
     rollbar.anonymousErrorsPending += 1;
@@ -373,7 +382,7 @@ describe('options.captureUncaught', function() {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
       captureUncaught: true
     };
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     var element = document.getElementById('throw-error');
 
@@ -411,7 +420,7 @@ describe('options.captureUncaught', function() {
       captureUncaught: true,
       ignoreDuplicateErrors: false
     };
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     var element = document.getElementById('throw-error');
 
@@ -447,7 +456,7 @@ describe('options.captureUncaught', function() {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
       captureUncaught: true
     };
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     var element = document.getElementById('throw-dom-exception');
     element.click();
@@ -471,12 +480,13 @@ describe('options.captureUncaught', function() {
 });
 
 describe('options.captureUnhandledRejections', function() {
-  before(function (done) {
+  beforeEach(function (done) {
     window.server = sinon.createFakeServer();
     done();
   });
 
-  after(function () {
+  afterEach(function () {
+    window.rollbar.configure({ autoInstrument: false });
     window.server.restore();
   });
 
@@ -499,7 +509,7 @@ describe('options.captureUnhandledRejections', function() {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
       captureUnhandledRejections: true
     };
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     Promise.reject(new Error('test reject'));
 
@@ -529,7 +539,7 @@ describe('options.captureUnhandledRejections', function() {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
       captureUnhandledRejections: false
     };
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     rollbar.configure({
       captureUnhandledRejections: true
@@ -565,7 +575,7 @@ describe('options.captureUnhandledRejections', function() {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
       captureUnhandledRejections: true
     };
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     rollbar.configure({
       captureUnhandledRejections: false
@@ -587,12 +597,13 @@ describe('options.captureUnhandledRejections', function() {
 });
 
 describe('log', function() {
-  before(function (done) {
+  beforeEach(function (done) {
     window.server = sinon.createFakeServer();
     done();
   });
 
-  after(function () {
+  afterEach(function () {
+    window.rollbar.configure({ autoInstrument: false });
     window.server.restore();
   });
 
@@ -615,7 +626,7 @@ describe('log', function() {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
       captureUnhandledRejections: true
     };
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     rollbar.log(null);
 
@@ -631,12 +642,13 @@ describe('log', function() {
 
 // Test direct call to onerror, as used in verification of browser js install.
 describe('onerror', function() {
-  before(function (done) {
+  beforeEach(function (done) {
     window.server = sinon.createFakeServer();
     done();
   });
 
-  after(function () {
+  afterEach(function () {
+    window.rollbar.configure({ autoInstrument: false });
     window.server.restore();
   });
 
@@ -659,7 +671,7 @@ describe('onerror', function() {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
       captureUncaught: true
     };
-    new Rollbar(options);
+    window.rollbar = new Rollbar(options);
 
     window.onerror("TestRollbarError: testing window.onerror", window.location.href);
 
@@ -675,9 +687,13 @@ describe('onerror', function() {
 });
 
 describe('captureEvent', function() {
+  afterEach(function () {
+    window.rollbar.configure({ autoInstrument: false });
+  });
+
   it('should handle missing/default type and level', function(done) {
     var options = {};
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     var event = rollbar.captureEvent({foo: 'bar'});
     expect(event.type).to.eql('manual');
@@ -688,7 +704,7 @@ describe('captureEvent', function() {
   });
   it('should handle specified type and level', function(done) {
     var options = {};
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     var event = rollbar.captureEvent('log', {foo: 'bar'}, 'debug');
     expect(event.type).to.eql('log');
@@ -699,7 +715,7 @@ describe('captureEvent', function() {
   });
   it('should handle extra args', function(done) {
     var options = {};
-    var rollbar = new Rollbar(options);
+    var rollbar = window.rollbar = new Rollbar(options);
 
     var event = rollbar.captureEvent('meaningless', {foo: 'bar'}, 23);
     expect(event.type).to.eql('manual');
@@ -711,10 +727,14 @@ describe('captureEvent', function() {
 });
 
 describe('createItem', function() {
+  afterEach(function () {
+    window.rollbar.configure({ autoInstrument: false });
+  });
+
   it('should handle multiple strings', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var args = ['first', 'second'];
     var item = rollbar._createItem(args);
@@ -726,7 +746,7 @@ describe('createItem', function() {
   it('should handle errors', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var args = [new Error('Whoa'), 'first', 'second'];
     var item = rollbar._createItem(args);
@@ -739,7 +759,7 @@ describe('createItem', function() {
   it('should handle a callback', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var myCallbackCalled = false;
     var myCallback = function() {
@@ -759,7 +779,7 @@ describe('createItem', function() {
   it('should handle arrays', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var args = [new Error('Whoa'), 'first', [1, 2, 3], 'second'];
     var item = rollbar._createItem(args);
@@ -773,7 +793,7 @@ describe('createItem', function() {
   it('should handle objects', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var args = [new Error('Whoa'), 'first', {a: 1, b: 2}, 'second'];
     var item = rollbar._createItem(args);
@@ -788,7 +808,7 @@ describe('createItem', function() {
   it('should have a timestamp', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var args = [new Error('Whoa'), 'first', {a: 1, b: 2}, 'second'];
     var item = rollbar._createItem(args);
@@ -800,7 +820,7 @@ describe('createItem', function() {
   it('should have an uuid', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var args = [new Error('Whoa'), 'first', {a: 1, b: 2}, 'second'];
     var item = rollbar._createItem(args);
@@ -816,7 +836,7 @@ describe('createItem', function() {
   it('should handle dates', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var y2k = new Date(2000, 0, 1)
     var args = [new Error('Whoa'), 'first', y2k, {a: 1, b: 2}, 'second'];
@@ -828,7 +848,7 @@ describe('createItem', function() {
   it('should handle numbers', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     var args = [new Error('Whoa'), 'first', 42, {a: 1, b: 2}, 'second'];
     var item = rollbar._createItem(args);
@@ -839,7 +859,7 @@ describe('createItem', function() {
   it('should handle domexceptions', function(done) {
     var client = new (TestClientGen())();
     var options = {};
-    var rollbar = new Rollbar(options, client);
+    var rollbar = window.rollbar = new Rollbar(options, client);
 
     if (document && document.querySelectorAll) {
       var e;


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar.js/issues/751

In some environments, the console methods (e.g. `log`, `debug`, etc.) have been replaced with read-only properties. No known browsers do this by default, but it appears that other code running in the browser replaces or modifies `window.console` to use read-only properties. (See examples here: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Getter_only)

In strict mode code environments, Rollbar will then fail with `TypeError: setting getter-only property "debug"`. In non strict mode environments, Rollbar will silently fail to update the console methods. 

This fix sets strict mode while updating the console methods. This ensures a consistent and predictable behavior across different code environments, and allows Rollbar to record a diagnostic message in cases where it might have silently failed before.

NOTE: This PR also includes a commit to reset telemetry hooks between tests. Otherwise, telemetry related tests can't work correctly.