### PR TITLE
Add ts definition for config.host in node/server env

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -58,6 +58,7 @@ declare namespace Rollbar {
         exitOnUncaughtException?: boolean;
         environment?: string;
         filterTelemetry?: (e: TelemetryEvent) => boolean;
+        host?: string; // used in node only
         hostBlackList?: string[];
         hostWhiteList?: string[];
         ignoredMessages?: string[];


### PR DESCRIPTION
From Clubhouse story (69341), PR makes `options.host` available in TypeScript. 

This is somewhat documented here. (Doc could be improved.)
https://docs.rollbar.com/docs/environments#recommended-usage

And is used here:
https://github.com/rollbar/rollbar.js/blob/master/src/server/transforms.js#L35