### PR TITLE
Add diagnostic keys for node source maps

### DIFF
--- a/src/server/sourceMap/stackTrace.js
+++ b/src/server/sourceMap/stackTrace.js
@@ -112,7 +112,7 @@ function retrieveSourceMap(source) {
   };
 }
 
-exports.mapSourcePosition = function mapSourcePosition(position) {
+exports.mapSourcePosition = function mapSourcePosition(position, diagnostic) {
   var sourceMap = sourceMapCache[position.source];
   if (!sourceMap) {
     // Call the (overrideable) retrieveSourceMap function to get the source map.
@@ -122,6 +122,7 @@ exports.mapSourcePosition = function mapSourcePosition(position) {
         url: urlAndMap.url,
         map: new SourceMapConsumer(urlAndMap.map)
       };
+      diagnostic.node_source_maps.source_mapping_urls[position.source] = urlAndMap.url;
 
       // Load all sources stored inline with the source map into the file cache
       // to pretend like they are already loaded. They may not exist on disk.
@@ -139,6 +140,7 @@ exports.mapSourcePosition = function mapSourcePosition(position) {
         url: null,
         map: null
       };
+      diagnostic.node_source_maps.source_mapping_urls[position.source] = 'not found';
     }
   }
 

--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -95,7 +95,7 @@ function handleItemWithError(item, options, callback) {
     }
     callback(null, item);
   };
-  async.eachSeries(errors, _buildTraceData(chain, options), cb);
+  async.eachSeries(errors, _buildTraceData(chain, options, item), cb);
 }
 
 function addRequestData(item, options, callback) {
@@ -224,9 +224,9 @@ function _isJsonContentType(req) {
   return req.headers && req.headers['content-type'] && req.headers['content-type'].includes('json');
 }
 
-function _buildTraceData(chain, options) {
+function _buildTraceData(chain, options, item) {
   return function(ex, cb) {
-    parser.parseException(ex, options, function (err, errData) {
+    parser.parseException(ex, options, item, function (err, errData) {
       if (err) {
         return cb(err);
       }

--- a/test/server.parser.test.js
+++ b/test/server.parser.test.js
@@ -9,6 +9,7 @@ vows.describe('parser')
     'parseStack': {
       'a valid stack trace': {
         topic: function() {
+          var item = { diagnostic: {} }
           var stack = 'ReferenceError: foo is not defined\n' +
                       '  at MethodClass.method.<anonymous> (app/server.js:2:4)\n' +
                       '  at /app/node_modules/client.js:321:23\n' +
@@ -16,7 +17,7 @@ vows.describe('parser')
                       '  at MethodClass.method.(anonymous) (app/server.js:62:14)\n' +
                       '  at MethodClass.method (app/server.ts:52:4)\n' +
                       '  at MethodClass.method (app/server.js:62:14)\n';
-          p.parseStack(stack, {}, this.callback);
+          p.parseStack(stack, {}, item, this.callback);
         },
         'should parse valid js frame': function(err, frames) {
           var frame = frames[0];

--- a/test/server.transforms.test.js
+++ b/test/server.transforms.test.js
@@ -275,11 +275,19 @@ vows.describe('transforms')
           assert.isTrue(addItem.called);
           if (addItem.called) {
             var frame = addItem.getCall(0).args[0].body.trace_chain[0].frames.pop();
-            console.log(frame);
             assert.ok(frame.filename.includes('src/index.ts'));
             assert.equal(frame.lineno, 10);
             assert.equal(frame.colno, 22);
             assert.equal(frame.code, "  var error = <Error> new CustomError('foo');");
+
+            var sourceMappingURLs = addItem.getCall(0).args[0].notifier.diagnostic.node_source_maps.source_mapping_urls;
+            var urls = Object.keys(sourceMappingURLs);
+            assert.ok(urls[0].includes('index.js'));
+            assert.ok(sourceMappingURLs[urls[0]].includes('index.js.map'));
+            assert.ok(urls[1].includes('server.transforms.test.js'));
+            assert.ok(sourceMappingURLs[urls[1]].includes('not found'));
+            assert.ok(urls[2].includes('timers.js'));
+            assert.ok(sourceMappingURLs[urls[2]].includes('not found'));
           }
           addItem.reset();
         },


### PR DESCRIPTION
Add to `notifier.diagnostic` a key showing whether a map file was found for each source file, and if so, what its URL was.

Payload keys are snake_case.