### PR TITLE
Remove debug from dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2052,6 +2052,7 @@
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -6157,7 +6158,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "async": "~1.2.1",
     "buffer-from": "~1.1.1",
     "console-polyfill": "0.3.0",
-    "debug": "2.6.9",
     "error-stack-parser": "^2.0.4",
     "json-stringify-safe": "~5.0.0",
     "lru-cache": "~2.2.1",


### PR DESCRIPTION
Since https://github.com/rollbar/rollbar.js/pull/473/ removed the use of `debug`, it doesn't seem like this package is still needed.