### PR TITLE
move rollbar _createItem to top.. (remove error _createItem not defined)

### DIFF
--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -96,6 +96,13 @@ Rollbar.configure = function(options, payloadData) {
   }
 };
 
+
+
+Rollbar.prototype._createItem = function(args) {
+  var requestKeys = ['headers', 'protocol', 'url', 'method', 'body', 'route'];
+  return _.createItem(args, logger, this, requestKeys, this.lambdaContext);
+};
+
 Rollbar.prototype.lastError = function() {
   return this.client.lastError;
 };
@@ -510,11 +517,6 @@ function addPredicatesToQueue(queue) {
     .addPredicate(sharedPredicates.urlIsWhitelisted(logger))
     .addPredicate(sharedPredicates.messageIsIgnored(logger));
 }
-
-Rollbar.prototype._createItem = function(args) {
-  var requestKeys = ['headers', 'protocol', 'url', 'method', 'body', 'route'];
-  return _.createItem(args, logger, this, requestKeys, this.lambdaContext);
-};
 
 function _getFirstFunction(args) {
   for (var i = 0, len = args.length; i < len; ++i) {


### PR DESCRIPTION
In node 8.16 the lib is making an error `_createItem` is not defined. moved the function defintion to top to fix it.