### PR TITLE
Network telemetry improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,6 +122,7 @@
         "passwordConfirmation",
         "access_token",
         "accessToken",
+        "X-Rollbar-Access-Token",
         "secret_key",
         "secretKey",
         "secretToken",


### PR DESCRIPTION
Fills in some gaps in network telemetry capture, and adds scrubbing for request/response JSON bodies and headers.

Enable telemetry capture for:
* Fetch request headers
* Fetch response headers
* Fetch response body
* XHR request headers

Enable scrubbing:
* Detect fetch request/response content type
* Detect XHR request/response content type
* Scrub request/response headers (XHR and fetch)
* Scrub request/response JSON bodies (XHR and fetch)

Some parts of the Fetch API are missing on IE. All features were tested for IE compat and graceful degradation.