### PR TITLE
Webpack strict mode

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -83,6 +83,11 @@ module.exports = function (config) {
             }
           },
           {
+            test: /\.js$/,
+            loader: 'strict-loader',
+            exclude: [/node_modules/, /vendor/, /lib/, /dist/, /test/]
+          },
+          {
             test: /(mootootls|requirejs)\.js$/,
             loader: 'script'
           },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rollbar",
-  "version": "2.13.0",
+  "version": "2.14.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5756,7 +5756,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -16370,10 +16369,49 @@
       }
     },
     "strict-loader": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/strict-loader/-/strict-loader-0.1.3.tgz",
-      "integrity": "sha1-xu61UoDfzsR2a4ANx0Ks/2dzH+U=",
-      "dev": true
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/strict-loader/-/strict-loader-1.2.0.tgz",
+      "integrity": "sha1-7FPw/u6kw4681WCh1dWSMmlVJ3w=",
+      "dev": true,
+      "requires": {
+        "esprima": "^3.1.3",
+        "loader-utils": "^1.1.0",
+        "source-map": "^0.5.6"
+      },
+      "dependencies": {
+        "big.js": {
+          "version": "5.2.2",
+          "resolved": "https://registry.npmjs.org/big.js/-/big.js-5.2.2.tgz",
+          "integrity": "sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==",
+          "dev": true
+        },
+        "esprima": {
+          "version": "3.1.3",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+          "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+          "dev": true
+        },
+        "json5": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+          "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+          "dev": true,
+          "requires": {
+            "minimist": "^1.2.0"
+          }
+        },
+        "loader-utils": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+          "dev": true,
+          "requires": {
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
+          }
+        }
+      }
     },
     "string-template": {
       "version": "0.2.1",

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "script-loader": "0.6.1",
     "sinon": "^7.3.0",
     "stackframe": "^0.2.2",
-    "strict-loader": "^0.1.2",
+    "strict-loader": "^1.2.0",
     "time-grunt": "^1.0.0",
     "uglifyjs-webpack-plugin": "^2.1.2",
     "vows": "~0.7.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,11 @@ var snippetConfig = {
           failOnError: true,
           configFile: path.resolve(__dirname, '.eslintrc')
         }
+      },
+      {
+        test: /\.js$/,
+        loader: 'strict-loader',
+        exclude: [/node_modules/, /vendor/]
       }
     ],
   }
@@ -59,6 +64,11 @@ var pluginConfig = {
           failOnError: true,
           configFile: path.resolve(__dirname, '.eslintrc')
         }
+      },
+      {
+        test: /\.js$/,
+        loader: 'strict-loader',
+        exclude: [/node_modules/, /vendor/]
       }
     ],
   }
@@ -84,6 +94,11 @@ var vanillaConfigBase = {
           failOnError: true,
           configFile: path.resolve(__dirname, '.eslintrc')
         }
+      },
+      {
+        test: /\.js$/,
+        loader: 'strict-loader',
+        exclude: [/node_modules/, /vendor/]
       }
     ],
   }
@@ -111,6 +126,11 @@ var UMDConfigBase = {
           failOnError: true,
           configFile: path.resolve(__dirname, '.eslintrc')
         }
+      },
+      {
+        test: /\.js$/,
+        loader: 'strict-loader',
+        exclude: [/node_modules/, /vendor/]
       }
     ],
   }


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar.js/issues/797

This PR restores the strict-loader that was removed in the migration to Webpack 4 between versions 2.6.x and 2.7.0.

- [x] Remove dist files
Dist files built with the new webpack config have been included here to facilitate inspection and test. They will be removed before merge.