### PR TITLE
Add opentracing integration

### DIFF
--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -18,7 +18,11 @@ function Rollbar(options, client) {
   this.options = _.handleOptions(defaultOptions, options);
   this.options._configuredOptions = options;
   var api = new API(this.options, transport, urllib);
-  this.client = client || new Client(this.options, api, logger, 'browser');
+
+  // remove tracer object from options so we don't try to parse it
+  var tracer = options.tracer || null;
+  delete options.tracer;
+  this.client = client || new Client(this.options, api, logger, 'browser', tracer);
 
   var gWindow = _gWindow();
   var gDocument = (typeof document != 'undefined') && document;

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -23,7 +23,12 @@ function Rollbar(options, client) {
   delete this.options.maxItems;
   this.options.environment = this.options.environment || 'unspecified';
   var api = new API(this.options, transport, urllib);
-  this.client = client || new Client(this.options, api, logger, 'react-native');
+
+  // remove tracer object from options so we don't try to parse it
+  var tracer = options.tracer || null;
+  delete options.tracer;
+  this.client = client || new Client(this.options, api, logger, 'react-native', tracer);
+
   addTransformsToNotifier(this.client.notifier);
   addPredicatesToQueue(this.client.queue);
 }

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -11,7 +11,7 @@ var _ = require('./utility');
  * @param api
  * @param logger
  */
-function Rollbar(options, api, logger, platform) {
+function Rollbar(options, api, logger, platform, tracer) {
   this.options = _.merge(options);
   this.logger = logger;
   Rollbar.rateLimiter.configureGlobal(this.options);
@@ -23,6 +23,13 @@ function Rollbar(options, api, logger, platform) {
   setStackTraceLimit(options);
   this.lastError = null;
   this.lastErrorHash = 'none';
+
+  if (validateTracer(tracer)) {
+    this.tracer = tracer;
+  } else {
+    this.tracer = null;
+  }
+
 }
 
 var defaultOptions = {
@@ -32,81 +39,86 @@ var defaultOptions = {
 
 Rollbar.rateLimiter = new RateLimiter(defaultOptions);
 
-Rollbar.prototype.global = function(options) {
+Rollbar.prototype.global = function (options) {
   Rollbar.rateLimiter.configureGlobal(options);
   return this;
 };
 
-Rollbar.prototype.configure = function(options, payloadData) {
+Rollbar.prototype.configure = function (options, payloadData) {
   var oldOptions = this.options;
   var payload = {};
   if (payloadData) {
-    payload = {payload: payloadData};
+    payload = { payload: payloadData };
   }
   this.options = _.merge(oldOptions, options, payload);
   this.notifier && this.notifier.configure(this.options);
   this.telemeter && this.telemeter.configure(this.options);
   setStackTraceLimit(options);
   this.global(this.options);
+
+  if (validateTracer(options.tracer)) {
+    this.tracer = options.tracer
+  }
+
   return this;
 };
 
-Rollbar.prototype.log = function(item) {
+Rollbar.prototype.log = function (item) {
   var level = this._defaultLogLevel();
   return this._log(level, item);
 };
 
-Rollbar.prototype.debug = function(item) {
+Rollbar.prototype.debug = function (item) {
   this._log('debug', item);
 };
 
-Rollbar.prototype.info = function(item) {
+Rollbar.prototype.info = function (item) {
   this._log('info', item);
 };
 
-Rollbar.prototype.warn = function(item) {
+Rollbar.prototype.warn = function (item) {
   this._log('warning', item);
 };
 
-Rollbar.prototype.warning = function(item) {
+Rollbar.prototype.warning = function (item) {
   this._log('warning', item);
 };
 
-Rollbar.prototype.error = function(item) {
+Rollbar.prototype.error = function (item) {
   this._log('error', item);
 };
 
-Rollbar.prototype.critical = function(item) {
+Rollbar.prototype.critical = function (item) {
   this._log('critical', item);
 };
 
-Rollbar.prototype.wait = function(callback) {
+Rollbar.prototype.wait = function (callback) {
   this.queue.wait(callback);
 };
 
-Rollbar.prototype.captureEvent = function(type, metadata, level) {
+Rollbar.prototype.captureEvent = function (type, metadata, level) {
   return this.telemeter.captureEvent(type, metadata, level);
 };
 
-Rollbar.prototype.captureDomContentLoaded = function(ts) {
+Rollbar.prototype.captureDomContentLoaded = function (ts) {
   return this.telemeter.captureDomContentLoaded(ts);
 };
 
-Rollbar.prototype.captureLoad = function(ts) {
+Rollbar.prototype.captureLoad = function (ts) {
   return this.telemeter.captureLoad(ts);
 };
 
-Rollbar.prototype.buildJsonPayload = function(item) {
+Rollbar.prototype.buildJsonPayload = function (item) {
   return this.api.buildJsonPayload(item);
 };
 
-Rollbar.prototype.sendJsonPayload = function(jsonPayload) {
+Rollbar.prototype.sendJsonPayload = function (jsonPayload) {
   this.api.postJsonPayload(jsonPayload);
 };
 
 /* Internal */
 
-Rollbar.prototype._log = function(defaultLevel, item) {
+Rollbar.prototype._log = function (defaultLevel, item) {
   var callback;
   if (item.callback) {
     callback = item.callback;
@@ -121,6 +133,7 @@ Rollbar.prototype._log = function(defaultLevel, item) {
     return;
   }
   try {
+    this._addTracingInfo(item);
     item.level = item.level || defaultLevel;
     this.telemeter._captureRollbarItem(item);
     item.telemetryEvents = this.telemeter.copyEvents();
@@ -130,11 +143,11 @@ Rollbar.prototype._log = function(defaultLevel, item) {
   }
 };
 
-Rollbar.prototype._defaultLogLevel = function() {
+Rollbar.prototype._defaultLogLevel = function () {
   return this.options.logLevel || 'debug';
 };
 
-Rollbar.prototype._sameAsLastError = function(item) {
+Rollbar.prototype._sameAsLastError = function (item) {
   if (!item._isUncaught) {
     return false;
   }
@@ -146,6 +159,31 @@ Rollbar.prototype._sameAsLastError = function(item) {
   this.lastErrorHash = itemHash;
   return false;
 };
+
+Rollbar.prototype._addTracingInfo = function (item) {
+  // Tracer validation occurs in the constructor
+  // or in the Rollbar.prototype.configure methods
+  if (this.tracer) {
+    // add rollbar occurrence uuid to span
+    var span = this.tracer.scope().active();
+    span.setTag('rollbar_uuid', item.uuid);
+    span.setTag('has_rollbar_error', true);
+
+    // add span ID & trace ID to occurrence
+    var opentracingSpanId = span.context().toSpanId();
+    var opentracingTraceId = span.context().toTraceId();
+
+    if (item.custom) {
+      item.custom.opentracing_span_id = opentracingSpanId;
+      item.custom.opentracing_trace_id = opentracingTraceId;
+    } else {
+      item.custom = {
+        opentracing_span_id: opentracingSpanId,
+        opentracing_trace_id: opentracingTraceId
+      };
+    }
+  }
+}
 
 function generateItemHash(item) {
   var message = item.message || '';
@@ -160,6 +198,45 @@ function setStackTraceLimit(options) {
   if (options.stackTraceLimit) {
     Error.stackTraceLimit = options.stackTraceLimit;
   }
+}
+
+/**
+ * Validate the tracer object provided to the Client
+ * is valid for our Opentracing use case.
+ * @param {ls-trace-js.Tracer} tracer
+ */
+function validateTracer(tracer) {
+  if (!tracer) {
+    return false;
+  }
+
+  if (!tracer.scope || typeof tracer.scope !== 'function') {
+    return false;
+  }
+
+  const scope = tracer.scope();
+
+  if (!scope || !scope.active || typeof scope.active !== 'function') {
+    return false;
+  }
+
+  const activeSpan = scope.active();
+
+  if (!activeSpan || !activeSpan.context || typeof activeSpan.context !== 'function') {
+    return false;
+  }
+
+  const spanContext = activeSpan.context();
+
+  if (!spanContext
+    || !spanContext.toSpanId
+    || !spanContext.toTraceId
+    || typeof spanContext.toSpanId !== 'function'
+    || typeof spanContext.toTraceId !== 'function') {
+    return false
+  }
+
+  return true;
 }
 
 module.exports = Rollbar;

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -35,14 +35,20 @@ function Rollbar(options, client) {
   this.lambdaTimeoutHandle = null;
   var transport = new Transport();
   var api = new API(this.options, transport, urllib, jsonBackup);
-  this.client = client || new Client(this.options, api, logger, 'server');
+
+  // remove tracer object from options so we don't try to parse it
+  var tracer = options.tracer || null;
+  delete options.tracer;
+
+  this.client = client || new Client(this.options, api, logger, 'server', tracer);
+
   addTransformsToNotifier(this.client.notifier);
   addPredicatesToQueue(this.client.queue);
   this.setupUnhandledCapture();
 }
 
 var _instance = null;
-Rollbar.init = function(options, client) {
+Rollbar.init = function (options, client) {
   if (_instance) {
     return _instance.global(options).configure(options);
   }
@@ -58,14 +64,14 @@ function handleUninitialized(maybeCallback) {
   }
 }
 
-Rollbar.prototype.global = function(options) {
+Rollbar.prototype.global = function (options) {
   options = _.handleOptions(options);
   // On the server we want to ignore any maxItems setting
   delete options.maxItems;
   this.client.global(options);
   return this;
 };
-Rollbar.global = function(options) {
+Rollbar.global = function (options) {
   if (_instance) {
     return _instance.global(options);
   } else {
@@ -73,11 +79,11 @@ Rollbar.global = function(options) {
   }
 };
 
-Rollbar.prototype.configure = function(options, payloadData) {
+Rollbar.prototype.configure = function (options, payloadData) {
   var oldOptions = this.options;
   var payload = {};
   if (payloadData) {
-    payload = {payload: payloadData};
+    payload = { payload: payloadData };
   }
   this.options = _.handleOptions(oldOptions, options, payload);
   this.options._configuredOptions = _.handleOptions(oldOptions._configuredOptions, options, payload);
@@ -88,7 +94,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
   this.setupUnhandledCapture();
   return this;
 };
-Rollbar.configure = function(options, payloadData) {
+Rollbar.configure = function (options, payloadData) {
   if (_instance) {
     return _instance.configure(options, payloadData);
   } else {
@@ -96,10 +102,10 @@ Rollbar.configure = function(options, payloadData) {
   }
 };
 
-Rollbar.prototype.lastError = function() {
+Rollbar.prototype.lastError = function () {
   return this.client.lastError;
 };
-Rollbar.lastError = function() {
+Rollbar.lastError = function () {
   if (_instance) {
     return _instance.lastError();
   } else {
@@ -107,13 +113,13 @@ Rollbar.lastError = function() {
   }
 };
 
-Rollbar.prototype.log = function() {
+Rollbar.prototype.log = function () {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
   this.client.log(item);
-  return {uuid: uuid};
+  return { uuid: uuid };
 };
-Rollbar.log = function() {
+Rollbar.log = function () {
   if (_instance) {
     return _instance.log.apply(_instance, arguments);
   } else {
@@ -122,13 +128,13 @@ Rollbar.log = function() {
   }
 };
 
-Rollbar.prototype.debug = function() {
+Rollbar.prototype.debug = function () {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
   this.client.debug(item);
-  return {uuid: uuid};
+  return { uuid: uuid };
 };
-Rollbar.debug = function() {
+Rollbar.debug = function () {
   if (_instance) {
     return _instance.debug.apply(_instance, arguments);
   } else {
@@ -137,13 +143,13 @@ Rollbar.debug = function() {
   }
 };
 
-Rollbar.prototype.info = function() {
+Rollbar.prototype.info = function () {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
   this.client.info(item);
-  return {uuid: uuid};
+  return { uuid: uuid };
 };
-Rollbar.info = function() {
+Rollbar.info = function () {
   if (_instance) {
     return _instance.info.apply(_instance, arguments);
   } else {
@@ -152,13 +158,13 @@ Rollbar.info = function() {
   }
 };
 
-Rollbar.prototype.warn = function() {
+Rollbar.prototype.warn = function () {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
   this.client.warn(item);
-  return {uuid: uuid};
+  return { uuid: uuid };
 };
-Rollbar.warn = function() {
+Rollbar.warn = function () {
   if (_instance) {
     return _instance.warn.apply(_instance, arguments);
   } else {
@@ -168,13 +174,13 @@ Rollbar.warn = function() {
 };
 
 
-Rollbar.prototype.warning = function() {
+Rollbar.prototype.warning = function () {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
   this.client.warning(item);
-  return {uuid: uuid};
+  return { uuid: uuid };
 };
-Rollbar.warning = function() {
+Rollbar.warning = function () {
   if (_instance) {
     return _instance.warning.apply(_instance, arguments);
   } else {
@@ -184,13 +190,13 @@ Rollbar.warning = function() {
 };
 
 
-Rollbar.prototype.error = function() {
+Rollbar.prototype.error = function () {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
   this.client.error(item);
-  return {uuid: uuid};
+  return { uuid: uuid };
 };
-Rollbar.error = function() {
+Rollbar.error = function () {
   if (_instance) {
     return _instance.error.apply(_instance, arguments);
   } else {
@@ -198,21 +204,21 @@ Rollbar.error = function() {
     handleUninitialized(maybeCallback);
   }
 };
-Rollbar.prototype._uncaughtError = function() {
+Rollbar.prototype._uncaughtError = function () {
   var item = this._createItem(arguments);
   item._isUncaught = true;
   var uuid = item.uuid;
   this.client.error(item);
-  return {uuid: uuid};
+  return { uuid: uuid };
 };
 
-Rollbar.prototype.critical = function() {
+Rollbar.prototype.critical = function () {
   var item = this._createItem(arguments);
   var uuid = item.uuid;
   this.client.critical(item);
-  return {uuid: uuid};
+  return { uuid: uuid };
 };
-Rollbar.critical = function() {
+Rollbar.critical = function () {
   if (_instance) {
     return _instance.critical.apply(_instance, arguments);
   } else {
@@ -221,10 +227,10 @@ Rollbar.critical = function() {
   }
 };
 
-Rollbar.prototype.buildJsonPayload = function(item) {
+Rollbar.prototype.buildJsonPayload = function (item) {
   return this.client.buildJsonPayload(item);
 };
-Rollbar.buildJsonPayload = function() {
+Rollbar.buildJsonPayload = function () {
   if (_instance) {
     return _instance.buildJsonPayload.apply(_instance, arguments);
   } else {
@@ -232,10 +238,10 @@ Rollbar.buildJsonPayload = function() {
   }
 };
 
-Rollbar.prototype.sendJsonPayload = function(jsonPayload) {
+Rollbar.prototype.sendJsonPayload = function (jsonPayload) {
   return this.client.sendJsonPayload(jsonPayload);
 };
-Rollbar.sendJsonPayload = function() {
+Rollbar.sendJsonPayload = function () {
   if (_instance) {
     return _instance.sendJsonPayload.apply(_instance, arguments);
   } else {
@@ -243,10 +249,10 @@ Rollbar.sendJsonPayload = function() {
   }
 };
 
-Rollbar.prototype.wait = function(callback) {
+Rollbar.prototype.wait = function (callback) {
   this.client.wait(callback);
 };
-Rollbar.wait = function(callback) {
+Rollbar.wait = function (callback) {
   if (_instance) {
     return _instance.wait(callback)
   } else {
@@ -255,9 +261,9 @@ Rollbar.wait = function(callback) {
   }
 };
 
-Rollbar.prototype.errorHandler = function() {
-  return function(err, request, response, next) {
-    var cb = function(rollbarError) {
+Rollbar.prototype.errorHandler = function () {
+  return function (err, request, response, next) {
+    var cb = function (rollbarError) {
       if (rollbarError) {
         logger.error('Error reporting to rollbar, ignoring: ' + rollbarError);
       }
@@ -273,7 +279,7 @@ Rollbar.prototype.errorHandler = function() {
     return this.error('Error: ' + err, request, cb);
   }.bind(this);
 };
-Rollbar.errorHandler = function() {
+Rollbar.errorHandler = function () {
   if (_instance) {
     return _instance.errorHandler()
   } else {
@@ -281,16 +287,16 @@ Rollbar.errorHandler = function() {
   }
 };
 
-Rollbar.prototype.lambdaHandler = function(handler, timeoutHandler) {
+Rollbar.prototype.lambdaHandler = function (handler, timeoutHandler) {
   if (handler.length <= 2) {
     return this.asyncLambdaHandler(handler, timeoutHandler);
   }
   return this.syncLambdaHandler(handler, timeoutHandler);
 };
 
-Rollbar.prototype.asyncLambdaHandler = function(handler, timeoutHandler) {
+Rollbar.prototype.asyncLambdaHandler = function (handler, timeoutHandler) {
   var self = this;
-  var _timeoutHandler = function(event, context) {
+  var _timeoutHandler = function (event, context) {
     var message = 'Function timed out';
     var custom = {
       originalEvent: event,
@@ -299,21 +305,21 @@ Rollbar.prototype.asyncLambdaHandler = function(handler, timeoutHandler) {
     self.error(message, custom);
   };
   var shouldReportTimeouts = self.options.captureLambdaTimeouts;
-  return function(event, context) {
-    return new Promise(function(resolve, reject) {
+  return function (event, context) {
+    return new Promise(function (resolve, reject) {
       self.lambdaContext = context;
       if (shouldReportTimeouts) {
         var timeoutCb = (timeoutHandler || _timeoutHandler).bind(null, event, context);
         self.lambdaTimeoutHandle = setTimeout(timeoutCb, context.getRemainingTimeInMillis() - 1000);
       }
       handler(event, context)
-        .then(function(resp) {
+        .then(function (resp) {
           clearTimeout(self.lambdaTimeoutHandle);
           resolve(resp);
         })
-        .catch(function(err) {
+        .catch(function (err) {
           self.error(err);
-          self.wait(function() {
+          self.wait(function () {
             clearTimeout(self.lambdaTimeoutHandle);
             reject(err);
           });
@@ -321,9 +327,9 @@ Rollbar.prototype.asyncLambdaHandler = function(handler, timeoutHandler) {
     });
   };
 };
-Rollbar.prototype.syncLambdaHandler = function(handler, timeoutHandler) {
+Rollbar.prototype.syncLambdaHandler = function (handler, timeoutHandler) {
   var self = this;
-  var _timeoutHandler = function(event, context, _cb) {
+  var _timeoutHandler = function (event, context, _cb) {
     var message = 'Function timed out';
     var custom = {
       originalEvent: event,
@@ -332,32 +338,32 @@ Rollbar.prototype.syncLambdaHandler = function(handler, timeoutHandler) {
     self.error(message, custom);
   };
   var shouldReportTimeouts = self.options.captureLambdaTimeouts;
-  return function(event, context, callback) {
+  return function (event, context, callback) {
     self.lambdaContext = context;
     if (shouldReportTimeouts) {
       var timeoutCb = (timeoutHandler || _timeoutHandler).bind(null, event, context, callback);
       self.lambdaTimeoutHandle = setTimeout(timeoutCb, context.getRemainingTimeInMillis() - 1000);
     }
     try {
-      handler(event, context, function(err, resp) {
+      handler(event, context, function (err, resp) {
         if (err) {
           self.error(err);
         }
-        self.wait(function() {
+        self.wait(function () {
           clearTimeout(self.lambdaTimeoutHandle);
           callback(err, resp);
         });
       });
     } catch (err) {
       self.error(err);
-      self.wait(function() {
+      self.wait(function () {
         clearTimeout(self.lambdaTimeoutHandle);
         throw err;
       });
     }
   };
 };
-Rollbar.lambdaHandler = function(handler) {
+Rollbar.lambdaHandler = function (handler) {
   if (_instance) {
     return _instance.lambdaHandler(handler);
   } else {
@@ -366,7 +372,7 @@ Rollbar.lambdaHandler = function(handler) {
 };
 
 function wrapCallback(r, f) {
-  return function() {
+  return function () {
     var err = arguments[0];
     if (err) {
       r.error(err);
@@ -375,10 +381,10 @@ function wrapCallback(r, f) {
   };
 }
 
-Rollbar.prototype.wrapCallback = function(f) {
+Rollbar.prototype.wrapCallback = function (f) {
   return wrapCallback(this, f);
 };
-Rollbar.wrapCallback = function(f) {
+Rollbar.wrapCallback = function (f) {
   if (_instance) {
     return _instance.wrapCallback(f);
   } else {
@@ -386,11 +392,11 @@ Rollbar.wrapCallback = function(f) {
   }
 };
 
-Rollbar.prototype.captureEvent = function() {
+Rollbar.prototype.captureEvent = function () {
   var event = _.createTelemetryEvent(arguments);
   return this.client.captureEvent(event.type, event.metadata, event.level);
 };
-Rollbar.captureEvent = function() {
+Rollbar.captureEvent = function () {
   if (_instance) {
     return _instance.captureEvent.apply(_instance, arguments);
   } else {
@@ -400,7 +406,7 @@ Rollbar.captureEvent = function() {
 
 /** DEPRECATED **/
 
-Rollbar.prototype.reportMessage = function(message, level, request, callback) {
+Rollbar.prototype.reportMessage = function (message, level, request, callback) {
   logger.log('reportMessage is deprecated');
   if (_.isFunction(this[level])) {
     return this[level](message, request, callback);
@@ -408,7 +414,7 @@ Rollbar.prototype.reportMessage = function(message, level, request, callback) {
     return this.error(message, request, callback);
   }
 };
-Rollbar.reportMessage = function(message, level, request, callback) {
+Rollbar.reportMessage = function (message, level, request, callback) {
   if (_instance) {
     return _instance.reportMessage(message, level, request, callback);
   } else {
@@ -416,11 +422,11 @@ Rollbar.reportMessage = function(message, level, request, callback) {
   }
 };
 
-Rollbar.prototype.reportMessageWithPayloadData = function(message, payloadData, request, callback) {
+Rollbar.prototype.reportMessageWithPayloadData = function (message, payloadData, request, callback) {
   logger.log('reportMessageWithPayloadData is deprecated');
   return this.error(message, request, payloadData, callback);
 };
-Rollbar.reportMessageWithPayloadData = function(message, payloadData, request, callback) {
+Rollbar.reportMessageWithPayloadData = function (message, payloadData, request, callback) {
   if (_instance) {
     return _instance.reportMessageWithPayloadData(message, payloadData, request, callback);
   } else {
@@ -429,11 +435,11 @@ Rollbar.reportMessageWithPayloadData = function(message, payloadData, request, c
 };
 
 
-Rollbar.prototype.handleError = function(err, request, callback) {
+Rollbar.prototype.handleError = function (err, request, callback) {
   logger.log('handleError is deprecated');
   return this.error(err, request, callback);
 };
-Rollbar.handleError = function(err, request, callback) {
+Rollbar.handleError = function (err, request, callback) {
   if (_instance) {
     return _instance.handleError(err, request, callback);
   } else {
@@ -442,11 +448,11 @@ Rollbar.handleError = function(err, request, callback) {
 };
 
 
-Rollbar.prototype.handleErrorWithPayloadData = function(err, payloadData, request, callback) {
+Rollbar.prototype.handleErrorWithPayloadData = function (err, payloadData, request, callback) {
   logger.log('handleErrorWithPayloadData is deprecated');
   return this.error(err, request, payloadData, callback);
 };
-Rollbar.handleErrorWithPayloadData = function(err, payloadData, request, callback) {
+Rollbar.handleErrorWithPayloadData = function (err, payloadData, request, callback) {
   if (_instance) {
     return _instance.handleErrorWithPayloadData(err, payloadData, request, callback);
   } else {
@@ -454,7 +460,7 @@ Rollbar.handleErrorWithPayloadData = function(err, payloadData, request, callbac
   }
 };
 
-Rollbar.handleUncaughtExceptions = function(accessToken, options) {
+Rollbar.handleUncaughtExceptions = function (accessToken, options) {
   if (_instance) {
     options = options || {};
     options.accessToken = accessToken;
@@ -464,7 +470,7 @@ Rollbar.handleUncaughtExceptions = function(accessToken, options) {
   }
 };
 
-Rollbar.handleUnhandledRejections = function(accessToken, options) {
+Rollbar.handleUnhandledRejections = function (accessToken, options) {
   if (_instance) {
     options = options || {};
     options.accessToken = accessToken;
@@ -474,7 +480,7 @@ Rollbar.handleUnhandledRejections = function(accessToken, options) {
   }
 };
 
-Rollbar.handleUncaughtExceptionsAndRejections = function(accessToken, options) {
+Rollbar.handleUncaughtExceptionsAndRejections = function (accessToken, options) {
   if (_instance) {
     options = options || {};
     options.accessToken = accessToken;
@@ -512,7 +518,7 @@ function addPredicatesToQueue(queue) {
     .addPredicate(sharedPredicates.messageIsIgnored(logger));
 }
 
-Rollbar.prototype._createItem = function(args) {
+Rollbar.prototype._createItem = function (args) {
   var requestKeys = ['headers', 'protocol', 'url', 'method', 'body', 'route'];
   return _.createItem(args, logger, this, requestKeys, this.lambdaContext);
 };
@@ -526,7 +532,7 @@ function _getFirstFunction(args) {
   return undefined;
 }
 
-Rollbar.prototype.setupUnhandledCapture = function() {
+Rollbar.prototype.setupUnhandledCapture = function () {
   if (this.options.captureUncaught || this.options.handleUncaughtExceptions) {
     this.handleUncaughtExceptions();
   }
@@ -535,24 +541,24 @@ Rollbar.prototype.setupUnhandledCapture = function() {
   }
 };
 
-Rollbar.prototype.handleUncaughtExceptions = function() {
+Rollbar.prototype.handleUncaughtExceptions = function () {
   var exitOnUncaught = !!this.options.exitOnUncaughtException;
   delete this.options.exitOnUncaughtException;
 
-  addOrReplaceRollbarHandler('uncaughtException', function(err) {
+  addOrReplaceRollbarHandler('uncaughtException', function (err) {
     if (!this.options.captureUncaught && !this.options.handleUncaughtExceptions) {
       return;
     }
 
-    this._uncaughtError(err, function(err) {
+    this._uncaughtError(err, function (err) {
       if (err) {
         logger.error('Encountered error while handling an uncaught exception.');
         logger.error(err);
       }
     });
     if (exitOnUncaught) {
-      setImmediate(function() {
-        this.wait(function() {
+      setImmediate(function () {
+        this.wait(function () {
           process.exit(1);
         });
       }.bind(this));
@@ -560,13 +566,13 @@ Rollbar.prototype.handleUncaughtExceptions = function() {
   }.bind(this));
 };
 
-Rollbar.prototype.handleUnhandledRejections = function() {
-  addOrReplaceRollbarHandler('unhandledRejection', function(reason) {
+Rollbar.prototype.handleUnhandledRejections = function () {
+  addOrReplaceRollbarHandler('unhandledRejection', function (reason) {
     if (!this.options.captureUnhandledRejections && !this.options.handleUnhandledRejections) {
       return;
     }
 
-    this._uncaughtError(reason, function(err) {
+    this._uncaughtError(reason, function (err) {
       if (err) {
         logger.error('Encountered error while handling an uncaught exception.');
         logger.error(err);
@@ -578,7 +584,7 @@ Rollbar.prototype.handleUnhandledRejections = function() {
 function addOrReplaceRollbarHandler(event, action) {
   // We only support up to two arguments which is enough for how this is used
   // rather than dealing with `arguments` and `apply`
-  var fn = function(a, b) {
+  var fn = function (a, b) {
     action(a, b);
   };
   fn._rollbarHandler = true;

--- a/test/react-native.rollbar.test.js
+++ b/test/react-native.rollbar.test.js
@@ -45,6 +45,30 @@ describe('sendJsonPayload', function() {
   });
 });
 
+const DUMMY_TRACE_ID = 'some-trace-id';
+const DUMMY_SPAN_ID = 'some-span-id';
+
+const ValidOpenTracingTracerStub = {
+  scope: () => {
+    return {
+      active: () => {
+        return {
+          setTag: () => { },
+          context: () => {
+            return {
+              toTraceId: () => DUMMY_TRACE_ID,
+              toSpanId: () => DUMMY_SPAN_ID
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+const InvalidOpenTracingTracerStub = {
+  foo: () => { }
+};
 
 function TestClientGen() {
   var TestClient = function() {
@@ -187,6 +211,24 @@ describe('Rollbar()', function() {
       expect(client.logCalls[i].func).to.eql(methods[i]);
       expect(client.logCalls[i].item.message).to.eql(msg)
     }
+
+    done();
+  });
+
+  it('should have a tracer if valid tracer is provided', function (done) {
+    var options = { tracer: ValidOpenTracingTracerStub };
+    var rollbar = new Rollbar(options);
+
+    expect(rollbar.client.tracer).to.eql(ValidOpenTracingTracerStub);
+
+    done();
+  });
+
+  it('should not have a tracer if invalid tracer is provided', function (done) {
+    var options = { tracer: InvalidOpenTracingTracerStub };
+    var rollbar = new Rollbar(options);
+
+    expect(rollbar.client.tracer).to.eql(null);
 
     done();
   });

--- a/test/server.rollbar.test.js
+++ b/test/server.rollbar.test.js
@@ -7,8 +7,33 @@ var sinon = require('sinon');
 process.env.NODE_ENV = process.env.NODE_ENV || 'test-node-env';
 var Rollbar = require('../src/server/rollbar');
 
+const DUMMY_TRACE_ID = 'some-trace-id';
+const DUMMY_SPAN_ID = 'some-span-id';
+
+const ValidOpenTracingTracerStub = {
+  scope: () => {
+    return {
+      active: () => {
+        return {
+          setTag: () => {},
+          context: () => {
+            return {
+              toTraceId: () => DUMMY_TRACE_ID,
+              toSpanId: () => DUMMY_SPAN_ID
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+const InvalidOpenTracingTracerStub = {
+  foo: () => {}
+};
+
 function TestClientGen() {
-  var TestClient = function() {
+  var TestClient = function () {
     this.notifier = {
       addTransform: function() { return this; }
     };
@@ -16,7 +41,7 @@ function TestClientGen() {
       addPredicate: function() { return this; }
     };
     this.logCalls = [];
-    var logs = 'log,debug,info,warn,wanring,error,critical'.split(',');
+    var logs = 'log,debug,info,warn,warning,error,critical'.split(',');
     for(var i=0, len=logs.length; i < len; i++) {
       var fn = logs[i].slice(0);
       this[fn] = function(fn, item) {
@@ -32,6 +57,7 @@ function TestClientGen() {
     this.clearLogCalls = function() {
       this.logCalls = [];
     };
+    this.tracer = ValidOpenTracingTracerStub;
   };
 
   return TestClient;
@@ -116,6 +142,24 @@ vows.describe('rollbar')
         'should set configured options': function(r) {
           assert.equal('fake-env', r.options._configuredOptions.environment);
         }
+      },
+      'with valid tracer': {
+        topic: function () {
+          var rollbar = new Rollbar({ captureUncaught: true, environment: 'fake-env', tracer: ValidOpenTracingTracerStub });
+          return rollbar;
+        },
+        'should configure tracer': function (r) {
+          assert.equal(ValidOpenTracingTracerStub, r.client.tracer);
+        }
+      },
+      'with invalid tracer': {
+        topic: function () {
+          var rollbar = new Rollbar({ captureUncaught: true, environment: 'fake-env', tracer: InvalidOpenTracingTracerStub });
+          return rollbar;
+        },
+        'should configure tracer': function (r) {
+          assert.equal(null, r.client.tracer);
+        }
       }
     },
     'configure': {
@@ -129,12 +173,65 @@ vows.describe('rollbar')
           assert.equal('new-env', r.options._configuredOptions.environment);
           assert.equal(false, r.options._configuredOptions.captureUncaught);
         }
+      },
+      'with valid tracer': {
+        topic: function() {
+          var rollbar = new Rollbar({ captureUncaught: true, environment: 'fake-env' });
+          rollbar.configure({ tracer: ValidOpenTracingTracerStub });
+          return rollbar;
+        },
+        'should configure tracer': function(r) {
+          assert.equal(ValidOpenTracingTracerStub, r.client.tracer);
+        }
+      },
+      'with invalid tracer': {
+        topic: function() {
+          var rollbar = new Rollbar({ captureUncaught: true, environment: 'fake-env' });
+          rollbar.configure({ tracer: InvalidOpenTracingTracerStub });
+          return rollbar;
+        },
+        'should configure tracer': function(r) {
+          assert.equal(null, r.client.tracer);
+        }
       }
+    },
+    'addTracingInfo': {
+      'with valid tracer': {
+        topic: function() {
+          var rollbar = new Rollbar({ captureUncaught: true, environment: 'fake-env', tracer: ValidOpenTracingTracerStub });
+          return rollbar;
+        },
+        'should add trace ID and span ID to custom field on item if no custom field set': function (r) {
+          const item = { uuid: 'some-uuid', custom: null };
+          r.client._addTracingInfo(item);
+          assert.equal(DUMMY_TRACE_ID, item.custom.opentracing_trace_id);
+          assert.equal(DUMMY_SPAN_ID, item.custom.opentracing_span_id);
+        },
+        'should add trace ID and span ID to custom field on item even if already has some custom fields': function(r) {
+          const item = { uuid: 'some-uuid', custom: { foo: 'foo' } };
+          r.client._addTracingInfo(item);
+          assert.equal(DUMMY_TRACE_ID, item.custom.opentracing_trace_id);
+          assert.equal(DUMMY_SPAN_ID, item.custom.opentracing_span_id);
+          assert.equal('foo', item.custom.foo);
+        }
+      },
+      'with invalid tracer': {
+        topic: function() {
+          var rollbar = new Rollbar({ captureUncaught: true, environment: 'fake-env', tracer: InvalidOpenTracingTracerStub });
+          return rollbar;
+        },
+        'should add trace ID and span ID to custom field on item': function (r) {
+          const item = { uuid: 'some-uuid', custom: {} };
+          r.client._addTracingInfo(item);
+          assert.equal(undefined, item.custom.opentracing_trace_id);
+          assert.equal(undefined, item.custom.opentracing_span_id);
+        }
+      },
     },
     'log': {
       topic: function() {
         var client = new (TestClientGen())();
-        var rollbar = new Rollbar({accessToken: 'abc123'}, client);
+        var rollbar = new Rollbar({ accessToken: 'abc123' }, client);
         return rollbar;
       },
       'message': {


### PR DESCRIPTION
These changes allow for a rollbar.js user to inject an OpenTracing tracer object as a configuration option. 

Whenever an error or message is logged via Rollbar we will check if the client has as tracer set. If that tracer is valid then we set the new occurrence UUID as metadata on the opentracing span as well as add the opentracing trace ID and span ID to the occurrence as custom metadata.

