### PR TITLE
Add item and occurrence URL as tags to tracer

### DIFF
--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -188,6 +188,8 @@ Rollbar.prototype._addTracingInfo = function (item) {
       span.setTag('rollbar.error_uuid', item.uuid);
       span.setTag('rollbar.has_error', true);
       span.setTag('error', true);
+      span.setTag('rollbar.item_url', `https://rollbar.com/item/uuid/?uuid=${item.uuid}`);
+      span.setTag('rollbar.occurrence_url', `https://rollbar.com/occurrence/uuid/?uuid=${item.uuid}`);
 
       // add span ID & trace ID to occurrence
       var opentracingSpanId = span.context().toSpanId();


### PR DESCRIPTION
## Description of the change
Add a few extra tags to the tracer's span, providing direct links to the item and individual occurrence, using the URLs described [here](https://docs.rollbar.com/docs/uuids#using-a-uuid) to ease linkages between tracing views and rollbar.

Note: I didn't see any tests related to checking the tracer span itself since that's presumably up to the implementation of whatever tracer it is, so there were none to add/update, but if any extra tests seem necessary I can add them.

> Description here
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [X] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues
N/A

## Checklists

### Development

- [X] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
