### PR TITLE
Network telemetry XHR response Content-Type fixes

### DIFF
--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -421,7 +421,7 @@ Instrumenter.prototype.captureNetwork = function(metadata, subtype, rollbarUUID)
 };
 
 Instrumenter.prototype.isJsonContentType = function(contentType) {
-  return (contentType && contentType.toLowerCase().includes('json')) ? true : false;
+  return (contentType && _.isType(contentType, 'string') && contentType.toLowerCase().includes('json')) ? true : false;
 }
 
 Instrumenter.prototype.scrubJson = function(json) {

--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -274,7 +274,7 @@ Instrumenter.prototype.instrumentNetwork = function() {
               if (body || headers) {
                 response = {};
                 if (body) {
-                  if (self.isJsonContentType(xhr.__rollbar_xhr.request_content_type)) {
+                  if (self.isJsonContentType(xhr.__rollbar_xhr.response_content_type)) {
                     response.body = self.scrubJson(body);
                   } else {
                     response.body = body;


### PR DESCRIPTION
## Description of the change

During network telemetry, the XHR response Content-Type header is used to determine whether the body is JSON and therefore parseable for scrubbing. This PR fixes two issues related to the Content-Type header:
* The type of the header value should be checked, and if the header value is not a string (e.g. 'application/json') it should be treated as unknown.
* The response Content-Type header (not the _request_ Content-Type header) should be checked when handling the response body.

This PR also improves the test cases for network telemetry by:
* Adding tests that cover the above conditions.
* Fixing an issue that prevented sinon stub responses from working correctly. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes ch73576
Fixes ch73612

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
