### PR TITLE
Use new url format for cdn

### DIFF
--- a/defaults.js
+++ b/defaults.js
@@ -12,7 +12,7 @@ module.exports = {
   __DEFAULT_LOG_LEVEL__: JSON.stringify(pkg.defaults.logLevel),
   __DEFAULT_REPORT_LEVEL__: JSON.stringify(pkg.defaults.reportLevel),
   __DEFAULT_UNCAUGHT_ERROR_LEVEL: JSON.stringify(pkg.defaults.uncaughtErrorLevel),
-  __DEFAULT_ROLLBARJS_URL__: JSON.stringify('https://' + pkg.cdn.host + '/ajax/libs/rollbar.js/' + version + '/rollbar.min.js'),
+  __DEFAULT_ROLLBARJS_URL__: JSON.stringify('https://' + pkg.cdn.host + '/rollbarjs/refs/tags/v' + version + '/rollbar.min.js'),
   __DEFAULT_MAX_ITEMS__: pkg.defaults.maxItems,
   __DEFAULT_ITEMS_PER_MIN__: pkg.defaults.itemsPerMin
 };

--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "lint": "./node_modules/.bin/eslint . --ext .js"
   },
   "cdn": {
-    "host": "cdnjs.cloudflare.com"
+    "host": "cdn.rollbar.com"
   },
   "defaults": {
     "endpoint": "api.rollbar.com/api/1/item/",


### PR DESCRIPTION
Starting in the next release, cdn files will be served from cdn.rollbar.com. 