### PR TITLE
Deprecate whitelist/blacklist in favor of safelist/blocklist

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -14,7 +14,7 @@ var sharedPredicates = require('../predicates');
 var errorParser = require('../errorParser');
 
 function Rollbar(options, client) {
-  this.options = _.handleOptions(defaultOptions, options);
+  this.options = _.handleOptions(defaultOptions, options, null, logger);
   this.options._configuredOptions = options;
   var Telemeter = this.components.telemeter;
   var Instrumenter = this.components.instrumenter;
@@ -84,7 +84,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
   if (payloadData) {
     payload = {payload: payloadData};
   }
-  this.options = _.handleOptions(oldOptions, options, payload);
+  this.options = _.handleOptions(oldOptions, options, payload, logger);
   this.options._configuredOptions = _.handleOptions(oldOptions._configuredOptions, options, payload);
   this.client.configure(this.options, payloadData);
   this.instrumenter && this.instrumenter.configure(this.options);
@@ -511,8 +511,8 @@ function addPredicatesToQueue(queue) {
     .addPredicate(sharedPredicates.checkLevel)
     .addPredicate(predicates.checkIgnore)
     .addPredicate(sharedPredicates.userCheckIgnore(logger))
-    .addPredicate(sharedPredicates.urlIsNotBlacklisted(logger))
-    .addPredicate(sharedPredicates.urlIsWhitelisted(logger))
+    .addPredicate(sharedPredicates.urlIsNotBlockListed(logger))
+    .addPredicate(sharedPredicates.urlIsSafeListed(logger))
     .addPredicate(sharedPredicates.messageIsIgnored(logger));
 }
 

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -20,7 +20,7 @@ function Rollbar(options, client) {
     options = {};
     options.accessToken = accessToken;
   }
-  this.options = _.handleOptions(Rollbar.defaultOptions, options);
+  this.options = _.handleOptions(Rollbar.defaultOptions, options, null, logger);
   this.options._configuredOptions = options;
   // This makes no sense in a long running app
   delete this.options.maxItems;
@@ -70,7 +70,7 @@ Rollbar.prototype.configure = function(options, payloadData) {
   if (payloadData) {
     payload = {payload: payloadData};
   }
-  this.options = _.handleOptions(oldOptions, options, payload);
+  this.options = _.handleOptions(oldOptions, options, payload, logger);
   this.options._configuredOptions = _.handleOptions(oldOptions._configuredOptions, options, payload);
   this.client.configure(options, payloadData);
   return this;

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -28,7 +28,7 @@ function Rollbar(options, client) {
     options.reportLevel = options.minimumLevel;
     delete options.minimumLevel;
   }
-  this.options = _.handleOptions(Rollbar.defaultOptions, options);
+  this.options = _.handleOptions(Rollbar.defaultOptions, options, null, logger);
   this.options._configuredOptions = options;
   // On the server we want to ignore any maxItems setting
   delete this.options.maxItems;
@@ -84,7 +84,7 @@ Rollbar.prototype.configure = function (options, payloadData) {
   if (payloadData) {
     payload = { payload: payloadData };
   }
-  this.options = _.handleOptions(oldOptions, options, payload);
+  this.options = _.handleOptions(oldOptions, options, payload, logger);
   this.options._configuredOptions = _.handleOptions(oldOptions._configuredOptions, options, payload);
   // On the server we want to ignore any maxItems setting
   delete this.options.maxItems;
@@ -512,8 +512,8 @@ function addPredicatesToQueue(queue) {
   queue
     .addPredicate(sharedPredicates.checkLevel)
     .addPredicate(sharedPredicates.userCheckIgnore(logger))
-    .addPredicate(sharedPredicates.urlIsNotBlacklisted(logger))
-    .addPredicate(sharedPredicates.urlIsWhitelisted(logger))
+    .addPredicate(sharedPredicates.urlIsNotBlockListed(logger))
+    .addPredicate(sharedPredicates.urlIsSafeListed(logger))
     .addPredicate(sharedPredicates.messageIsIgnored(logger));
 }
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -665,8 +665,9 @@ function filterIp(requestData, captureIp) {
   requestData['user_ip'] = newIp;
 }
 
-function handleOptions(current, input, payload) {
+function handleOptions(current, input, payload, logger) {
   var result = merge(current, input, payload);
+  result = updateDeprecatedOptions(result, logger);
   if (!input || input.overwriteScrubFields) {
     return result;
   }
@@ -674,6 +675,20 @@ function handleOptions(current, input, payload) {
     result.scrubFields = (current.scrubFields || []).concat(input.scrubFields);
   }
   return result;
+}
+
+function updateDeprecatedOptions(options, logger) {
+  if(options.hostWhiteList && !options.hostSafeList) {
+    options.hostSafeList = options.hostWhiteList;
+    options.hostWhiteList = undefined;
+    logger && logger.log('hostWhiteList is deprecated. Use hostSafeList.');
+  }
+  if(options.hostBlackList && !options.hostBlockList) {
+    options.hostBlockList = options.hostBlackList;
+    options.hostBlackList = undefined;
+    logger && logger.log('hostBlackList is deprecated. Use hostBlockList.');
+  }
+  return options;
 }
 
 module.exports = {

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -140,6 +140,21 @@ describe('Rollbar()', function() {
     done();
   });
 
+  it ('should replace deprecated options', function(done) {
+    var client = new (TestClientGen())();
+    var options = {
+      hostWhiteList: ['foo'],
+      hostBlackList: ['bar']
+    };
+    var rollbar = window.rollbar = new Rollbar(options, client);
+
+    expect(rollbar.options.hostWhiteList).to.eql(undefined);
+    expect(rollbar.options.hostBlackList).to.eql(undefined);
+    expect(rollbar.options.hostSafeList).to.contain('foo');
+    expect(rollbar.options.hostBlockList).to.contain('bar');
+    done();
+  });
+
   it('should return a uuid when logging', function(done) {
     var client = new (TestClientGen())();
     var options = {};
@@ -252,6 +267,21 @@ describe('configure', function() {
     expect(rollbar.options.somekey).to.eql('borkbork');
     expect(rollbar.options.payload.b).to.eql(97);
     expect(client.payloadData.b).to.eql(97);
+    done();
+  });
+  it ('should replace deprecated options', function(done) {
+    var client = new (TestClientGen())();
+    var options = {
+      hostWhiteList: ['foo'],
+      hostBlackList: ['bar']
+    };
+    var rollbar = window.rollbar = new Rollbar({ autoInstrument: false }, client);
+    rollbar.configure(options);
+
+    expect(rollbar.options.hostWhiteList).to.eql(undefined);
+    expect(rollbar.options.hostBlackList).to.eql(undefined);
+    expect(rollbar.options.hostSafeList).to.contain('foo');
+    expect(rollbar.options.hostBlockList).to.contain('bar');
     done();
   });
   it('should store configured options', function(done) {

--- a/test/predicates.test.js
+++ b/test/predicates.test.js
@@ -53,7 +53,7 @@ describe('userCheckIgnore', function() {
   });
 });
 
-describe('urlIsWhitelisted', function() {
+describe('urlIsSafeListed', function() {
   var item = {
     level: 'critical',
     body: {trace: {frames: [
@@ -76,12 +76,12 @@ describe('urlIsWhitelisted', function() {
     ]}
     ]}
   };
-  it('should return true with no whitelist', function() {
+  it('should return true with no safelist', function() {
     var settings = {
       reportLevel: 'debug'
     };
-    expect(p.urlIsWhitelisted(logger)(item, settings)).to.be.ok();
-    expect(p.urlIsWhitelisted(logger)(traceChainItem, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(traceChainItem, settings)).to.be.ok();
   });
   it('should return true with no trace', function() {
     var item = {
@@ -90,17 +90,17 @@ describe('urlIsWhitelisted', function() {
     };
     var settings = {
       reportLevel: 'debug',
-      hostWhiteList: ['fake.com', 'example.com']
+      hostSafeList: ['fake.com', 'example.com']
     };
-    expect(p.urlIsWhitelisted(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(item, settings)).to.be.ok();
   });
   it('should return true if at least one regex matches at least one filename in the trace', function() {
     var settings = {
       reportLevel: 'debug',
-      hostWhiteList: ['example.com']
+      hostSafeList: ['example.com']
     };
-    expect(p.urlIsWhitelisted(logger)(item, settings)).to.be.ok();
-    expect(p.urlIsWhitelisted(logger)(traceChainItem, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(traceChainItem, settings)).to.be.ok();
   });
   it('should return true if the filename is not a string', function() {
     var item = {
@@ -127,10 +127,10 @@ describe('urlIsWhitelisted', function() {
     };
     var settings = {
       reportLevel: 'debug',
-      hostWhiteList: ['nope.com']
+      hostSafeList: ['nope.com']
     };
-    expect(p.urlIsWhitelisted(logger)(item, settings)).to.be.ok();
-    expect(p.urlIsWhitelisted(logger)(traceChainItem, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(traceChainItem, settings)).to.be.ok();
   });
   it('should return true if there is no frames key', function() {
     var item = {
@@ -146,10 +146,10 @@ describe('urlIsWhitelisted', function() {
     };
     var settings = {
       reportLevel: 'debug',
-      hostWhiteList: ['nope.com']
+      hostSafeList: ['nope.com']
     };
-    expect(p.urlIsWhitelisted(logger)(item, settings)).to.be.ok();
-    expect(p.urlIsWhitelisted(logger)(traceChainItem, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(traceChainItem, settings)).to.be.ok();
   });
   it('should return true if there are no frames', function() {
     var item = {
@@ -165,22 +165,22 @@ describe('urlIsWhitelisted', function() {
     };
     var settings = {
       reportLevel: 'debug',
-      hostWhiteList: ['nope.com']
+      hostSafeList: ['nope.com']
     };
-    expect(p.urlIsWhitelisted(logger)(item, settings)).to.be.ok();
-    expect(p.urlIsWhitelisted(logger)(traceChainItem, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsSafeListed(logger)(traceChainItem, settings)).to.be.ok();
   });
-  it('should return false if nothing in the whitelist matches', function() {
+  it('should return false if nothing in the safelist matches', function() {
     var settings = {
       reportLevel: 'debug',
-      hostWhiteList: ['baz\.com', 'foo\.com']
+      hostSafeList: ['baz\.com', 'foo\.com']
     };
-    expect(p.urlIsWhitelisted(logger)(item, settings)).to.not.be.ok();
-    expect(p.urlIsWhitelisted(logger)(traceChainItem, settings)).to.not.be.ok();
+    expect(p.urlIsSafeListed(logger)(item, settings)).to.not.be.ok();
+    expect(p.urlIsSafeListed(logger)(traceChainItem, settings)).to.not.be.ok();
   });
 });
 
-describe('urlIsNotBlacklisted', function() {
+describe('urlIsNotBlockListed', function() {
   var item = {
     level: 'critical',
     body: {trace: {frames: [
@@ -203,12 +203,12 @@ describe('urlIsNotBlacklisted', function() {
     ]}
     ]}
   };
-  it('should return true with no blacklist', function() {
+  it('should return true with no blocklist', function() {
     var settings = {
       reportLevel: 'debug'
     };
-    expect(p.urlIsNotBlacklisted(logger)(item, settings)).to.be.ok();
-    expect(p.urlIsNotBlacklisted(logger)(traceChainItem, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(traceChainItem, settings)).to.be.ok();
   });
   it('should return true with no trace', function() {
     var item = {
@@ -217,17 +217,17 @@ describe('urlIsNotBlacklisted', function() {
     };
     var settings = {
       reportLevel: 'debug',
-      hostBlackList: ['fake.com', 'other.com']
+      hostBlockList: ['fake.com', 'other.com']
     };
-    expect(p.urlIsNotBlacklisted(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(item, settings)).to.be.ok();
   });
   it('should return false if any regex matches at least one filename in the trace', function() {
     var settings = {
       reportLevel: 'debug',
-      hostBlackList: ['example.com', 'other.com']
+      hostBlockList: ['example.com', 'other.com']
     };
-    expect(p.urlIsNotBlacklisted(logger)(item, settings)).to.not.be.ok();
-    expect(p.urlIsNotBlacklisted(logger)(traceChainItem, settings)).to.not.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(item, settings)).to.not.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(traceChainItem, settings)).to.not.be.ok();
   });
   it('should return true if the filename is not a string', function() {
     var item = {
@@ -254,10 +254,10 @@ describe('urlIsNotBlacklisted', function() {
     };
     var settings = {
       reportLevel: 'debug',
-      hostBlackList: ['example.com', 'other.com']
+      hostBlockList: ['example.com', 'other.com']
     };
-    expect(p.urlIsNotBlacklisted(logger)(item, settings)).to.be.ok();
-    expect(p.urlIsNotBlacklisted(logger)(traceChainItem, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(traceChainItem, settings)).to.be.ok();
   });
   it('should return true if there is no frames key', function() {
     var item = {
@@ -273,10 +273,10 @@ describe('urlIsNotBlacklisted', function() {
     };
     var settings = {
       reportLevel: 'debug',
-      hostBlackList: ['nope.com']
+      hostBlockList: ['nope.com']
     };
-    expect(p.urlIsNotBlacklisted(logger)(item, settings)).to.be.ok();
-    expect(p.urlIsNotBlacklisted(logger)(traceChainItem, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(traceChainItem, settings)).to.be.ok();
   });
   it('should return true if there are no frames', function() {
     var item = {
@@ -292,18 +292,18 @@ describe('urlIsNotBlacklisted', function() {
     };
     var settings = {
       reportLevel: 'debug',
-      hostBlackList: ['nope.com']
+      hostBlockList: ['nope.com']
     };
-    expect(p.urlIsNotBlacklisted(logger)(item, settings)).to.be.ok();
-    expect(p.urlIsNotBlacklisted(logger)(traceChainItem, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(traceChainItem, settings)).to.be.ok();
   });
-  it('should return true if nothing in the blacklist matches', function() {
+  it('should return true if nothing in the blocklist matches', function() {
     var settings = {
       reportLevel: 'debug',
-      hostBlackList: ['baz\.com', 'foo\.com']
+      hostBlockList: ['baz\.com', 'foo\.com']
     };
-    expect(p.urlIsNotBlacklisted(logger)(item, settings)).to.be.ok();
-    expect(p.urlIsNotBlacklisted(logger)(traceChainItem, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(item, settings)).to.be.ok();
+    expect(p.urlIsNotBlockListed(logger)(traceChainItem, settings)).to.be.ok();
   });
 });
 

--- a/test/react-native.rollbar.test.js
+++ b/test/react-native.rollbar.test.js
@@ -175,6 +175,21 @@ describe('Rollbar()', function() {
     done();
   });
 
+  it ('should replace deprecated options', function(done) {
+    var client = new (TestClientGen())();
+    var options = {
+      hostWhiteList: ['foo'],
+      hostBlackList: ['bar']
+    };
+    var rollbar = new Rollbar(options, client);
+
+    expect(rollbar.options.hostWhiteList).to.eql(undefined);
+    expect(rollbar.options.hostBlackList).to.eql(undefined);
+    expect(rollbar.options.hostSafeList).to.contain('foo');
+    expect(rollbar.options.hostBlockList).to.contain('bar');
+    done();
+  });
+
   it('should return a uuid when logging', function(done) {
     var client = new (TestClientGen())();
     var options = {};
@@ -283,6 +298,21 @@ describe('configure', function() {
     expect(rollbar.options.somekey).to.eql('borkbork');
     expect(rollbar.options.payload.b).to.eql(97);
     expect(client.payloadData.b).to.eql(97);
+    done();
+  });
+  it ('should replace deprecated options', function(done) {
+    var client = new (TestClientGen())();
+    var options = {
+      hostWhiteList: ['foo'],
+      hostBlackList: ['bar']
+    };
+    var rollbar = window.rollbar = new Rollbar({ autoInstrument: false }, client);
+    rollbar.configure(options);
+
+    expect(rollbar.options.hostWhiteList).to.eql(undefined);
+    expect(rollbar.options.hostBlackList).to.eql(undefined);
+    expect(rollbar.options.hostSafeList).to.contain('foo');
+    expect(rollbar.options.hostBlockList).to.contain('bar');
     done();
   });
   it('should store configured options', function(done) {

--- a/test/server.rollbar.test.js
+++ b/test/server.rollbar.test.js
@@ -143,6 +143,20 @@ vows.describe('rollbar')
           assert.equal('fake-env', r.options._configuredOptions.environment);
         }
       },
+      'with deprecated options': {
+        topic: function() {
+          return new Rollbar({
+            hostWhiteList: ['foo'],
+            hostBlackList: ['bar']
+          });
+        },
+        'should replace options': function(r) {
+          assert.equal(r.options.hostWhiteList, undefined);
+          assert.equal(r.options.hostBlackList, undefined);
+          assert.equal(r.options.hostSafeList, 'foo');
+          assert.equal(r.options.hostBlockList, 'bar');
+        }
+      },
       'with valid tracer': {
         topic: function () {
           var rollbar = new Rollbar({ captureUncaught: true, environment: 'fake-env', tracer: ValidOpenTracingTracerStub });
@@ -172,6 +186,22 @@ vows.describe('rollbar')
         'should set configured options': function(r) {
           assert.equal('new-env', r.options._configuredOptions.environment);
           assert.equal(false, r.options._configuredOptions.captureUncaught);
+        }
+      },
+      'with deprecated options': {
+        topic: function() {
+          var rollbar = new Rollbar({ captureUncaught: true });
+          rollbar.configure({
+            hostWhiteList: ['foo'],
+            hostBlackList: ['bar']
+          });
+          return rollbar;
+        },
+        'should replace options': function(r) {
+          assert.equal(r.options.hostWhiteList, undefined);
+          assert.equal(r.options.hostBlackList, undefined);
+          assert.equal(r.options.hostSafeList, 'foo');
+          assert.equal(r.options.hostBlockList, 'bar');
         }
       },
       'with valid tracer': {


### PR DESCRIPTION
## Description of the change

Rollbar's new standard naming convention, that applies to all SDKs, replaces usage of `whitelist` and `blacklist` with `safelist` and `blocklist`. This PR adds new config properties with updated names and deprecates the old ones.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes ch69177

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
