### PR TITLE
Fix error while initializing LRU cache

### DIFF
--- a/src/server/parser.js
+++ b/src/server/parser.js
@@ -15,7 +15,7 @@ var jadeTracePattern = /^\s*at .+ \(.+ (at[^)]+\))\)$/;
 var jadeFramePattern = /^\s*(>?) [0-9]+\|(\s*.+)$/m;
 
 
-var cache = lru({max: 100});
+var cache = new lru({max: 100});
 var pendingReads = {};
 
 exports.cache = cache;


### PR DESCRIPTION
Running rollbar on aws lambda with node version 12.16.1 gave me the following error:

```
Class constructor LRUCache cannot be invoked without 'new'
```

This pull request fixes it