### PR TITLE
Add Subresource Integrity to Snippet

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -13,8 +13,10 @@ var glob = require('glob');
 var path = require('path');
 var pkg = require('./package.json');
 var fs = require('fs');
+var webpack = require('webpack');
 
 var webpackConfig = require('./webpack.config.js');
+var webpackSnippetConfig = require('./webpack.config.snippet.js');
 var browserStackBrowsers = require('./browserstack.browsers');
 
 
@@ -156,7 +158,7 @@ module.exports = function(grunt) {
 
   grunt.initConfig({
     pkg: pkg,
-    webpack: webpackConfig,
+    webpack: [...webpackConfig, webpackSnippetConfig],
     vows: {
       all: {
         options: {
@@ -202,10 +204,21 @@ module.exports = function(grunt) {
     }
   });
 
+  grunt.registerTask('build', function build() {
+    var done = this.async();
+    webpack(webpackConfig, (error) => {
+      if (error) throw error;
+      
+      webpack(webpackSnippetConfig, (error) => {
+        if (error) throw error;
+        done();
+      })
+    })
+  })
   grunt.registerTask('build', ['webpack', 'replace:snippets']);
   grunt.registerTask('default', ['build']);
   grunt.registerTask('test', ['test-server', 'test-browser']);
-  grunt.registerTask('release', ['build', 'copyrelease']);
+  grunt.registerTask('release', ['build', 'replace:snippets', 'copyrelease']);
 
   grunt.registerTask('test-server', function(_target) {
     var tasks = ['vows'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -12582,6 +12582,18 @@
         "lodash.assign": "^3.0.0"
       }
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
+    "lodash.has": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI=",
+      "dev": true
+    },
     "lodash.isarguments": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/lodash.isarguments/-/lodash.isarguments-3.1.0.tgz",
@@ -17762,6 +17774,58 @@
           "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
           "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==",
           "dev": true
+        }
+      }
+    },
+    "webpack-assets-manifest": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/webpack-assets-manifest/-/webpack-assets-manifest-3.1.1.tgz",
+      "integrity": "sha512-JV9V2QKc5wEWQptdIjvXDUL1ucbPLH2f27toAY3SNdGZp+xSaStAgpoMcvMZmqtFrBc9a5pTS1058vxyMPOzRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0",
+        "lodash.get": "^4.0",
+        "lodash.has": "^4.0",
+        "mkdirp": "^0.5",
+        "schema-utils": "^1.0.0",
+        "tapable": "^1.0.0",
+        "webpack-sources": "^1.0.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "time-grunt": "^1.0.0",
     "vows": "^0.8.3",
     "webpack": "^4.41.3",
+    "webpack-assets-manifest": "^3.1.1",
     "webpack-dev-server": "^3.1.10"
   },
   "optionalDependencies": {

--- a/src/browser/bundles/rollbar.snippet.js
+++ b/src/browser/bundles/rollbar.snippet.js
@@ -1,3 +1,4 @@
+/* global __DEFAULT_ROLLBARJS_HASH__:false */
 /* global __DEFAULT_ROLLBARJS_URL__:false */
 /* global _rollbarConfig:true */
 
@@ -6,6 +7,7 @@ var snippetCallback = require('../snippet_callback');
 
 _rollbarConfig = _rollbarConfig || {};
 _rollbarConfig.rollbarJsUrl = _rollbarConfig.rollbarJsUrl || __DEFAULT_ROLLBARJS_URL__;
+_rollbarConfig.integrity = _rollbarConfig.integrity || __DEFAULT_ROLLBARJS_HASH__;
 _rollbarConfig.async = _rollbarConfig.async === undefined || _rollbarConfig.async;
 
 var shim = Shim.setupShim(window, _rollbarConfig);

--- a/src/browser/shim.js
+++ b/src/browser/shim.js
@@ -112,6 +112,9 @@ Shim.prototype.loadFull = function(window, document, immediate, options, callbac
   if (!immediate) {
     s.async = true;
   }
+  if (!options.integrity) {
+    s.integrity = options.integrity;
+  }
 
   s.onload = s.onreadystatechange = _wrapInternalErr(function() {
     if (!done && (!this.readyState || this.readyState === 'loaded' || this.readyState === 'complete')) {

--- a/webpack.config.snippet.js
+++ b/webpack.config.snippet.js
@@ -1,0 +1,64 @@
+var fs = require('fs');
+var path = require('path');
+var webpack = require('webpack');
+var defaults = require('./defaults');
+var webpackConfig = require('./webpack.config.js');
+
+var outputPath = path.resolve(__dirname, 'dist');
+
+var defaultsPlugin = new webpack.DefinePlugin(defaults);
+
+var snippetConfig = {
+  name: 'snippet',
+  entry: {
+    'rollbar.snippet': './src/browser/bundles/rollbar.snippet.js'
+  },
+  output: {
+    path: outputPath,
+    filename: '[name].js'
+  },
+  plugins: [defaultsPlugin],
+  module: {
+    rules: [
+      {
+        enforce: 'pre',
+        test: /\.js$/,
+        loader: 'eslint-loader',
+        exclude: [/node_modules/, /vendor/],
+        options: {
+          failOnError: true,
+          configFile: path.resolve(__dirname, '.eslintrc')
+        }
+      },
+      {
+        test: /\.js$/,
+        loader: 'strict-loader',
+        exclude: [/node_modules/, /vendor/]
+      }
+    ],
+  }
+};
+
+function buildConfig() {
+  var hash
+  try {
+    hash = JSON.parse(
+      fs.readFileSync(path.join(
+        webpackConfig.find(({entry}) => entry.rollbar).output.path, 'manifest.json',
+      )),
+    )['rollbar.js'].integrity;
+  } catch (error) {} // eslint-disable-line no-empty
+
+  return {
+    ...snippetConfig,
+    plugins: [
+      ...snippetConfig.plugins,
+      new webpack.DefinePlugin({
+        __DEFAULT_ROLLBARJS_HASH__: JSON.stringify(hash),
+      }),
+    ],
+  }
+}
+
+
+module.exports = buildConfig;


### PR DESCRIPTION
This change protects the loading of rollbar.js via the Browser JS Snippet from the cdn attack vector via [Subresource Integrity][].

I made a few changes to the build system in order to make this happen:

- The webpack config that builds the snippet has been broken out into a separate config file. This config also exports a function so that the manifest can be read later in the build pipeline.
- [webpack-assets-manifest][] outputs the sha256 hash of the file which ends up on the cdn (minified vanilla config) to a file dist/manifest.json
- Grunt builds rollbar.js via the [webpack node api][], not the grunt-webpack. This is done because the snippet build depends on the assets output from the vanilla build.
  - I'm pretty rusty with Grunt, so I couldn't find a good way to get things to work "the grunt way". I can put up another WIP branch if you'd like.

It might be nice to [leverage multi-compiler mode](https://github.com/webdeveric/webpack-assets-manifest#assets) in order to avoid reading from disk. Also, I'm not sure if it's useful to publish dist/manifest.json.


[Subresource Integrity]: https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity
[webpack-assets-manifest]: https://github.com/webdeveric/webpack-assets-manifest
[webpack node api]: https://webpack.js.org/api/node/