### PR TITLE
Enable reporting for CSP errors

### DIFF
--- a/examples/csp-errors.html
+++ b/examples/csp-errors.html
@@ -1,0 +1,10 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Generate CSP error for test automation</title>
+  <script src="https://example.com/v3/"></script>
+</head>
+<body>
+</body>
+</html>

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -59,6 +59,16 @@ module.exports = function (config) {
       '/examples/': '/base/examples/'
     },
 
+    customHeaders: [
+      // Allow CSP error testing, but leave enough enabled so that karma
+      // can still run correctly.
+      {
+        match: '\\.html',
+        name: 'Content-Security-Policy',
+        value: "default-src 'self' 'unsafe-inline' 'unsafe-eval';"
+      }
+    ],
+
     reporters: ['progress'],
 
     singleRun: true,


### PR DESCRIPTION
## Description of the change

Browsers use Content Security Policy directives (provided in the HTTP response header, or in a meta tag) to govern what resources can and can't be loaded. When an attempt to load a resource is blocked, an error is written to the dev console, but no exception is thrown. Instead, the browser sends a `contentsecuritypolicy` event.

This PR listens for these events and records the error as a telemetry event, and if `errorOnContentSecurityPolicy` is set, sends a Rollbar error occurrence.

To enable/disable the feature, use these `autoInstrument` flags:
```
config.autoInstrument = {
  contentSecurityPolicy: true, // enables telemetry tracking, enabled by default
  errorOnContentSecurityPolicy: true // send a Rollbar error message, disabled by default
}
```

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes: ch72648

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
