### PR TITLE
Use correct byte size for truncation

### DIFF
--- a/src/truncation.js
+++ b/src/truncation.js
@@ -80,7 +80,7 @@ function minBody(payload, jsonBackup) {
 }
 
 function needsTruncation(payload, maxSize) {
-  return payload.length > maxSize;
+  return _.maxByteSize(payload) > maxSize;
 }
 
 function truncate(payload, jsonBackup, maxSize) {

--- a/test/truncation.test.js
+++ b/test/truncation.test.js
@@ -25,6 +25,24 @@ describe('truncate', function() {
     expect(resultValue.data.body.trace.exception.message.length).to.be.below(256);
     expect(resultValue.data.body.trace.frames.length).to.be.below(3);
   });
+
+  it('should not truncate ascii payload close to max size', function() {
+    var payload = tracePayload(10, repeat('i', 500));
+    var result = t.truncate(payload, undefined, 1100); // payload will be 500 + 528
+    expect(result.value).to.be.ok();
+
+    var resultValue = JSON.parse(result.value);
+    expect(resultValue).to.eql(payload);
+  });
+
+  it('should truncate non-ascii payload when oversize', function() {
+    var payload = tracePayload(10, repeat('あ', 500)); // あ is 3 utf-8 bytes (U+3042)
+    var result = t.truncate(payload, undefined, 1100); // payload will be 1500 + 528
+    expect(result.value).to.be.ok();
+
+    var resultValue = JSON.parse(result.value);
+    expect(resultValue.data.body.trace.frames.length).to.be.below(3);
+  });
 });
 
 describe('raw', function() {


### PR DESCRIPTION
When calculating payload length for truncation, `payload.length` was being used. This returns the character count (or more accurately the UTF-16 code point count), rather than the UTF-8 byte count. This leads to non-ascii payloads being insufficiently truncated and then rejected by the API.

This PR uses a minimal implementation for counting UTF-8 bytes that never undercounts bytes, and rarely overcounts*. This is safe and valid to be used for truncation, and is significantly smaller and faster than a complete UTF-8 encoder. 

* It will overcount when it encounters UTF-16 surrogates (two code point chars.) These should be rare in practice, but specific support for these could be added if/when desired. 