### PR TITLE
Allow non-native JSON functions when not using the polyfill

### DIFF
--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -12,6 +12,7 @@ var transforms = require('./transforms');
 var sharedTransforms = require('../transforms');
 var sharedPredicates = require('../predicates');
 var truncation = require('../truncation');
+var polyfillJSON = require('../../vendor/JSON-js/json3');
 
 function Rollbar(options, client) {
   if (_.isType(options, 'string')) {
@@ -31,7 +32,7 @@ function Rollbar(options, client) {
   this.client = client || new Client(this.options, api, logger, telemeter, 'react-native');
   addTransformsToNotifier(this.client.notifier);
   addPredicatesToQueue(this.client.queue);
-  _.setupJSON();
+  _.setupJSON(polyfillJSON);
 }
 
 var _instance = null;

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -16,6 +16,7 @@ var transforms = require('./transforms');
 var sharedTransforms = require('../transforms');
 var sharedPredicates = require('../predicates');
 var truncation = require('../truncation');
+var polyfillJSON = require('../../vendor/JSON-js/json3');
 
 function Rollbar(options, client) {
   if (_.isType(options, 'string')) {
@@ -42,7 +43,7 @@ function Rollbar(options, client) {
   addTransformsToNotifier(this.client.notifier);
   addPredicatesToQueue(this.client.queue);
   this.setupUnhandledCapture();
-  _.setupJSON();
+  _.setupJSON(polyfillJSON);
 }
 
 var _instance = null;

--- a/src/utility.js
+++ b/src/utility.js
@@ -1,23 +1,31 @@
 var merge = require('./merge');
 
 var RollbarJSON = {};
-var __initRollbarJSON = false;
 function setupJSON(polyfillJSON) {
-  if (__initRollbarJSON) {
+  if (isFunction(RollbarJSON.stringify) && isFunction(RollbarJSON.parse)) {
     return;
   }
-  __initRollbarJSON = true;
 
   if (isDefined(JSON)) {
-    if (isNativeFunction(JSON.stringify)) {
-      RollbarJSON.stringify = JSON.stringify;
-    }
-    if (isNativeFunction(JSON.parse)) {
-      RollbarJSON.parse = JSON.parse;
+    // If polyfill is provided, prefer it over existing non-native shims.
+    if(polyfillJSON) {
+      if (isNativeFunction(JSON.stringify)) {
+        RollbarJSON.stringify = JSON.stringify;
+      }
+      if (isNativeFunction(JSON.parse)) {
+        RollbarJSON.parse = JSON.parse;
+      }
+    } else { // else accept any interface that is present.
+      if (isFunction(JSON.stringify)) {
+        RollbarJSON.stringify = JSON.stringify;
+      }
+      if (isFunction(JSON.parse)) {
+        RollbarJSON.parse = JSON.parse;
+      }
     }
   }
   if (!isFunction(RollbarJSON.stringify) || !isFunction(RollbarJSON.parse)) {
-    polyfillJSON(RollbarJSON);
+    polyfillJSON && polyfillJSON(RollbarJSON);
   }
 }
 
@@ -691,6 +699,7 @@ module.exports = {
   merge: merge,
   now: now,
   redact: redact,
+  RollbarJSON: RollbarJSON,
   sanitizeUrl: sanitizeUrl,
   set: set,
   setupJSON: setupJSON,


### PR DESCRIPTION
## Description of the change
Fixes: https://github.com/rollbar/rollbar.js/issues/887

- [x] Previous behavior for `setupJSON` preferred the rollbar.js polyfill over any non-native functions for `JSON.parse` and `JSON.stringify`. However, when using the componentized package option and not including the polyfill, `setupJSON` should use the interface already set at `JSON.parse` and `JSON.stringify`, whether native or not.

- [x] The setup for Node and React Native now passes in the polyfill to `setupJSON`.

- [x] Tests added for each possible set of conditions for `setupJSON`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fixes: https://github.com/rollbar/rollbar.js/issues/887 , ch72254

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
