### PR TITLE
Trigger s3 workflow on release created

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -2,7 +2,7 @@ name: Upload Rollbar.js release to S3
 
 on:
   release:
-    types: [published]
+    types: [created]
 
 jobs:
   upload-distros-to-s3:


### PR DESCRIPTION
Allows testing without publish, and allows URL verification before publish.