### PR TITLE
Add cache-control

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@master
     - uses: jakejarvis/s3-sync-action@v0.5.1
       with:
-        args: --follow-symlinks --delete
+        args: --cache-control "public, max-age=30672000" --follow-symlinks --delete
       env:
         AWS_S3_BUCKET: ${{ secrets.AWS_S3_BUCKET }}
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
s3-sync-action passes through any additional command line params to s3 sync. Add one for cache-control.