### PR TITLE
Improve error callback handling

### DIFF
--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -156,6 +156,9 @@ Rollbar.prototype._log = function (defaultLevel, item) {
     item.telemetryEvents = (this.telemeter && this.telemeter.copyEvents()) || [];
     this.notifier.log(item, callback);
   } catch (e) {
+    if (callback) {
+      callback(e);
+    }
     this.logger.error(e);
   }
 };

--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -86,7 +86,7 @@ function handleItemWithError(item, options, callback) {
   do {
     errors.push(err);
     err = err.nested;
-  } while (err !== undefined);
+  } while (err);
   item.stackInfo = chain;
 
   if (options.addErrorContext) {

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -857,6 +857,42 @@ describe('log', function() {
 
     done();
   })
+
+  it('should call the item callback on error', function(done) {
+    var server = window.server;
+    stubResponse(server);
+    server.requests.length = 0;
+
+    // Create an invalid tracer, in order to force an error in notifier._log()
+    var tracer = {
+      scope: function() {
+        return {
+          active: function() {
+            throw new Error('Test error');
+          }
+        }
+      }
+    };
+
+    var options = {
+      accessToken: 'POST_CLIENT_ITEM_TOKEN',
+      tracer: tracer
+    };
+    var rollbar = window.rollbar = new Rollbar(options);
+
+    var callbackCalled;
+    var callback = function(err) {
+      callbackCalled = err;
+    };
+
+    rollbar.log('test', callback);
+
+    server.respond();
+
+    expect(callbackCalled.message).to.eql('Test error');
+
+    done();
+  })
 });
 
 // Test direct call to onerror, as used in verification of browser js install.

--- a/test/server.transforms.test.js
+++ b/test/server.transforms.test.js
@@ -383,6 +383,28 @@ vows.describe('transforms')
                 assert.equal(trace_chain[1].exception.class, 'ReferenceError');
               }
             },
+            'with a null nested error': {
+              topic: function (options) {
+                var err = new CustomError('With null nested error');
+
+                // Set nested to null for the test
+                err.nested = null;
+
+                var item = {
+                  data: {body: {}},
+                  err: err
+                };
+                t.handleItemWithError(item, options, this.callback);
+              },
+              'should not error': function(err, item) {
+                assert.ifError(err);
+              },
+              'should have the right data in the trace_chain': function(err, item) {
+                var trace_chain = item.stackInfo;
+                assert.lengthOf(trace_chain, 1);
+                assert.equal(trace_chain[0].exception.class, 'CustomError');
+              }
+            },
             'with error context': {
               topic: function (options) {
                 var test = function() {


### PR DESCRIPTION
## Description of the change

This PR fixes two issues:
* Ensures the client callback is called fro errors caught in `Roolbar.client.log()`.
* When traversing nested errors, handles `null` value of `err.nested` rather than only `undefined`.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes ch74675
Fixes https://github.com/rollbar/rollbar.js/issues/898

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
