### PR TITLE
Enable node.js stack locals capture

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -67,6 +67,7 @@ declare namespace Rollbar {
         includeItemsInTelemetry?: boolean;
         inspectAnonymousErrors?: boolean;
         itemsPerMinute?: number;
+        locals?: boolean;
         logLevel?: Level;
         maxItems?: number;
         maxTelemetryEvents?: number;

--- a/src/server/locals.js
+++ b/src/server/locals.js
@@ -43,9 +43,7 @@ Locals.prototype.initSession = function() {
 }
 
 Locals.prototype.currentLocalsMap = function() {
-  if (Locals.currentErrors.size) {
-    return new Map(Locals.currentErrors);
-  }
+  return new Map(Locals.currentErrors);
 }
 
 Locals.prototype.mergeLocals = function(localsMap, stack, key, callback) {

--- a/src/server/locals.js
+++ b/src/server/locals.js
@@ -3,6 +3,10 @@ var inspector = require('inspector');
 var async = require('async');
 
 function Locals(config) {
+  if (!(this instanceof Locals)) {
+    return new Locals(config);
+  }
+
   this.config = config;
 
   this.initSession();

--- a/src/server/locals.js
+++ b/src/server/locals.js
@@ -1,0 +1,160 @@
+/* globals Map */
+var inspector = require('inspector');
+var async = require('async');
+
+function Locals(config) {
+  this.config = config;
+  this.errorCounter = 0;
+  this.currentErrors = new Map();
+
+  this.initSession();
+}
+
+Locals.prototype.initSession = function() {
+  this.session = new inspector.Session();
+  this.session.connect();
+
+  this.session.on('Debugger.paused', ({ params }) => {
+    if (params.reason == 'promiseRejection' || params.reason == 'exception') {
+      var key = params.data.description;
+      this.currentErrors.set(key, params);
+
+      if (this.currentErrors.size > 4) {
+        var firstKey = this.currentErrors.keys()[0];
+        this.currentErrors.delete(firstKey);
+      }
+    }
+  });
+
+  this.session.post('Debugger.enable', (_err, _result) => {
+    this.session.post('Debugger.setPauseOnExceptions', { state: 'all'}, (_err, _result) => {
+    });
+  });
+}
+
+Locals.prototype.currentLocalsMap = function() {
+  if (this.currentErrors.size) {
+    return new Map(this.currentErrors);
+  }
+}
+
+Locals.prototype.mergeLocals = function(localsMap, stack, key, callback) {
+  var matchedFrames;
+
+  try {
+    var localParams = localsMap.get(key);
+    matchedFrames = this.matchFrames(localParams, stack.slice().reverse());
+  } catch (e) {
+    return callback(e);
+  }
+
+  this.getLocalScopesForFrames(matchedFrames, function(err) {
+    callback(err);
+  });
+}
+
+// Finds frames in localParams that match file and line locations in stack.
+Locals.prototype.matchFrames = function(localParams, stack) {
+  var matchedFrames = [];
+  var localIndex = 0, stackIndex = 0;
+  var stackLength = stack.length;
+  var callFrames = localParams.callFrames;
+  var callFramesLength = callFrames.length;
+
+  for (; stackIndex < stackLength; stackIndex++) {
+    while (localIndex < callFramesLength) {
+      if (this.firstFrame(localIndex, stackIndex) || this.matchedFrame(callFrames[localIndex], stack[stackIndex])) {
+        matchedFrames.push({
+          stackLocation: stack[stackIndex],
+          callFrame: callFrames[localIndex]
+        });
+        localIndex++;
+        break;
+      } else {
+        localIndex++;
+      }
+    }
+  }
+
+  return matchedFrames;
+}
+
+Locals.prototype.firstFrame = function(localIndex, stackIndex) {
+  return !localIndex && !stackIndex;
+}
+
+Locals.prototype.matchedFrame = function(callFrame, stackLocation) {
+  if (!callFrame || !stackLocation) {
+    return false;
+  }
+
+  var position = stackLocation.runtimePosition;
+
+  // Node.js prefixes filename some URLs with 'file:///' in Debugger.callFrame,
+  // but with only '/' in the error.stack string. Remove the prefix to facilitate a match.
+  var callFrameUrl = callFrame.url.replace(/file:\/\//,'');
+
+  // lineNumber is zero indexed, so offset it.
+  var callFrameLine = callFrame.location.lineNumber + 1;
+  var callFrameColumn = callFrame.location.columnNumber;
+
+  return callFrameUrl === position.source &&
+    callFrameLine === position.line &&
+    callFrameColumn === position.column;
+}
+
+Locals.prototype.getLocalScopesForFrames = function(matchedFrames, callback) {
+  async.each(matchedFrames, this.getLocalScopeForFrame.bind(this), function (err) {
+    callback(err);
+  });
+}
+
+Locals.prototype.getLocalScopeForFrame = function(matchedFrame, callback) {
+  var scopes = matchedFrame.callFrame.scopeChain;
+
+  var _this = this;
+  for (var i = 0; i < scopes.length; i++) {
+    var scope = scopes[i]
+    if (scope.type === 'local') {
+      this.getProperties(scope.object.objectId, function(err, response){
+        if (err) {
+          return callback(err);
+        }
+
+        var locals = response.result;
+        matchedFrame.stackLocation.locals = {};
+        for (var local of locals) {
+          matchedFrame.stackLocation.locals[local.name] = _this.getLocalValue(local);
+        }
+
+        callback(null);
+      });
+    }
+  }
+}
+
+Locals.prototype.getLocalValue = function(local) {
+  var value;
+
+  switch (local.value.type) {
+    case 'undefined': value = 'undefined'; break;
+    case 'object': value = this.getObjectValue(local); break;
+    default: value = local.value.value; break;
+  }
+
+  return value;
+}
+
+Locals.prototype.getObjectValue = function(local) {
+  if (local.value.className) {
+    return '<' + local.value.className + ' object>'
+  } else {
+    return '<object>'
+  }
+}
+
+Locals.prototype.getProperties = function(objectId, callback) {
+  this.session.post('Runtime.getProperties', { objectId : objectId, ownProperties: true }, callback);
+}
+
+module.exports = Locals;

--- a/src/server/locals.js
+++ b/src/server/locals.js
@@ -124,24 +124,25 @@ function getLocalScopesForFrames(matchedFrames, callback) {
 function getLocalScopeForFrame(matchedFrame, callback) {
   var scopes = matchedFrame.callFrame.scopeChain;
 
-  for (var i = 0; i < scopes.length; i++) {
-    var scope = scopes[i]
-    if (scope.type === 'local') {
-      getProperties(scope.object.objectId, function(err, response){
-        if (err) {
-          return callback(err);
-        }
+  var scope = scopes.find(scope => scope.type === 'local');
 
-        var locals = response.result;
-        matchedFrame.stackLocation.locals = {};
-        for (var local of locals) {
-          matchedFrame.stackLocation.locals[local.name] = getLocalValue(local);
-        }
-
-        callback(null);
-      });
-    }
+  if (!scope) {
+    return callback(null); // Do nothing return success.
   }
+
+  getProperties(scope.object.objectId, function(err, response){
+    if (err) {
+      return callback(err);
+    }
+
+    var locals = response.result;
+    matchedFrame.stackLocation.locals = {};
+    for (var local of locals) {
+      matchedFrame.stackLocation.locals[local.name] = getLocalValue(local);
+    }
+
+    callback(null);
+  });
 }
 
 function getLocalValue(local) {

--- a/test/fixtures/locals.fixtures.js
+++ b/test/fixtures/locals.fixtures.js
@@ -162,6 +162,99 @@ var localsFixtures = {
         uncaught: true
       },
       hitBreakpoints: []
+    },
+    noLocalScope: {
+      callFrames: [
+        { callFrameId: '{"ordinal":0,"injectedScriptId":1}',
+          functionName: '',
+          functionLocation: { scriptId: '121', lineNumber: 24, columnNumber: 12 },
+          location: { scriptId: '121', lineNumber: 28, columnNumber: 16 },
+          url: '/example/test/locals2.js',
+          scopeChain: [
+            { type: 'global',
+              object: {
+                type: 'object',
+                className: 'global',
+                description: 'global',
+                objectId: '{"injectedScriptId":1,"id":41}'
+              }
+            },
+            { type: 'closure',
+              object: {
+                type: 'object',
+                className: 'Object',
+                description: 'Object',
+                objectId: '{"injectedScriptId":1,"id":44}'
+              },
+              startLocation: { scriptId: '121', lineNumber: 0, columnNumber: 0 },
+              endLocation: { scriptId: '121', lineNumber: 219, columnNumber: 34 }
+            },
+          ]
+        },
+        { callFrameId: '{"ordinal":0,"injectedScriptId":1}',
+          functionName: '',
+          // functionLocation should not be used for matching. Set to a non-matching value.
+          functionLocation: { scriptId: '121', lineNumber: 136, columnNumber: 1 },
+          location: { scriptId: '121', lineNumber: 139, columnNumber: 14 },
+          url: 'file:///example/test/locals3.js', // The `file://` prefix may be present.
+          scopeChain: [
+            { type: 'global',
+              object: {
+                type: 'object',
+                className: 'global',
+                description: 'global',
+                objectId: '{"injectedScriptId":1,"id":41}'
+              }
+            },
+            { type: 'closure',
+              object: {
+                type: 'object',
+                className: 'Object',
+                description: 'Object',
+                objectId: '{"injectedScriptId":1,"id":44}'
+              },
+              startLocation: { scriptId: '121', lineNumber: 0, columnNumber: 0 },
+              endLocation: { scriptId: '121', lineNumber: 219, columnNumber: 34 }
+            },
+          ]
+        },
+        { callFrameId: '{"ordinal":0,"injectedScriptId":1}',
+          functionName: '',
+          functionLocation: { scriptId: '121', lineNumber: 128, columnNumber: 1 },
+          location: { scriptId: '121', lineNumber: 132, columnNumber: 34 },
+          url: 'file:///example/test/locals4.js',
+          scopeChain: [
+            { type: 'global',
+              object: {
+                type: 'object',
+                className: 'global',
+                description: 'global',
+                objectId: '{"injectedScriptId":1,"id":41}'
+              }
+            },
+            { type: 'closure',
+              object: {
+                type: 'object',
+                className: 'Object',
+                description: 'Object',
+                objectId: '{"injectedScriptId":1,"id":44}'
+              },
+              startLocation: { scriptId: '121', lineNumber: 0, columnNumber: 0 },
+              endLocation: { scriptId: '121', lineNumber: 219, columnNumber: 34 }
+            },
+          ]
+        }
+      ],
+      reason: 'exception',
+      data: {
+        type: 'object',
+        subtype: 'error',
+        className: 'Error',
+        description: 'Error: node error',
+        objectId: '{"injectedScriptId":1,"id":1}',
+        uncaught: true
+      },
+      hitBreakpoints: []
     }
   },
 

--- a/test/fixtures/locals.fixtures.js
+++ b/test/fixtures/locals.fixtures.js
@@ -1,0 +1,294 @@
+'use strict';
+
+var localsFixtures = {
+  maps: {
+    // simple map includes only the local scope and a single stack frame.
+    simple: {
+      callFrames: [
+        { callFrameId: '{"ordinal":0,"injectedScriptId":1}',
+          functionName: '',
+          functionLocation: { scriptId: '121', lineNumber: 24, columnNumber: 12 },
+          location: { scriptId: '121', lineNumber: 28, columnNumber: 16 },
+          url: 'file:///example/test/locals1.js',
+          scopeChain: [
+            { type: 'local',
+              object: {
+                type: 'object',
+                className: 'Object',
+                description: 'Object',
+                objectId: 'objectId1' // Used to query locals from getProperties
+              },
+              name: 'nodeThrowNested',
+              startLocation: { scriptId: '121', lineNumber: 40, columnNumber: 30 },
+              endLocation: { scriptId: '121', lineNumber: 57, columnNumber: 1 }
+            }
+          ]
+        }
+      ],
+      reason: 'exception',
+      data: {
+        type: 'object',
+        subtype: 'error',
+        className: 'Error',
+        description: 'Error: node error',
+        objectId: '{"injectedScriptId":1,"id":1}',
+        uncaught: true
+      },
+      hitBreakpoints: []
+    },
+    // complex map includes multiple scopes and multiple stack frames.
+    complex: {
+      callFrames: [
+        { callFrameId: '{"ordinal":0,"injectedScriptId":1}',
+          functionName: '',
+          functionLocation: { scriptId: '121', lineNumber: 24, columnNumber: 12 },
+          location: { scriptId: '121', lineNumber: 28, columnNumber: 16 },
+          url: '/example/test/locals2.js',
+          scopeChain: [
+            { type: 'global',
+              object: {
+                type: 'object',
+                className: 'global',
+                description: 'global',
+                objectId: '{"injectedScriptId":1,"id":41}'
+              }
+            },
+            { type: 'local',
+              object: {
+                type: 'object',
+                className: 'Object',
+                description: 'Object',
+                objectId: 'objectId1' // Used to query locals from getProperties
+              },
+              name: 'nodeThrowNested',
+              startLocation: { scriptId: '121', lineNumber: 40, columnNumber: 30 },
+              endLocation: { scriptId: '121', lineNumber: 57, columnNumber: 1 }
+            },
+            { type: 'closure',
+              object: {
+                type: 'object',
+                className: 'Object',
+                description: 'Object',
+                objectId: '{"injectedScriptId":1,"id":44}'
+              },
+              startLocation: { scriptId: '121', lineNumber: 0, columnNumber: 0 },
+              endLocation: { scriptId: '121', lineNumber: 219, columnNumber: 34 }
+            },
+          ]
+        },
+        { callFrameId: '{"ordinal":0,"injectedScriptId":1}',
+          functionName: '',
+          // functionLocation should not be used for matching. Set to a non-matching value.
+          functionLocation: { scriptId: '121', lineNumber: 136, columnNumber: 1 },
+          location: { scriptId: '121', lineNumber: 139, columnNumber: 14 },
+          url: 'file:///example/test/locals3.js', // The `file://` prefix may be present.
+          scopeChain: [
+            { type: 'global',
+              object: {
+                type: 'object',
+                className: 'global',
+                description: 'global',
+                objectId: '{"injectedScriptId":1,"id":41}'
+              }
+            },
+            { type: 'local',
+              object: {
+                type: 'object',
+                className: 'Object',
+                description: 'Object',
+                objectId: 'objectId2' // Used to query locals from getProperties
+              },
+              name: 'nodeThrowNested',
+              startLocation: { scriptId: '121', lineNumber: 40, columnNumber: 30 },
+              endLocation: { scriptId: '121', lineNumber: 57, columnNumber: 1 }
+            },
+            { type: 'closure',
+              object: {
+                type: 'object',
+                className: 'Object',
+                description: 'Object',
+                objectId: '{"injectedScriptId":1,"id":44}'
+              },
+              startLocation: { scriptId: '121', lineNumber: 0, columnNumber: 0 },
+              endLocation: { scriptId: '121', lineNumber: 219, columnNumber: 34 }
+            },
+          ]
+        },
+        { callFrameId: '{"ordinal":0,"injectedScriptId":1}',
+          functionName: '',
+          functionLocation: { scriptId: '121', lineNumber: 128, columnNumber: 1 },
+          location: { scriptId: '121', lineNumber: 132, columnNumber: 34 },
+          url: 'file:///example/test/locals4.js',
+          scopeChain: [
+            { type: 'global',
+              object: {
+                type: 'object',
+                className: 'global',
+                description: 'global',
+                objectId: '{"injectedScriptId":1,"id":41}'
+              }
+            },
+            { type: 'local',
+              object: {
+                type: 'object',
+                className: 'Object',
+                description: 'Object',
+                objectId: 'objectId3' // Used to query locals from getProperties
+              },
+              name: 'nodeThrowNested',
+              startLocation: { scriptId: '121', lineNumber: 40, columnNumber: 30 },
+              endLocation: { scriptId: '121', lineNumber: 57, columnNumber: 1 }
+            },
+            { type: 'closure',
+              object: {
+                type: 'object',
+                className: 'Object',
+                description: 'Object',
+                objectId: '{"injectedScriptId":1,"id":44}'
+              },
+              startLocation: { scriptId: '121', lineNumber: 0, columnNumber: 0 },
+              endLocation: { scriptId: '121', lineNumber: 219, columnNumber: 34 }
+            },
+          ]
+        }
+      ],
+      reason: 'exception',
+      data: {
+        type: 'object',
+        subtype: 'error',
+        className: 'Error',
+        description: 'Error: node error',
+        objectId: '{"injectedScriptId":1,"id":1}',
+        uncaught: true
+      },
+      hitBreakpoints: []
+    }
+  },
+
+  stacks: {
+    simple: [
+      { method: 'Timeout._onTimeout',
+        filename: '/example/test/locals1.js',
+        lineno: 29,
+        colno: 16,
+        runtimePosition: {
+          source: '/example/test/locals1.js',
+          line: 29,
+          column: 16
+        }
+      }
+    ],
+    // The stack order presented by Rollbar.js is reversed.
+    complex: [
+      { method: 'Method1',
+        filename: '/example/test/locals4.js',
+        lineno: 133,
+        colno: 34,
+        runtimePosition: {
+          source: '/example/test/locals4.js',
+          line: 133,
+          column: 34
+        }
+      },
+      { method: 'Method2',
+        filename: '/example/test/locals3.ts',
+        lineno: 120,
+        colno: 40,
+        // Runtime location is transpiled, with different filename and location
+        runtimePosition: {
+          source: '/example/test/locals3.js',
+          line: 140,
+          column: 14
+        }
+      },
+      { method: 'Method3',
+        filename: '/example/test/locals2.js',
+        lineno: 13,
+        colno: 26,
+        runtimePosition: {
+          source: '/example/test/locals2.js',
+          line: 13,
+          column: 26
+        }
+      }
+    ]
+  },
+
+  locals: {
+    object1: {
+      name: 'foo',
+      value: {
+        type: 'object',
+        className: 'FooClass',
+        description: 'FooClass',
+        objectId: '{"injectedScriptId":1,"id":48}'
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+      isOwn: true
+    },
+    object2: {
+      name: 'bar',
+      value: {
+        type: 'object',
+        className: 'BarClass',
+        description: 'BarClass',
+        objectId: '{"injectedScriptId":1,"id":48}'
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+      isOwn: true
+    },
+    boolean1: {
+      name: 'old',
+      value: {
+        type: 'boolean',
+        value: false
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+      isOwn: true
+    },
+    boolean2: {
+      name: 'new',
+      value: {
+        type: 'boolean',
+        value: true
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+      isOwn: true
+    },
+    string1: {
+      name: 'response',
+      value: {
+        type: 'string',
+        value: 'success'
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+      isOwn: true
+    },
+    array1: {
+      name: 'args',
+      value: {
+        type: 'array',
+        subtype: 'array',
+        className: 'Array',
+        description: 'Array(1)',
+        objectId: '{"injectedScriptId":1,"id":54}'
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+      isOwn: true
+    }
+  }
+}
+
+module.exports = localsFixtures;

--- a/test/server.locals.test.js
+++ b/test/server.locals.test.js
@@ -412,4 +412,22 @@ vows.describe('locals')
       }
     }
   })
+  .addBatch({
+    'currentLocalsMap called with no local scopes in map': {
+      topic: function() {
+        var locals = new Locals();
+
+        // Ensure empty map, as vows uses the same class object between tests.
+        Locals.currentErrors = new Map();
+
+        return locals;
+      },
+      'should return empty map': function(locals) {
+        var localsMap = locals.currentLocalsMap();
+
+        assert.instanceOf(localsMap, Map);
+        assert.equal(localsMap.size, 0);
+      }
+    }
+  })
   .export(module, {error: false});

--- a/test/server.locals.test.js
+++ b/test/server.locals.test.js
@@ -364,4 +364,52 @@ vows.describe('locals')
       }
     }
   })
+  .addBatch({
+    'mergeLocals called with no local scopes in map': {
+      topic: function() {
+        var getPropertiesResponses = {
+          objectId1: [
+            localsFixtures.locals.object1,
+            localsFixtures.locals.object2,
+          ],
+          objectId2: [
+            localsFixtures.locals.boolean1,
+            localsFixtures.locals.boolean2,
+          ],
+          objectId3: [
+            localsFixtures.locals.string1,
+            localsFixtures.locals.array1,
+          ],
+        }
+
+        var locals = new Locals();
+        sinon.stub(Locals.session, 'post').callsFake(fakeSessionPostHandler(getPropertiesResponses));
+
+        var key = 'key';
+        var localsMap = new Map();
+
+        localsMap.set(key, localsFixtures.maps.noLocalScope);
+
+        var stack = cloneStack(localsFixtures.stacks.complex);
+
+        var self = this;
+        locals.mergeLocals(localsMap, stack, key, function(err) {
+          self.callback(err, stack);
+        });
+      },
+      'should succeed without merged locals': function(err, stack) {
+        if (err) {
+          // Ensure unexpected error can be seen.
+          console.log(err);
+        }
+        assert.isNull(err);
+
+        assert.equal(stack[0].locals, undefined);
+        assert.equal(stack[1].locals, undefined);
+        assert.equal(stack[2].locals, undefined);
+
+        sinon.restore();
+      }
+    }
+  })
   .export(module, {error: false});

--- a/test/server.locals.test.js
+++ b/test/server.locals.test.js
@@ -1,0 +1,171 @@
+'use strict';
+
+var assert = require('assert');
+var vows = require('vows');
+var sinon = require('sinon');
+
+process.env.NODE_ENV = process.env.NODE_ENV || 'test-node-env';
+var Rollbar = require('../src/server/rollbar');
+var Locals = require('../src/server/locals');
+
+var nodeMajorVersion = process.versions.node.split('.')[0];
+
+async function wait(ms) {
+  return new Promise(resolve => {
+    setTimeout(resolve, ms);
+  });
+}
+
+async function promiseReject(rollbar, callback) {
+  var error = new Error('promise reject');
+
+  Promise.reject(error);
+  await wait(500);
+  callback(rollbar);
+}
+
+async function nodeThrow(rollbar, callback) {
+  setTimeout(function () {
+    var error = new Error('node error');
+    throw error;
+  }, 1);
+  await wait(500);
+  callback(rollbar);
+}
+
+function nestedError(nestedMessage, _password) {
+  var nestedError = new Error(nestedMessage);
+  throw(nestedError);
+}
+
+async function nodeThrowNested(rollbar, callback) {
+  setTimeout(function () {
+    var message = 'test error';
+    var password = '123456';
+    var err = new Error(message);
+
+    try {
+      var newMessage = 'nested ' + message;
+      nestedError(newMessage, password)
+    } catch (e) {
+      err.nested = e;
+    }
+
+    throw err;
+  }, 1);
+  await wait(500);
+  callback(rollbar);
+}
+
+vows.describe('locals')
+  .addBatch({
+    'on exception': {
+      'uncaught': {
+        topic: function() {
+          var rollbar = new Rollbar({
+            accessToken: 'abc123',
+            captureUncaught: true,
+            locals: true
+          });
+          var notifier = rollbar.client.notifier;
+          rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+          nodeThrow(rollbar, this.callback);
+        },
+        'should include locals': function(r) {
+          var addItemStub = r.addItemStub;
+
+          assert.isTrue(addItemStub.called);
+          var data = addItemStub.getCall(0).args[3].data;
+          assert.equal(data.body.trace_chain[0].exception.message, 'node error');
+          if (nodeMajorVersion < 10) {
+            // Node 8; locals disabled
+            var length = data.body.trace_chain[0].frames.length;
+            assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+            assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+          } else {
+            var length = data.body.trace_chain[0].frames.length;
+            assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
+            assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
+          }
+          addItemStub.reset();
+          Locals.session = undefined;
+        },
+        'nested': {
+          topic: function() {
+            var rollbar = new Rollbar({
+              accessToken: 'abc123',
+              captureUncaught: true,
+              locals: true
+            });
+            var notifier = rollbar.client.notifier;
+            rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+            nodeThrowNested(rollbar, this.callback);
+          },
+          'should include locals': function(r) {
+            var addItemStub = r.addItemStub;
+
+            assert.isTrue(addItemStub.called);
+            var data = addItemStub.getCall(0).args[3].data;
+            assert.equal(data.body.trace_chain[0].exception.message, 'test error');
+            assert.equal(data.body.trace_chain[1].exception.message, 'nested test error');
+            if (nodeMajorVersion < 10) {
+              // Node 8; locals disabled
+              var length = data.body.trace_chain[0].frames.length;
+              assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+              assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+            } else {
+              var length = data.body.trace_chain[0].frames.length;
+              assert.equal(data.body.trace_chain[0].frames[length-1].locals.err, '<Error object>');
+              assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
+
+              length = data.body.trace_chain[1].frames.length;
+              assert.equal(data.body.trace_chain[1].frames[length-1].locals.nestedMessage, 'nested test error');
+              assert.equal(data.body.trace_chain[1].frames[length-1].locals.nestedError, '<Error object>');
+              assert.equal(data.body.trace_chain[1].frames[length-2].locals.message, 'test error');
+              assert.equal(data.body.trace_chain[1].frames[length-2].locals.password, '********');
+              assert.equal(data.body.trace_chain[1].frames[length-2].locals.err, '<Error object>');
+              assert.equal(data.body.trace_chain[1].frames[length-2].locals.newMessage, 'nested test error');
+            }
+            addItemStub.reset();
+            Locals.session = undefined;
+          },
+          'promise rejection': {
+            topic: function() {
+              var rollbar = new Rollbar({
+                accessToken: 'abc123',
+                captureUnhandledRejections: true,
+                locals: true
+              });
+              var notifier = rollbar.client.notifier;
+              rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+              promiseReject(rollbar, this.callback);
+            },
+            'should include locals': function(r) {
+              var addItemStub = r.addItemStub;
+
+              assert.isTrue(addItemStub.called);
+              var data = addItemStub.getCall(0).args[3].data;
+              assert.equal(data.body.trace_chain[0].exception.message, 'promise reject');
+              if (nodeMajorVersion < 10) {
+                // Node 8; locals disabled
+                var length = data.body.trace_chain[0].frames.length;
+                assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+                assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+              } else {
+                var length = data.body.trace_chain[0].frames.length;
+                assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
+                assert.equal(data.body.trace_chain[0].frames[length-1].locals.rollbar, '<Rollbar object>');
+                assert.equal(data.body.trace_chain[0].frames[length-2].locals.notifier, '<Notifier object>');
+                assert.equal(data.body.trace_chain[0].frames[length-2].locals.rollbar, '<Rollbar object>');
+              }
+              addItemStub.reset();
+              Locals.session = undefined;
+            },
+          }
+        }
+      },
+    }
+  }).export(module, {error: false});

--- a/test/server.rollbar.test.js
+++ b/test/server.rollbar.test.js
@@ -459,6 +459,9 @@ vows.describe('rollbar')
 
           nodeThrow(rollbar, this.callback);
         },
+        'should have locals disabled': function(r) {
+          assert.equal(r.client.notifier.locals, undefined);
+        },
         'should log': function(r) {
           var logStub = r.logStub;
 


### PR DESCRIPTION
## Description of the change

Enables capture of local stack variables in Node.js. To enable, set `locals: true` in the config.

This feature uses the Node Inspector API to access debugger data at runtime. The Inspector API is a wrapper for the V8 Inspector interface. While the V8 interface relies on `send()` and `receive()` functions that can't be accessed from Node, the Node Inspector API provides access to these via the `post()` method on the Inspector Session instance. Using `session.post()`, all of the DevTools protocol can be accessed, including the `Debugger` and `Runtime` interfaces, which are used here.

The initial version of this feature supports both caught and uncaught exceptions and promise rejections. Nested exceptions and trace chains are supported.

The DevTools protocol allows retrieving nested variables to an arbitrary depth. However, the initial version of this feature only implements the equivalent of depth = 0. A future PR may enable arbitrary depth with a config option to set the depth.

Unexpanded objects are identified by their class, in keeping with the example in the Rollbar API docs. (https://explorer.docs.rollbar.com/#tag/Item)

Example:
```
trace: {
  frames: [
    {
      // ...
      locals: {
        foo: 'bar', // immediate string value
        obj: '<Foo object>' // instance of Foo
      }
    }
  ]
}
```

The feature is enabled for Node 10+. Node 8 doesn't implement the `url` property on the `CallFrame` object, and cannot reliably resolve to the correct locations in the stack. (There may be a workaround, but none that I know at this time.)

This PR adheres to the established style of Rollbar.js and uses `var` declarations, rather than `let` and `const`. ES5 style classes are used. I'm not sure whether `session.post()` supports async/await. Regardless, callbacks are used throughout as shared code that cannot be made async prevents the use of async/await in this code path.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes: ch74679

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [x] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
