### PR TITLE
Diagnostic improvements

### DIFF
--- a/src/predicates.js
+++ b/src/predicates.js
@@ -15,7 +15,6 @@ function checkLevel(item, settings) {
 function userCheckIgnore(logger) {
   return function(item, settings) {
     var isUncaught = !!item._isUncaught;
-    delete item._isUncaught;
     var args = item._originalArgs;
     delete item._originalArgs;
     try {

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -75,9 +75,22 @@ function addConfigToPayload(item, options, callback) {
   callback(null, item);
 }
 
+function addFunctionOption(options, name) {
+  if(_.isFunction(options[name])) {
+    options[name] = options[name].toString();
+  }
+}
+
 function addConfiguredOptions(item, options, callback) {
-  delete options._configuredOptions.accessToken;
-  item.data.notifier.configured_options = options._configuredOptions;
+  var configuredOptions = options._configuredOptions;
+
+  // These must be stringified or they'll get dropped during serialization.
+  addFunctionOption(configuredOptions, 'transform');
+  addFunctionOption(configuredOptions, 'checkIgnore');
+  addFunctionOption(configuredOptions, 'onSendCallback');
+
+  delete configuredOptions.accessToken;
+  item.data.notifier.configured_options = configuredOptions;
   callback(null, item);
 }
 
@@ -86,6 +99,11 @@ function addDiagnosticKeys(item, options, callback) {
 
   if (_.get(item, 'err._isAnonymous')) {
     diagnostic.is_anonymous = true;
+  }
+
+  if (item._isUncaught) {
+    diagnostic.is_uncaught = item._isUncaught;
+    delete item._isUncaught;
   }
 
   if (item.err) {

--- a/src/utility.js
+++ b/src/utility.js
@@ -413,11 +413,13 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
   var arg;
   var extraArgs = [];
   var diagnostic = {};
+  var argTypes = [];
 
   for (var i = 0, l = args.length; i < l; ++i) {
     arg = args[i];
 
     var typ = typeName(arg);
+    argTypes.push(typ);
     switch (typ) {
       case 'undefined':
         break;
@@ -488,7 +490,7 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
   if (lambdaContext) {
     item.lambdaContext = lambdaContext;
   }
-  item._originalArgs = args;
+  item.diagnostic.original_arg_types = argTypes;
   return item;
 }
 


### PR DESCRIPTION
Add a few things to the `notifier.diagnostic` key in the payload.
* is_uncaught
* Callback functions from config, if present (`transform`, `onSendCallback`, `checkIgnore`)
* Caller's type signature for `Rollbar.log()`

Payload keys are snake_case, except option keys within `configured_options` which retain their original javascript case. 