### PR TITLE
Clone the fetch response before reading

### DIFF
--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -367,8 +367,9 @@ Instrumenter.prototype.instrumentNetwork = function() {
           }
           var body = null;
           if (self.autoInstrument.networkResponseBody) {
-            if (typeof resp.text === 'function') { // Response.text() is not implemented on multiple platforms
-              body = resp.text(); //returns a Promise
+            if (typeof resp.text === 'function') { // Response.text() is not implemented on some platforms
+              // The response must be cloned to prevent reading (and locking) the original stream.
+              body = resp.clone().text(); //returns a Promise
             }
           }
           if (headers || body) {


### PR DESCRIPTION
Fixes: https://github.com/mozilla/pdf.js/issues/11490

In network telemetry, when reading the fetch response body, clone the response object first and read the clone.

Using any of the read methods on the original object will lock the response body when it is a `ReadableStream` type (and may have similar issues with other allowed types.) 