### PR TITLE
Allow rollbar errors on xhr/fetch http status (4xx/5xx/0)

### DIFF
--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -18,7 +18,7 @@ function handleItemWithError(item, options, callback) {
   item.data = item.data || {};
   if (item.err) {
     try {
-      item.stackInfo = item.err._savedStackTrace || errorParser.parse(item.err);
+      item.stackInfo = item.err._savedStackTrace || errorParser.parse(item.err, item.skipFrames);
     } catch (e) {
       logger.error('Error while parsing the error object.', e);
       try {

--- a/src/errorParser.js
+++ b/src/errorParser.js
@@ -30,30 +30,21 @@ function Frame(stackFrame) {
 }
 
 
-function Stack(exception) {
+function Stack(exception, skip) {
   function getStack() {
     var parserStack = [];
-    var exc;
 
-    if (!exception.stack) {
-      try {
-        throw exception;
-      } catch (e) {
-        exc = e;
-      }
-    } else {
-      exc = exception;
-    }
+    skip = skip || 0;
 
     try {
-      parserStack = ErrorStackParser.parse(exc);
+      parserStack = ErrorStackParser.parse(exception);
     } catch(e) {
       parserStack = [];
     }
 
     var stack = [];
 
-    for (var i = 0; i < parserStack.length; i++) {
+    for (var i = skip; i < parserStack.length; i++) {
       stack.push(new Frame(parserStack[i]));
     }
 
@@ -70,21 +61,23 @@ function Stack(exception) {
 }
 
 
-function parse(e) {
+function parse(e, skip) {
   var err = e;
 
   if (err.nested) {
     var traceChain = [];
     while (err) {
-      traceChain.push(new Stack(err));
+      traceChain.push(new Stack(err, skip));
       err = err.nested;
+
+      skip = 0; // Only apply skip value to primary error
     }
 
     // Return primary error with full trace chain attached.
     traceChain[0].traceChain = traceChain;
     return traceChain[0];
   } else {
-    return new Stack(err);
+    return new Stack(err, skip);
   }
 }
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -479,10 +479,9 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
     diagnostic: diagnostic,
     uuid: uuid4()
   };
-  if (custom && custom.level !== undefined) {
-    item.level = custom.level;
-    delete custom.level;
-  }
+
+  setCustomItemKeys(item, custom);
+
   if (requestKeys && request) {
     item.request = request;
   }
@@ -491,6 +490,17 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
   }
   item._originalArgs = args;
   return item;
+}
+
+function setCustomItemKeys(item, custom) {
+  if (custom && custom.level !== undefined) {
+    item.level = custom.level;
+    delete custom.level;
+  }
+  if (custom && custom.skipFrames !== undefined) {
+    item.skipFrames = custom.skipFrames;
+    delete custom.skipFrames;
+  }
 }
 
 var TELEMETRY_TYPES = ['log', 'network', 'dom', 'navigation', 'error', 'manual'];


### PR DESCRIPTION
When telemetry is enabled, this optionally allows Rollbar errors to be sent for XHR or fetch HTTP status codes. Disabled by default, the new flags are:
```
autoInstrument: {
  networkErrorOnHttp5xx: false,
  networkErrorOnHttp4xx: false,
  networkErrorOnHttp0: false
}
```

This PR also enables setting `skipFrames` when calling `Rollbar.error()`. The HTTP status error occurrences use this to allow the stack to point to where the `xhr.send()` or `fetch()` was called in the client code.