### PR TITLE
Update naming convention for Lightstep open tracing span tags

### DIFF
--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -186,8 +186,8 @@ Rollbar.prototype._addTracingInfo = function (item) {
     var span = this.tracer.scope().active();
 
     if (validateSpan(span)) {
-      span.setTag('rollbar_uuid', item.uuid);
-      span.setTag('has_rollbar_error', true);
+      span.setTag('rollbar.occurrence_uuid', item.uuid);
+      span.setTag('rollbar.has_error', true);
 
       // add span ID & trace ID to occurrence
       var opentracingSpanId = span.context().toSpanId();

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -186,7 +186,7 @@ Rollbar.prototype._addTracingInfo = function (item) {
     var span = this.tracer.scope().active();
 
     if (validateSpan(span)) {
-      span.setTag('rollbar.occurrence_uuid', item.uuid);
+      span.setTag('rollbar.error_uuid', item.uuid);
       span.setTag('rollbar.has_error', true);
 
       // add span ID & trace ID to occurrence


### PR DESCRIPTION
Lightstep wanted to use more "namespaced" tag names like `rollbar.<TAG_NAME>` so this PR fixes changes to use that new convention.