### PR TITLE
Support nested routes in the request data and context item payloads

### DIFF
--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -112,6 +112,8 @@ function addRequestData(item, options, callback) {
     return;
   }
 
+  var baseUrl = req.baseUrl || '';
+
   if (options.addRequestData && _.isFunction(options.addRequestData)) {
     options.addRequestData(item.data, req);
     callback(null, item);
@@ -122,11 +124,15 @@ function addRequestData(item, options, callback) {
   _.filterIp(requestData, options.captureIp);
   item.data.request = requestData;
 
+  var routePath;
+
   if (req.route) {
-    item.data.context = req.route.path;
+    routePath = req.route.path;
+    item.data.context = baseUrl && baseUrl.length ? baseUrl + routePath : routePath;
   } else {
     try {
-      item.data.context = req.app._router.matchRequest(req).path;
+      routePath = req.app._router.matchRequest(req).path;
+      item.data.context = baseUrl && baseUrl.length ? baseUrl + routePath : routePath;
     } catch (ignore) {
       // Ignored
     }
@@ -263,8 +269,10 @@ function _buildRequestData(req) {
   var host = headers.host || '<no host>';
   var proto = req.protocol || ((req.socket && req.socket.encrypted) ? 'https' : 'http' );
   var parsedUrl;
+  var baseUrl = req.baseUrl || '';
   if (_.isType(req.url, 'string')) {
-    parsedUrl = url.parse(req.url, true);
+    var fullUrl = baseUrl && baseUrl.length ? baseUrl + req.url : req.url
+    parsedUrl = url.parse(fullUrl, true);
   } else {
     parsedUrl = req.url || {};
   }

--- a/test/server.transforms.test.js
+++ b/test/server.transforms.test.js
@@ -508,6 +508,46 @@ vows.describe('transforms')
                   assert.equal(item.data.context, '/api/:bork');
                 },
               },
+              'with a request for a nested router with a baseURL': {
+                topic: function(options) {
+                  var item = {
+                    request: {
+                      headers: {
+                        host: 'example.com',
+                        'x-auth-token': '12345'
+                      },
+                      protocol: 'https',
+                      url: '/some/endpoint',
+                      baseUrl: '/nested',
+                      ip: '192.192.192.1',
+                      method: 'GET',
+                      body: {
+                        token: 'abc123',
+                        something: 'else'
+                      },
+                      route: { path: '/api/:bork' },
+                      user: {
+                        id: 42,
+                        email: 'fake@example.com'
+                      }
+                    },
+                    stuff: 'hey',
+                    data: {other: 'thing'}
+                  };
+                  t.addRequestData(item, options, this.callback);
+                },
+                'should not error': function(err, item) {
+                  assert.ifError(err);
+                },
+                'should have a request object inside data': function(err, item) {
+                  assert.ok(item.data.request);
+                },
+                'should set some fields based on request data': function(err, item) {
+                  var r = item.data.request;
+                  assert.equal(r.url, 'https://example.com/nested/some/endpoint');
+                  assert.equal(item.data.context, '/nested/api/:bork');
+                },
+              },
               'with a request like from hapi': {
                 topic: function(options) {
                   var item = {


### PR DESCRIPTION
Previously we only relied on the top URL provided by the request but failed to check if there was a base URL. This is often caused by using nested routers in libraries like express.js.

> Fixes https://github.com/rollbar/rollbar.js/issues/865

---

### Example
```javascript
const express = require('express');
const Rollbar = require('rollbar');
const rollbar = new Rollbar({
  accessToken: process.env.ROLLBAR_ACCESS_TOKEN,
  captureUncaught: true,
  captureUnhandledRejections: true
});

const app = express();

const topLevelRouter = express.Router({ mergeParams: true });

topLevelRouter.get('/:topLevelId', (req, res) => {
  rollbar.warn('test top level route', req);

  res.status(200).send({
    message: 'ok',
    topLevelId: req.params.topLevelId
  });
});

const nestedRouter = express.Router({ mergeParams: true });

nestedRouter.get('/:nestedId', (req, res) => {
  rollbar.warn('test nested route', req);

  res.status(200).send({
    message: 'ok',
    topLevelId: req.params.topLevelId,
    nestedId: req.params.nestedId
  });
});

topLevelRouter.use('/:topLevelId/nested', nestedRouter);
app.use('/top', topLevelRouter);

app.use(rollbar.errorHandler());

app.listen(3000, () => {
  console.log(`listening at http://localhost:3000`);
});
```


![Screen Shot 2020-07-08 at 11 12 22 AM](https://user-images.githubusercontent.com/8395995/86936391-f2c4b480-c10b-11ea-8117-fa98c5574b4d.png)
![Screen Shot 2020-07-08 at 11 12 30 AM](https://user-images.githubusercontent.com/8395995/86936393-f35d4b00-c10b-11ea-8fcc-6d8c4060f9dd.png)
