### PR TITLE
Add call to set error tag to true

### DIFF
--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -187,6 +187,7 @@ Rollbar.prototype._addTracingInfo = function (item) {
     if (validateSpan(span)) {
       span.setTag('rollbar.error_uuid', item.uuid);
       span.setTag('rollbar.has_error', true);
+      span.setTag('error', true);
 
       // add span ID & trace ID to occurrence
       var opentracingSpanId = span.context().toSpanId();


### PR DESCRIPTION
## Description of the change

Add explicit call to `setTag('error', true)` tag in span.
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Request from LightStep
## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
