### PR TITLE
Fix type definition to work with async handler functions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,7 +32,11 @@ declare class Rollbar {
 }
 
 declare namespace Rollbar {
-    export type LambdaHandler<E = object> = (event: E, context: object, callback: Callback) => void;
+    export type LambdaHandler<TEvent = any, TResult = any> = (
+        event: TEvent,
+        context: Context,
+        callback: Callback<TResult>,
+    ) => void | Promise<TResult>;
     export type MaybeError = Error | undefined | null;
     export type Level = "debug" | "info" | "warning" | "error" | "critical";
     export interface Configuration {


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar.js/issues/837

Uses the definition from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/aws-lambda/handler.d.ts as suggested in the linked issue.