### PR TITLE
Allow scrubbing by full path in payload

### DIFF
--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -292,8 +292,9 @@ function errorClass(stackInfo, guess, options) {
 }
 
 function scrubPayload(item, options, callback) {
-  var scrubFields = options.scrubFields;
-  item.data = _.scrub(item.data, scrubFields);
+  var scrubFields = options.scrubFields || [];
+  var scrubPaths = options.scrubPaths || [];
+  item.data = _.scrub(item.data, scrubFields, scrubPaths);
   callback(null, item);
 }
 

--- a/src/react-native/transforms.js
+++ b/src/react-native/transforms.js
@@ -85,8 +85,9 @@ function handleItemWithError(item, options, callback) {
 function scrubPayload(item, options, callback) {
   var scrubHeaders = options.scrubHeaders || [];
   var scrubFields = options.scrubFields || [];
+  var scrubPaths = options.scrubPaths || [];
   scrubFields = scrubHeaders.concat(scrubFields);
-  item.data = _.scrub(item.data, scrubFields);
+  item.data = _.scrub(item.data, scrubFields, scrubPaths);
   callback(null, item);
 }
 

--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -184,10 +184,11 @@ function addLambdaData(item, options, callback) {
 function scrubPayload(item, options, callback) {
   var scrubHeaders = options.scrubHeaders || [];
   var scrubFields = options.scrubFields || [];
+  var scrubPaths = options.scrubPaths || [];
   scrubFields = scrubHeaders.concat(scrubFields);
 
   parseRequestBody(item.data.request, options);
-  item.data = _.scrub(item.data, scrubFields);
+  item.data = _.scrub(item.data, scrubFields, scrubPaths);
   serializeRequestBody(item.data.request, options);
 
   callback(null, item);

--- a/src/utility.js
+++ b/src/utility.js
@@ -602,8 +602,15 @@ function set(obj, path, value) {
   }
 }
 
-function scrub(data, scrubFields) {
+function scrub(data, scrubFields, scrubPaths) {
   scrubFields = scrubFields || [];
+
+  if (scrubPaths) {
+    for (var i = 0; i < scrubPaths.length; ++i) {
+      scrubPath(data, scrubPaths[i]);
+    }
+  }
+
   var paramRes = _getScrubFieldRegexs(scrubFields);
   var queryRes = _getScrubQueryParamRegexs(scrubFields);
 
@@ -645,6 +652,22 @@ function scrub(data, scrubFields) {
   }
 
   return traverse(data, scrubber, []);
+}
+
+function scrubPath(obj, path) {
+  var keys = path.split('.');
+  var last = keys.length - 1;
+  try {
+    for (var i = 0; i <= last; ++i) {
+      if (i < last) {
+        obj = obj[keys[i]];
+      } else {
+        obj[keys[i]] = redact();
+      }
+    }
+  } catch (e) {
+    // Missing key is OK;
+  }
 }
 
 function _getScrubFieldRegexs(scrubFields) {

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -702,6 +702,33 @@ describe('scrub', function() {
     expect(result.inner.a).to.be.ok();
     expect(result.inner.b).to.eql('yes');
   });
+  it('should handle scrubPaths', function() {
+    var data = {
+      a: {
+        b: {
+          foo: 'secret',
+          bar: 'stuff'
+        },
+        c: 'bork',
+        password: 'abc123'
+      },
+      secret: 'blahblah'
+    };
+    var scrubPaths = [
+      'nowhere', // path not found
+      'a.b.foo', // nested path
+      'a.password', // nested path
+      'secret' // root path
+    ];
+
+    var result = _.scrub(data, [], scrubPaths);
+
+    expect(result.a.b.bar).to.eql('stuff');
+    expect(result.a.b.foo).to.not.eql('secret');
+    expect(result.a.c).to.eql('bork');
+    expect(result.a.password).to.not.eql('abc123');
+    expect(result.secret).to.not.eql('blahblah');
+  });
 });
 
 describe('formatArgsAsString', function() {

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -656,7 +656,7 @@ describe('scrub', function() {
 
     var result = _.scrub(data, scrubFields);
 
-    expect(result.password).to.not.eql('abc123');
+    expect(result.password).to.eql(_.redact());
   });
   it('should handle nested objects', function() {
     var data = {
@@ -675,10 +675,10 @@ describe('scrub', function() {
     var result = _.scrub(data, scrubFields);
 
     expect(result.a.b.other).to.eql('stuff');
-    expect(result.a.badthing).to.not.eql('secret');
+    expect(result.a.b.badthing).to.eql(_.redact());
     expect(result.a.c).to.eql('bork');
-    expect(result.a.password).to.not.eql('abc123');
-    expect(result.secret).to.not.eql('blahblah');
+    expect(result.a.password).to.eql(_.redact());
+    expect(result.secret).to.eql(_.redact());
     expect(data.secret).to.eql('blahblah');
   });
   it('should do something sane for recursive objects', function() {
@@ -697,8 +697,8 @@ describe('scrub', function() {
     var result = _.scrub(data, scrubFields);
 
     expect(result.thing).to.eql('stuff');
-    expect(result.password).to.not.eql('abc123');
-    expect(result.inner.a).to.not.eql('what');
+    expect(result.password).to.eql(_.redact());
+    expect(result.inner.a).to.eql(_.redact());
     expect(result.inner.a).to.be.ok();
     expect(result.inner.b).to.eql('yes');
   });
@@ -724,10 +724,10 @@ describe('scrub', function() {
     var result = _.scrub(data, [], scrubPaths);
 
     expect(result.a.b.bar).to.eql('stuff');
-    expect(result.a.b.foo).to.not.eql('secret');
+    expect(result.a.b.foo).to.eql(_.redact());
     expect(result.a.c).to.eql('bork');
-    expect(result.a.password).to.not.eql('abc123');
-    expect(result.secret).to.not.eql('blahblah');
+    expect(result.a.password).to.eql(_.redact());
+    expect(result.secret).to.eql(_.redact());
   });
 });
 


### PR DESCRIPTION
This PR adds `config.scrubPaths`, which allows scrubbing specific key locations by specifying the full path of the key. (When using `config.scrubFields`, all matching key names in the payload will be scrubbed regardless of location.)

Example:
```
config.scrubPaths = [
  'request.query_string',
  'client.javascript.plugins'
]
```

This makes it possible to scrub 'request.body', whereas adding 'body' to `config.scrubFields` would scrub every `body` key in the payload.

By adding `scrubPaths` as a separate key from `scrubFields`, fields that contain dots will still work and paths that don't (root keys) will also work.

This PR does not support paths that contain arrays. That can be added later if there is sufficient interest.
