### PR TITLE
Store original error in server and react native targets

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,14 +12,14 @@
   "types": "./index.d.ts",
   "dependencies": {
     "async": "~1.2.1",
-    "buffer-from": ">=1.1",
+    "buffer-from": "~1.1.1",
     "console-polyfill": "0.3.0",
     "debug": "2.6.9",
     "error-stack-parser": "1.3.3",
     "json-stringify-safe": "~5.0.0",
     "lru-cache": "~2.2.1",
     "request-ip": "~2.0.1",
-    "source-map": ">=0.5.0",
+    "source-map": "^0.5.7",
     "uuid": "3.0.x"
   },
   "devDependencies": {

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -270,7 +270,6 @@ Rollbar.clearPerson = function() {
 };
 
 /** Internal **/
-
 function addTransformsToNotifier(notifier) {
   notifier
     .addTransform(transforms.baseData)
@@ -281,6 +280,7 @@ function addTransformsToNotifier(notifier) {
     .addTransform(sharedTransforms.addConfigToPayload)
     .addTransform(transforms.scrubPayload)
     .addTransform(sharedTransforms.addConfiguredOptions)
+    .addTransform(sharedTransforms.addDiagnosticKeys)
     .addTransform(sharedTransforms.itemToPayload);
 }
 

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -499,6 +499,7 @@ function addTransformsToNotifier(notifier) {
     .addTransform(transforms.scrubPayload)
     .addTransform(sharedTransforms.userTransform(logger))
     .addTransform(sharedTransforms.addConfiguredOptions)
+    .addTransform(sharedTransforms.addDiagnosticKeys)
     .addTransform(sharedTransforms.itemToPayload);
 }
 

--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -90,7 +90,7 @@ function handleItemWithError(item, options, callback) {
   var cb = function(e) {
     if (e) {
       item.message = item.err.message || item.err.description || item.message || String(item.err);
-      delete item.err;
+      item.diagnostic.buildTraceData = e.message;
       delete item.stackInfo;
     }
     callback(null, item);


### PR DESCRIPTION
Stores the original error before parsing, for diagnostic purposes. This is already enabled for browser. Here, just adding to server and react native. 