### PR TITLE
Allow configuration of stack trace limit

### DIFF
--- a/examples/angular2/src/app/rollbar.ts
+++ b/examples/angular2/src/app/rollbar.ts
@@ -15,7 +15,8 @@ const rollbarConfig:Rollbar.Configuration = {
   ignoreDuplicateErrors: true,
   wrapGlobalEventHandlers: false,
   scrubRequestBody: true,
-  exitOnUncaughtException: false
+  exitOnUncaughtException: false,
+  stackTraceLimit: 20
 };
 
 export const RollbarService = new InjectionToken<Rollbar>('rollbar');

--- a/examples/error.html
+++ b/examples/error.html
@@ -16,6 +16,14 @@
       // is true in the config.
       throw new DOMException('test DOMException');
     };
+    // Deep stack error
+    window.throwDeepStackError = function throwDeepStackError(curr, limit) {
+      if (curr < limit) {
+        throwDeepStackError(curr + 1, limit);
+      } else {
+        throw new Error('deep stack error');
+      }
+    };
   </script>
 </head>
 <body>
@@ -26,4 +34,5 @@
   </div>
   <button id="throw-error" onclick="throwError()">Throw Error</button>
   <button id="throw-dom-exception" onclick="throwDomException()">Throw DOMException</button>
+  <button id="throw-depp-stack-error" onclick="throwDeepStackError(0,20)">Throw deep stack Error</button>
 </html>

--- a/index.d.ts
+++ b/index.d.ts
@@ -74,6 +74,7 @@ declare namespace Rollbar {
         scrubRequestBody?: boolean;
         scrubTelemetryInputs?: boolean;
         sendConfig?: boolean;
+        stackTraceLimit?: number;
         telemetryScrubber?: TelemetryScrubber;
         transform?: (data: object) => void;
         transmit?: boolean;

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -20,6 +20,7 @@ function Rollbar(options, api, logger, platform) {
   this.queue = new Queue(Rollbar.rateLimiter, api, logger, this.options);
   this.notifier = new Notifier(this.queue, this.options);
   this.telemeter = new Telemeter(this.options);
+  setStackTraceLimit(options);
   this.lastError = null;
   this.lastErrorHash = 'none';
 }
@@ -45,6 +46,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
   this.options = _.merge(oldOptions, options, payload);
   this.notifier && this.notifier.configure(this.options);
   this.telemeter && this.telemeter.configure(this.options);
+  setStackTraceLimit(options);
   this.global(this.options);
   return this;
 };
@@ -149,6 +151,15 @@ function generateItemHash(item) {
   var message = item.message || '';
   var stack = (item.err || {}).stack || String(item.err);
   return message + '::' + stack;
+}
+
+// Node.js, Chrome, Safari, and some other browsers support this property
+// which globally sets the number of stack frames returned in an Error object.
+// If a browser can't use it, no harm done.
+function setStackTraceLimit(options) {
+  if (options.stackTraceLimit) {
+    Error.stackTraceLimit = options.stackTraceLimit;
+  }
 }
 
 module.exports = Rollbar;

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -477,7 +477,7 @@ describe('options.captureUncaught', function() {
     done();
   });
 
-    it('should capture exta frames when stackTraceLimit is set', function(done) {
+  it('should capture exta frames when stackTraceLimit is set', function(done) {
     var server = window.server;
     stubResponse(server);
     server.requests.length = 0;


### PR DESCRIPTION
The default stack trace length in Chrome and Node is 10 frames, which often doesn't include the frames related to the cause of the error.

Chrome, Safari, Node, and some other environments allow increasing the number of stack frames by setting `Error.stackTraceLimit`.

The config option, off by default, can be set at `options.stackTraceLimit`. Changing the default would impact grouping, since stack traces for the same error may now be a different length. Therefore the current behavior is preserved as the default.