### PR TITLE
Fix TypeScript compilation errors

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -32,9 +32,9 @@ declare class Rollbar {
 }
 
 declare namespace Rollbar {
-    export type LambdaHandler<TEvent = any, TResult = any> = (
+    export type LambdaHandler<TEvent = any, TResult = any, TContext = any> = (
         event: TEvent,
-        context: Context,
+        context: TContext,
         callback: Callback<TResult>,
     ) => void | Promise<TResult>;
     export type MaybeError = Error | undefined | null;
@@ -87,7 +87,7 @@ declare namespace Rollbar {
         version?: string;
         wrapGlobalEventHandlers?: boolean;
     }
-    export type Callback = (err: MaybeError, response: object) => void;
+    export type Callback<TResponse = any> = (err: MaybeError, response: TResponse) => void;
     export type LogArgument = string | Error | object | Callback | Date | any[];
     export interface LogResult {
         uuid: string;


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar.js/issues/853

At the moment, the `LambdaHandler` type does not correctly compile,
because:

 - the `Context` type is not defined
 - the `Callback` type is not a generic, but is treated as such

This change fixes these errors by:

 - adding an optional `TContext` to the `LambdaHandler` generic types
 - adding an optional generic typing to the `Callback` type