### PR TITLE
Restore item._originalArgs

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -490,6 +490,7 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
   if (lambdaContext) {
     item.lambdaContext = lambdaContext;
   }
+  item._originalArgs = args;
   item.diagnostic.original_arg_types = argTypes;
   return item;
 }

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -840,7 +840,33 @@ describe('callback options', function() {
     done();
   });
 
-    it('should send when checkIgnore returns false', function(done) {
+  it('should receive valid arguments at checkIgnore', function(done) {
+    var server = window.server;
+    stubResponse(server);
+    server.requests.length = 0;
+
+    var options = {
+      accessToken: 'POST_CLIENT_ITEM_TOKEN',
+      checkIgnore: function(_isUncaught, args, payload) {
+        if (_isUncaught === false && args[0] instanceof Error && payload.uuid) {
+          return true;
+        }
+        return false;
+      }
+    };
+    var rollbar = window.rollbar = new Rollbar(options);
+
+    rollbar.log(new Error('test'));
+
+    server.respond();
+
+    // Should be ignored if all checks pass.
+    expect(server.requests.length).to.eql(0);
+
+    done();
+  });
+
+  it('should send when checkIgnore returns false', function(done) {
     var server = window.server;
     stubResponse(server);
     server.requests.length = 0;


### PR DESCRIPTION
Fixes: https://github.com/rollbar/rollbar.js/issues/857

Restores `item._originalArgs` and adds some related test coverage.