### PR TITLE
scrubField: Add * as a 'scrub everything' value

### DIFF
--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -634,6 +634,20 @@ describe('set', function() {
 });
 
 describe('scrub', function() {
+  it('supports * to scrub all', function() {
+    var data = {
+      a: 'somestring',
+      password: 'abc123',
+      tempWorker: 'cool'
+    };
+    var scrubFields = ['*'];
+
+    var result = _.scrub(data, scrubFields);
+
+    expect(result.a).to.not.eql('somestring');
+    expect(result.password).to.not.eql('abc123');
+    expect(result.tempWorker).to.not.eql('cool');
+  });
   it('should not redact fields that are okay', function() {
     var data = {
       a: 'somestring',


### PR DESCRIPTION
Hello!  Earlier today I ran into a field being reported to rollbar that I didn't expect.  I'd prefer to be able to scrub all fields, as you can with the Ruby gem.  So this PR updates `scrubFields` to allow passing the special value `"*"` that scrubs everything.

I tried to follow the guidance in https://github.com/rollbar/rollbar.js#developing, and then to run the linter and tests so I could add some test cases for this, but ran into failures running those on master.  I opened that separately in https://github.com/rollbar/rollbar.js/issues/801, so for this PR I added a test case in `utility.test.js` but couldn't run it.  I didn't add tests to the various transform test files.