### PR TITLE
Add CodePush Rewrite Rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -203,7 +203,8 @@
       "rewriteFilenamePatterns": [
         "^.*/[0-9A-F]{8}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{12}/[^/]*.app/(.*)$",
         "^.*/[0-9A-Fa-f]{64}/codepush_ios/(.*)$",
-        "^.*/[0-9A-Fa-f]{64}/codepush_android/(.*)$"
+        "^.*/[0-9A-Fa-f]{64}/codepush_android/(.*)$",
+        "^.*/[0-9A-Fa-f]{64}/CodePush/(.*)$"
       ]
     },
     "logLevel": "debug",


### PR DESCRIPTION
From my rollbar dashboard, I get code push url like:

```
http://reactnativehost//var/mobile/Containers/Data/Application/52713282-5486-4447-8D8F-683E8835FE7A/Library/Application Support/CodePush/220c9e918e33429e06837cbddcbcc0e8c0c6e5fd9519abe662c9d8d9d2eb9db5/CodePush/main.jsbundle
```

So I add an extra rule to match above url

Refer to

https://github.com/rollbar/rollbar.js/pull/780
https://github.com/rollbar/rollbar-react-native/issues/75