### PR TITLE
Add "addErrorContext" in config type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -41,6 +41,7 @@ declare namespace Rollbar {
     export type Level = "debug" | "info" | "warning" | "error" | "critical";
     export interface Configuration {
         accessToken?: string;
+        addErrorContext?: boolean;
         addRequestData?: (data: object, req: object) => void;
         autoInstrument?: AutoInstrumentOptions;
         captureEmail?: boolean;


### PR DESCRIPTION
PR #870 adds a new option, addErrorContext, which can be added to the configuration object when initializing Rollbar. This option will be included in the `Rollbar.Configuration` type in `index.d.ts`, to ensure people who type their configuration object to be able to use this option.

Fixes: #873 