### PR TITLE
Optionally guess error class when missing

### DIFF
--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -183,7 +183,7 @@ function addBodyTrace(item, options, callback) {
   } else {
     var stackInfo = item.stackInfo;
     var guess = errorParser.guessErrorClass(stackInfo.message);
-    var className = stackInfo.name || guess[0];
+    var className = errorClass(stackInfo, guess[0], options);
     var message = guess[1];
 
     item.message = className + ': ' + message;
@@ -197,7 +197,7 @@ function buildTrace(item, stackInfo, options) {
   var stack = stackFromItem(item);
 
   var guess = errorParser.guessErrorClass(stackInfo.message);
-  var className = stackInfo.name || guess[0];
+  var className = errorClass(stackInfo, guess[0], options);
   var message = guess[1];
   var trace = {
     exception: {
@@ -278,6 +278,16 @@ function buildTrace(item, stackInfo, options) {
   }
 
   return trace;
+}
+
+function errorClass(stackInfo, guess, options) {
+  if (stackInfo.name) {
+    return stackInfo.name;
+  } else if (options.guessErrorClass) {
+    return guess;
+  } else {
+    return '(unknown)';
+  }
 }
 
 function scrubPayload(item, options, callback) {

--- a/test/browser.transforms.test.js
+++ b/test/browser.transforms.test.js
@@ -321,6 +321,73 @@ describe('addBody', function() {
       });
     });
   });
+  describe('without stackInfo.name', function() {
+    it('should set error class unknown', function(done) {
+      var err;
+      try {
+        throw new Error('bork');
+      } catch (e) {
+        err = e;
+      }
+      var args = ['a message', err, {custom: 'stuff'}];
+      var item = itemFromArgs(args);
+      item.description = 'borked';
+      var options = {};
+      t.handleItemWithError(item, options, function(e, i) {
+        expect(i.stackInfo).to.be.ok();
+        i.stackInfo.name = null; // force alternate path to determine error class.
+        t.addBody(i, options, function(e, i) {
+          expect(i.data.body.trace.exception.class).to.eql('(unknown)');
+          expect(i.data.body.trace.exception.message).to.eql('bork');
+          done(e);
+        });
+      });
+    });
+    describe('when config.guessErrorClass is set', function() {
+      it('should guess error class ', function(done) {
+        var err;
+        try {
+          throw new Error('GuessedError: bork');
+        } catch (e) {
+          err = e;
+        }
+        var args = [err, {custom: 'stuff'}];
+        var item = itemFromArgs(args);
+        item.description = 'borked';
+        var options = { guessErrorClass: true };
+        t.handleItemWithError(item, options, function(e, i) {
+          expect(i.stackInfo).to.be.ok();
+          i.stackInfo.name = null; // force alternate path to determine error class.
+          t.addBody(i, options, function(e, i) {
+            expect(i.data.body.trace.exception.class).to.eql('GuessedError');
+            expect(i.data.body.trace.exception.message).to.eql('bork');
+            done(e);
+          });
+        });
+      });
+      it('should set error class unknown', function(done) {
+        var err;
+        try {
+          throw new Error('bork');
+        } catch (e) {
+          err = e;
+        }
+        var args = [err, {custom: 'stuff'}];
+        var item = itemFromArgs(args);
+        item.description = 'borked';
+        var options = { guessErrorClass: true };
+        t.handleItemWithError(item, options, function(e, i) {
+          expect(i.stackInfo).to.be.ok();
+          i.stackInfo.name = null; // force alternate path to determine error class.
+          t.addBody(i, options, function(e, i) {
+            expect(i.data.body.trace.exception.class).to.eql('(unknown)');
+            expect(i.data.body.trace.exception.message).to.eql('bork');
+            done(e);
+          });
+        });
+      });
+    });
+  });
   describe('with nested error', function() {
     it('should create trace_chain', function(done) {
       var nestedErr = new Error('nested error');


### PR DESCRIPTION
Fixes: https://app.clubhouse.io/rollbar/story/54135/rollbar-js-exception-class

Previously, when `error.name` and `error.constructor.name` are both missing, `error.message` would be used to guess the class, using a regex to look for and extract the part before the colon.

This has unintended results most of the time. In cases where the `name` property is missing, it is unlikely the class will be in the message string. Meanwhile, it's possible for other strings to match the regex and generate unexpected values that get assigned to be the error class. Besides being confusing and not useful, this interferes with grouping.

This PR makes the default behavior to assign "(unknown)" as the error class. This is the value already being used when no value can be guessed.

When `config.guessErrorClass` is set, this engages the old behavior. For any users who are intentionally adding error classes to their message strings, setting this will allow them to be extracted. Note that as before, this only happens when both `error.name` and `error.constructor.name` are missing.

