### PR TITLE
Scrub all occurrences of objects seen twice

### DIFF
--- a/src/scrub.js
+++ b/src/scrub.js
@@ -50,7 +50,7 @@ function scrub(data, scrubFields, scrubPaths) {
     }
   }
 
-  return traverse(data, scrubber, []);
+  return traverse(data, scrubber);
 }
 
 function scrubPath(obj, path) {

--- a/src/truncation.js
+++ b/src/truncation.js
@@ -54,7 +54,7 @@ function truncateStrings(len, payload, jsonBackup) {
         return v;
     }
   }
-  payload = traverse(payload, truncator, []);
+  payload = traverse(payload, truncator);
   return [payload, _.stringify(payload, jsonBackup)];
 }
 

--- a/src/utility/traverse.js
+++ b/src/utility/traverse.js
@@ -5,11 +5,22 @@ function traverse(obj, func, seen) {
   var isObj = _.isType(obj, 'object');
   var isArray = _.isType(obj, 'array');
   var keys = [];
+  var seenIndex;
 
-  if (isObj && seen.indexOf(obj) !== -1) {
-    return obj;
+  // Best might be to use Map here with `obj` as the keys, but we want to support IE < 11.
+  seen = seen || { obj: [], mapped: []};
+
+  if (isObj) {
+    seenIndex = seen.obj.indexOf(obj);
+
+    if (isObj && seenIndex !== -1) {
+      // Prefer the mapped object if there is one.
+      return seen.mapped[seenIndex] || seen.obj[seenIndex];
+    }
+
+    seen.obj.push(obj);
+    seenIndex = seen.obj.length - 1;
   }
-  seen.push(obj);
 
   if (isObj) {
     for (k in obj) {
@@ -32,7 +43,11 @@ function traverse(obj, func, seen) {
     same = same && result[k] === obj[k];
   }
 
-  return (keys.length != 0 && !same) ? result : obj;
+  if (isObj && !same) {
+    seen.mapped[seenIndex] = result;
+  }
+
+  return !same ? result : obj;
 }
 
 module.exports = traverse;

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -411,7 +411,7 @@ describe('traverse', function() {
       var result = traverse(obj, function(k, v) {
         callCount++;
         return v + 1;
-      }, []);
+      });
       expect(result).to.eql(expectedOutput);
       expect(callCount).to.eql(2);
 
@@ -427,7 +427,7 @@ describe('traverse', function() {
           return {ca: v.ca+1};
        }
         return v + 1;
-      }, []);
+      });
       expect(result).to.eql(expectedOutput);
       expect(callCount).to.eql(3);
 
@@ -793,9 +793,7 @@ describe('scrub', function() {
     var result = scrub(data, scrubFields);
 
     expect(result.request.password).to.eql(_.redact());
-
-    // TODO: This should be redacted.
-    expect(result.response.request.password).to.eql('foo');
+    expect(result.response.request.password).to.eql(_.redact());
   });
   it('should handle scrubPaths', function() {
     var data = {

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -778,6 +778,25 @@ describe('scrub', function() {
     expect(result.inner.a).to.be.ok();
     expect(result.inner.b).to.eql('yes');
   });
+  it('should scrub objects seen twice', function() {
+    var request = {
+      password: 'foo'
+    }
+
+    var data = {
+      request,
+      response: { request }
+    }
+
+    var scrubFields = ['password'];
+
+    var result = scrub(data, scrubFields);
+
+    expect(result.request.password).to.eql(_.redact());
+
+    // TODO: This should be redacted.
+    expect(result.response.request.password).to.eql('foo');
+  });
   it('should handle scrubPaths', function() {
     var data = {
       a: {


### PR DESCRIPTION
## Description of the change

The traversal logic used for scrubbing payloads has circular traversal protection to prevent infinite traversal of objects that contain circular references. The scrubbing logic always modifies a copy of objects that are scrubbed, and doesn't mutate the original object.

When scrubbing, the bug existed where when the original object was detected two or more times (circular traversal protection), the original object was used in the final payload, not the modified copy. If scrub fields existed in these objects, the unscrubbed version would be added to the payload.

This PR updates the traversal logic to use the previously scrubbed copy of the data in these cases.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes: https://github.com/rollbar/rollbar.js/issues/912

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
