### PR TITLE
Use most specific error name

### DIFF
--- a/src/browser/errorParser.js
+++ b/src/browser/errorParser.js
@@ -60,15 +60,10 @@ function Stack(exception) {
     return stack;
   }
 
-  var name = exception.constructor && exception.constructor.name;
-  if (!name || !name.length || name.length < 3) {
-    name = exception.name;
-  }
-
   return {
     stack: getStack(),
     message: exception.message,
-    name: name,
+    name: _mostSpecificErrorName(exception),
     rawStack: exception.stack,
     rawException: exception
   };
@@ -109,6 +104,22 @@ function guessErrorClass(errMsg) {
   return [errClass, errMsg];
 }
 
+// * Prefers any value over an empty string
+// * Prefers any value over 'Error' where possible
+// * Prefers name over constructor.name when both are more specific than 'Error'
+function _mostSpecificErrorName(error) {
+  var name = error.name && error.name.length && error.name;
+  var constructorName = error.constructor.name && error.constructor.name.length && error.constructor.name;
+
+  if (!name || !constructorName) {
+    return name || constructorName;
+  }
+
+  if (name === 'Error') {
+    return constructorName;
+  }
+  return name;
+}
 
 module.exports = {
   guessFunctionName: guessFunctionName,

--- a/test/browser.transforms.test.js
+++ b/test/browser.transforms.test.js
@@ -104,6 +104,32 @@ describe('handleItemWithError', function() {
       done(e);
     });
   });
+  it('should use most specific error name', function(done) {
+    var err = new Error('bork');
+    var args = ['a message', err];
+    var options = {};
+
+    var names = [
+      {name: 'TypeError', constructor: 'EvalError', result: 'TypeError'},
+      {name: 'TypeError', constructor: 'Error', result: 'TypeError'},
+      {name: 'Error', constructor: 'TypeError', result: 'TypeError'},
+      {name: 'Error', constructor: '', result: 'Error'},
+      {name: '', constructor: 'Error', result: 'Error'},
+      {name: '', constructor: '', result: ''}
+    ];
+
+    for(var i = 0; i < names.length; i++) {
+      err.name = names[i].name;
+      err.constructor = { name: names[i].constructor };
+      var item = itemFromArgs(args);
+      var result = names[i].result;
+
+      t.handleItemWithError(item, options, function(e, i) {
+        expect(i.stackInfo.name).to.eql(result);
+      });
+    };
+    done();
+  });
 });
 
 describe('ensureItemHasSomethingToSay', function() {


### PR DESCRIPTION
Grouping works best when the SDK sends the most specific error name available. Usually that's `error.name`, however there are known cases where `error.constructor.name` is more specific. (DOMException, for example)

This PR follows these rules:
* Prefers any value over an empty string
* Prefers any value over 'Error' where possible
* Prefers name over constructor.name when both are more specific than 'Error'