### PR TITLE
Update vows package to fix util dependency

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,6 +14,7 @@
   },
   "plugins": [
   ],
+  "globals": { "Promise": true },
   "rules": {
     "strict": 0,
     "camelcase": [2, {"properties": "never"}],
@@ -21,6 +22,7 @@
     "no-underscore-dangle": 0,
     "no-useless-escape": 0,
     "complexity": [2, { "max": 35 }],
-    "no-use-before-define": [1, { "functions": false }]
+    "no-use-before-define": [0, { "functions": false }],
+    "no-unused-vars": [2, { "argsIgnorePattern": "^_" }]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3638,9 +3638,9 @@
       "dev": true
     },
     "diff": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.0.7.tgz",
-      "integrity": "sha1-JLuwAcSn1VIhaefKvbLCgU7ZHPQ=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
       "dev": true
     },
     "diffie-hellman": {
@@ -17638,13 +17638,30 @@
       "dev": true
     },
     "vows": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/vows/-/vows-0.7.0.tgz",
-      "integrity": "sha1-3QBl8RC6DAptY+hEhRwyCBdtWGc=",
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/vows/-/vows-0.8.3.tgz",
+      "integrity": "sha512-PVIxa/ovXhrw5gA3mz6M+ZF3PHlqX4tutR2p/y9NWPAaFVKcWBE8b2ktfr0opQM/qFmcOVWKjSCJVjnYOvjXhw==",
       "dev": true,
       "requires": {
-        "diff": "~1.0.3",
-        "eyes": ">=0.1.6"
+        "diff": "^4.0.1",
+        "eyes": "~0.1.6",
+        "glob": "^7.1.2"
+      },
+      "dependencies": {
+        "glob": {
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "dev": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        }
       }
     },
     "watchpack": {

--- a/package.json
+++ b/package.json
@@ -89,7 +89,7 @@
     "strict-loader": "^1.2.0",
     "time-grunt": "^1.0.0",
     "uglifyjs-webpack-plugin": "^2.1.2",
-    "vows": "~0.7.0",
+    "vows": "^0.8.3",
     "webpack": "^4.30.0",
     "webpack-dev-server": "^3.1.10"
   },

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -323,7 +323,7 @@ Rollbar.prototype.asyncLambdaHandler = function(handler, timeoutHandler) {
 };
 Rollbar.prototype.syncLambdaHandler = function(handler, timeoutHandler) {
   var self = this;
-  var _timeoutHandler = function(event, context, cb) {
+  var _timeoutHandler = function(event, context, _cb) {
     var message = 'Function timed out';
     var custom = {
       originalEvent: event,


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar.js/issues/801

Vows was previously versioned at 0.7.0, which has a call to `util.print` that results in a "not a function" error... but only sometimes. The util package in my node_modules doesn't export a `print()` function, yet everything works in my environment, and has worked in CI (which should be a clean npm environment.) Despite this seeming to work for the lucky, it is clearly wrong by code review. (I can't find an old enough version of util that it still has `print()` anywhere.)

Later versions of vows no longer use `util.print`, so this PR updates to vows 0.8.3, which looks like the last stable version. 