### PR TITLE
Send error context as custom data

### DIFF
--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -19,6 +19,10 @@ function handleItemWithError(item, options, callback) {
   if (item.err) {
     try {
       item.stackInfo = item.err._savedStackTrace || errorParser.parse(item.err, item.skipFrames);
+
+      if (options.addErrorContext) {
+        addErrorContext(item);
+      }
     } catch (e) {
       logger.error('Error while parsing the error object.', e);
       try {
@@ -30,6 +34,20 @@ function handleItemWithError(item, options, callback) {
     }
   }
   callback(null, item);
+}
+
+function addErrorContext(item) {
+  var chain = [];
+  var err = item.err;
+
+  chain.push(err);
+
+  while (err.nested) {
+    err = err.nested;
+    chain.push(err);
+  }
+
+  _.addErrorContext(item, chain);
 }
 
 function ensureItemHasSomethingToSay(item, options, callback) {

--- a/src/react-native/transforms.js
+++ b/src/react-native/transforms.js
@@ -64,6 +64,10 @@ function handleItemWithError(item, options, callback) {
     return callback(null, item);
   }
 
+  if (options.addErrorContext) {
+    _.addErrorContext(item, [item.err]);
+  }
+
   var err = item.err;
   var parsedError = errorParser.parse(err);
   var guess = errorParser.guessErrorClass(parsedError.message);

--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -88,6 +88,10 @@ function handleItemWithError(item, options, callback) {
   } while (err !== undefined);
   item.stackInfo = chain;
 
+  if (options.addErrorContext) {
+    _.addErrorContext(item, errors);
+  }
+
   var cb = function(e) {
     if (e) {
       item.message = item.err.message || item.err.description || item.message || String(item.err);

--- a/src/utility.js
+++ b/src/utility.js
@@ -506,6 +506,27 @@ function setCustomItemKeys(item, custom) {
   }
 }
 
+function addErrorContext(item, errors) {
+  var custom = item.data.custom || {};
+  var contextAdded = false;
+
+  try {
+    for (var i = 0; i < errors.length; ++i) {
+      if (errors[i].hasOwnProperty('rollbarContext')) {
+        custom = merge(custom, errors[i].rollbarContext);
+        contextAdded = true;
+      }
+    }
+
+    // Avoid adding an empty object to the data.
+    if (contextAdded) {
+      item.data.custom = custom;
+    }
+  } catch (e) {
+    item.diagnostic.error_context = 'Failed: ' + e.message;
+  }
+}
+
 var TELEMETRY_TYPES = ['log', 'network', 'dom', 'navigation', 'error', 'manual'];
 var TELEMETRY_LEVELS = ['critical', 'error', 'warning', 'info', 'debug'];
 
@@ -776,6 +797,7 @@ function handleOptions(current, input, payload) {
 module.exports = {
   addParamsAndAccessTokenToPath: addParamsAndAccessTokenToPath,
   createItem: createItem,
+  addErrorContext: addErrorContext,
   createTelemetryEvent: createTelemetryEvent,
   filterIp: filterIp,
   formatArgsAsString: formatArgsAsString,

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -744,6 +744,33 @@ describe('log', function() {
     done();
   })
 
+  it('should add custom data when called with error context', function(done) {
+    var server = window.server;
+    stubResponse(server);
+    server.requests.length = 0;
+
+    var options = {
+      accessToken: 'POST_CLIENT_ITEM_TOKEN',
+      addErrorContext: true
+    };
+    var rollbar = window.rollbar = new Rollbar(options);
+
+    var err = new Error('test error');
+    err.rollbarContext = { err: 'test' };
+
+    rollbar.error(err, { 'foo': 'bar' });
+
+    server.respond();
+
+    var body = JSON.parse(server.requests[0].requestBody);
+
+    expect(body.data.body.trace.exception.message).to.eql('test error');
+    expect(body.data.custom.foo).to.eql('bar');
+    expect(body.data.custom.err).to.eql('test');
+
+    done();
+  })
+
   it('should send message when called with only null arguments', function(done) {
     var server = window.server;
     stubResponse(server);

--- a/test/browser.transforms.test.js
+++ b/test/browser.transforms.test.js
@@ -426,10 +426,28 @@ describe('addBody', function() {
         expect(i.stackInfo).to.be.ok();
       });
       t.addBody(item, options, function(e, i) {
-        console.log('body:', i.data.body)
         expect(i.data.body.trace_chain.length).to.eql(2);
         expect(i.data.body.trace_chain[0].exception.message).to.eql('test error');
         expect(i.data.body.trace_chain[1].exception.message).to.eql('nested error');
+        done(e);
+      });
+    });
+    it('should create add error context as custom data', function(done) {
+      var nestedErr = new Error('nested error');
+      nestedErr.rollbarContext = { err1: 'nested context' };
+      var err = new Error('test error');
+      err.rollbarContext = { err2: 'error context' };
+      err.nested = nestedErr;
+      var args = ['a message', err];
+      var item = itemFromArgs(args);
+      var options = { addErrorContext: true };
+      t.handleItemWithError(item, options, function(e, i) {
+        expect(i.stackInfo).to.be.ok();
+      });
+      t.addBody(item, options, function(e, i) {
+        expect(i.data.body.trace_chain.length).to.eql(2);
+        expect(i.data.custom.err1).to.eql('nested context');
+        expect(i.data.custom.err2).to.eql('error context');
         done(e);
       });
     });


### PR DESCRIPTION
Sometimes relevant debugging context is known at the time the error is thrown rather than at the time it is caught or reported. This PR enables detecting context data on the error object and merging it with the custom data in the Rollbar occurrence.

To use the feature:
* Set `options.addErrorContext = true`.
* Set `error.rollbarContext` with the data to be included in the custom data for the occurrence.

For trace chains, context data will be merged from any errors where it is present.