### PR TITLE
Test ignoredMessages with regex including escaped literal

### DIFF
--- a/test/predicates.test.js
+++ b/test/predicates.test.js
@@ -381,12 +381,38 @@ describe('messageIsIgnored', function() {
     var item = {
       level: 'critical',
       body: {
+        message: {body: 'This is an ignored message'}
+      }
+    };
+    var settings = {
+      reportLevel: 'debug',
+      ignoredMessages: ['^This is an .{7} message$']
+    };
+    expect(p.messageIsIgnored(logger)(item, settings)).to.not.be.ok();
+  });
+  it('false if ignoredMessages literal match', function() {
+    var item = {
+      level: 'critical',
+      body: {
         message: {body: '{"data":{"messages":[{"message":"Unauthorized"}]}}'}
       }
     };
     var settings = {
       reportLevel: 'debug',
       ignoredMessages: ['{"data":{"messages":\\[']
+    };
+    expect(p.messageIsIgnored(logger)(item, settings)).to.not.be.ok();
+  });
+  it('false if ignoredMessages more literal regex matches', function() {
+    var item = {
+      level: 'critical',
+      body: {
+        message: {body: 'Match these characters: (*+?)'}
+      }
+    };
+    var settings = {
+      reportLevel: 'debug',
+      ignoredMessages: ['\\(\\*\\+\\?\\)']
     };
     expect(p.messageIsIgnored(logger)(item, settings)).to.not.be.ok();
   });

--- a/test/predicates.test.js
+++ b/test/predicates.test.js
@@ -377,6 +377,19 @@ describe('messageIsIgnored', function() {
     };
     expect(p.messageIsIgnored(logger)(item, settings)).to.not.be.ok();
   });
+  it('false if ignoredMessages regex match', function() {
+    var item = {
+      level: 'critical',
+      body: {
+        message: {body: '{"data":{"messages":[{"message":"Unauthorized"}]}}'}
+      }
+    };
+    var settings = {
+      reportLevel: 'debug',
+      ignoredMessages: ['{"data":{"messages":\\[']
+    };
+    expect(p.messageIsIgnored(logger)(item, settings)).to.not.be.ok();
+  });
   it('true if both trace and body message but ignoredMessages only match body', function() {
     var item = {
       level: 'critical',


### PR DESCRIPTION
Verifies the double escape behavior when passing literals in the config option.

Update: Go ahead and add a few more regex tests while I have this open.