### PR TITLE
Enable depth of traversal for node local vars

### DIFF
--- a/src/server/locals.js
+++ b/src/server/locals.js
@@ -1,13 +1,28 @@
 /* globals Map */
 var inspector = require('inspector');
 var async = require('async');
+var _ = require('../utility');
 
-function Locals(config) {
+// It's helpful to have default limits, as the data expands quickly in real environments.
+// depth = 1 is  enough to capture the members of top level objects and arrays.
+// maxProperties limits the number of properties captured from non-array objects.
+// When this value is too small, relevant values for debugging are easily omitted.
+// maxArray applies to array objects, which in practice may be arbitrarily large,
+// yet for debugging we usually only care about the pattern of data that is established,
+// so a smaller limit is usually sufficient.
+var DEFAULT_OPTIONS = {
+  depth: 1,
+  maxProperties: 30,
+  maxArray: 5
+}
+
+function Locals(options) {
   if (!(this instanceof Locals)) {
-    return new Locals(config);
+    return new Locals(options);
   }
 
-  this.config = config;
+  options = _.isType(options, 'object') ? options : {};
+  this.options = _.merge(DEFAULT_OPTIONS, options);
 
   this.initSession();
 }
@@ -62,7 +77,7 @@ Locals.prototype.mergeLocals = function(localsMap, stack, key, callback) {
     return callback(e);
   }
 
-  getLocalScopesForFrames(matchedFrames, callback);
+  getLocalScopesForFrames(matchedFrames, this.options, callback);
 }
 
 // Finds frames in localParams that match file and line locations in stack.
@@ -115,11 +130,12 @@ function matchedFrame(callFrame, stackLocation) {
     callFrameColumn === position.column;
 }
 
-function getLocalScopesForFrames(matchedFrames, callback) {
-  async.each(matchedFrames, getLocalScopeForFrame, callback);
+function getLocalScopesForFrames(matchedFrames, options, callback) {
+  async.each(matchedFrames, getLocalScopeForFrame.bind({ options: options }), callback);
 }
 
 function getLocalScopeForFrame(matchedFrame, callback) {
+  var options = this.options;
   var scopes = matchedFrame.callFrame.scopeChain;
 
   var scope = scopes.find(scope => scope.type === 'local');
@@ -135,33 +151,100 @@ function getLocalScopeForFrame(matchedFrame, callback) {
 
     var locals = response.result;
     matchedFrame.stackLocation.locals = {};
-    for (var local of locals) {
-      matchedFrame.stackLocation.locals[local.name] = getLocalValue(local);
+    var localsContext = {
+      localsObject: matchedFrame.stackLocation.locals,
+      options: options,
+      depth: options.depth
     }
-
-    callback(null);
+    async.each(locals, getLocalValue.bind(localsContext), callback);
   });
 }
 
-function getLocalValue(local) {
-  var value;
+function getLocalValue(local, callback) {
+  var localsObject = this.localsObject;
+  var options = this.options;
+  var depth = this.depth;
+
+  function cb(error, value) {
+    if (error) {
+      // Add the relevant data to the error object,
+      // taking care to preserve the innermost data context.
+      if (!error.rollbarContext) {
+        error.rollbarContext = local;
+      }
+      return callback(error);
+    }
+
+    if (_.typeName(localsObject) === 'array') {
+      localsObject.push(value);
+    } else {
+      localsObject[local.name] = value;
+    }
+    callback(null);
+  }
+
+  if(!local.value) {
+    return cb(null, '[unavailable]');
+  }
 
   switch (local.value.type) {
-    case 'undefined': value = 'undefined'; break;
-    case 'object': value = getObjectValue(local); break;
-    case 'array': value = getObjectValue(local); break;
-    default: value = local.value.value; break;
+    case 'undefined': cb(null, 'undefined'); break;
+    case 'object': getObjectValue(local, options, depth, cb); break;
+    case 'function': cb(null, getObjectType(local)); break;
+    case 'symbol': cb(null, getSymbolValue(local)); break;
+    default: cb(null, local.value.value); break;
   }
-
-  return value;
 }
 
-function getObjectValue(local) {
+function getObjectType(local) {
   if (local.value.className) {
-    return '<' + local.value.className + ' object>'
+    return '<' + local.value.className + ' object>';
   } else {
-    return '<object>'
+    return '<object>';
   }
+}
+
+function getSymbolValue(local) {
+  return local.value.description;
+}
+
+function getObjectValue(local, options, depth, callback) {
+  if(!local.value.objectId) {
+    if ('value' in local.value) {
+      // Treat as immediate value. (Known example is `null`.)
+      return callback(null, local.value.value);
+    }
+  }
+
+  if (!depth) {
+    return callback(null, getObjectType(local));
+  }
+
+  getProperties(local.value.objectId, function(err, response){
+    if (err) {
+      return callback(err);
+    }
+
+    var isArray = local.value.className === 'Array';
+    var length = isArray ? options.maxArray : options.maxProperties;
+    var properties = response.result.slice(0, length);
+    var localsContext = {
+      localsObject: isArray ? [] : {},
+      options: options,
+      depth: depth - 1
+    }
+
+    // For arrays, use eachSeries to ensure order is preserved.
+    // Otherwise, use each for faster completion.
+    var iterator = isArray ? async.eachSeries : async.each;
+    iterator(properties, getLocalValue.bind(localsContext), function(error){
+      if (error) {
+        return callback(error);
+      }
+
+      callback(null, localsContext.localsObject);
+    });
+  });
 }
 
 function getProperties(objectId, callback) {

--- a/src/server/locals.js
+++ b/src/server/locals.js
@@ -183,7 +183,7 @@ function getLocalValue(local, callback) {
     callback(null);
   }
 
-  if(!local.value) {
+  if (!local.value) {
     return cb(null, '[unavailable]');
   }
 
@@ -209,14 +209,14 @@ function getSymbolValue(local) {
 }
 
 function getObjectValue(local, options, depth, callback) {
-  if(!local.value.objectId) {
+  if (!local.value.objectId) {
     if ('value' in local.value) {
       // Treat as immediate value. (Known example is `null`.)
       return callback(null, local.value.value);
     }
   }
 
-  if (!depth) {
+  if (depth === 0) {
     return callback(null, getObjectType(local));
   }
 

--- a/src/server/parser.js
+++ b/src/server/parser.js
@@ -314,7 +314,9 @@ exports.parseException = function (exc, options, item, callback) {
       item.notifier.locals.mergeLocals(item.localsMap, stack, exc.stack, function (err) {
         if (err) {
           logger.error('could not parse locals, err: ' + err);
-          return callback(err);
+
+          // Don't reject the occurrence, record the error instead.
+          item.diagnostic['error parsing locals'] = err;
         }
 
         return callback(null, ret);

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -41,11 +41,11 @@ function Rollbar(options, client) {
   var api = new API(this.options, transport, urllib, truncation, jsonBackup);
   var telemeter = new Telemeter(this.options)
   this.client = client || new Client(this.options, api, logger, telemeter, 'server');
-  if (options.locals) {
+  if (this.options.locals) {
     // Capturing stack local variables is only supported in Node 10 and higher.
     var nodeMajorVersion = process.versions.node.split('.')[0];
     if (nodeMajorVersion >= 10) {
-      this.locals = new Locals(this.options)
+      this.locals = new Locals(this.options.locals);
     }
   }
   addTransformsToNotifier(this.client.notifier);

--- a/test/fixtures/locals.fixtures.js
+++ b/test/fixtures/locals.fixtures.js
@@ -314,7 +314,7 @@ var localsFixtures = {
         type: 'object',
         className: 'FooClass',
         description: 'FooClass',
-        objectId: '{"injectedScriptId":1,"id":48}'
+        objectId: 'nestedProps1'
       },
       writable: true,
       configurable: true,
@@ -327,7 +327,7 @@ var localsFixtures = {
         type: 'object',
         className: 'BarClass',
         description: 'BarClass',
-        objectId: '{"injectedScriptId":1,"id":48}'
+        objectId: 'nestedProps2'
       },
       writable: true,
       configurable: true,
@@ -370,7 +370,7 @@ var localsFixtures = {
     array1: {
       name: 'args',
       value: {
-        type: 'array',
+        type: 'object',
         subtype: 'array',
         className: 'Array',
         description: 'Array(1)',
@@ -378,6 +378,43 @@ var localsFixtures = {
       },
       writable: true,
       configurable: true,
+      enumerable: true,
+      isOwn: true
+    },
+    function1: {
+      name: 'func',
+      value: {
+        type: 'function',
+        className: 'Function',
+        description: 'Array(1)',
+        objectId: '{"injectedScriptId":1,"id":64}'
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+      isOwn: true
+    },
+    function2: {
+      name: 'asyncFunc',
+      value: {
+        type: 'function',
+        className: 'AsyncFunction',
+        objectId: '{"injectedScriptId":1,"id":32}'
+      },
+      writable: true,
+      configurable: true,
+      enumerable: true,
+      isOwn: true
+    },
+    null1: {
+      name: 'parent',
+      value: {
+        subtype: 'null',
+        type: 'object',
+        value: null
+      },
+      configurable: true,
+      writable: true,
       enumerable: true,
       isOwn: true
     }


### PR DESCRIPTION
## Description of the change

Follow up PR to https://github.com/rollbar/rollbar.js/pull/902 adds traversal of objects and arrays. Capture is performed to the specified depth. Options are also provided to limit the maximum number of object properties and array members captured. 

### Options and defaults

Locals capture may be enabled by setting `options.locals = true` to enable with default options, or with an object containing overrides:
```javascript
options.locals = {
  depth: 2,
  maxProperties: 15,
  maxArray: 10
}
```

`depth` sets the depth to which objects and arrays are expanded. The previous PR supported depth = 0, which captures the value of primitive types, and displays the type of all non-primitives. This is consistent with the example in the Rollbar API doc.

**Example output, depth = 0**
```javascript
locals: {
  foo: "bar",
  res: "<ServerResponse object>", 
  req: "<IncomingMessage object>", 
  next: "<Function object>"
}
``` 

The default is depth = 1, which shows the properties of objects and arrays assigned to local variables.
 
**Example output, depth = 1, (maxProperties = 5 to keep the examples small)**
```javascript
locals: {
  foo: "bar",
  res: {
    _header: null, 
    writable: true,
    _maxListeners: "undefined", 
    _last: false, 
    outputCallbacks: "<Array object>",
  }, 
  req: {
    _readableState: "<ReadableState object>", 
    _eventsCount: 1, 
    baseUrl: "", 
    query: "<Object object>",
    rawHeaders: "<Array object>",
  }, 
  next: "<Function object>" // Function objects are not expanded, see notes below.
}
``` 

Larger values for depth are permitted at the cost of larger payloads.

**Example output, depth = 2 (maxProperties = 5 to keep the examples small)**
```javascript
locals: {
  foo: "bar",
  res: {
    _header: null, 
    writable: true,
    _maxListeners: "undefined", 
    _last: false, 
    outputCallbacks: [
      0, 
      "<Array object>"
    ],
  }, 
  req: {
    _readableState: {
      defaultEncoding: "utf8", 
      length: 0, 
      reading: false, 
      resumeScheduled: false, 
      highWaterMark: 16384, 
      buffer: "<BufferList object>",
    }, 
    _eventsCount: 1, 
    baseUrl: "", 
    query: {}, // empty object, but we didn't detect that with depth = 1 above
    rawHeaders: [
      "Host", 
      "localhost:3000", 
      "Connection", 
      "keep-alive", 
      "Cache-Control"
    ],
  }, 
  next: "<Function object>" // Function objects are not expanded, see notes below.
}
```

`maxProperties` limits the number of properties captured for objects that are traversed and expanded. The default is maxProperties = 30, which can be overriden as needed.

`maxArray` limits the number of members captured for arrays that are traversed and expanded. The default is maxArray = 5, which can be overriden as needed.

### Notes

When objects are expanded, we lose the ability to communicate their type. The information is still available at runtime, but the payload doesn't provide a place to put it. This is effectively by design, and no better or worse than locals support in other SDKs. Annotating the name was considered, e.g. `"foo1 <Foo>": { bar: baz }`. But that key is also used for scrubbing. Altering these keys risks unintended scrub failures.

When functions are assigned as locals, we only show the class name `<Function>` or `<AsyncFunction>`. The function signature and full body are available at runtime, and it would be possible to do something like `<Function  foo(bar)>` in a later PR if there's interest.

Another possible improvement would be to optionally skip locals for stack frames belonging to dependencies. This could be considered in a later PR if there's interest.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes ch75361

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
