### PR TITLE
Load locals as module, with enable/disable and uncaughtOnly options

### DIFF
--- a/src/server/locals.js
+++ b/src/server/locals.js
@@ -73,11 +73,11 @@ Locals.prototype.disconnectSession = function() {
 }
 
 Locals.prototype.updateOptions = function(options) {
-  var setPauseChanged = this.options.enabled != options.enabled || this.options.uncaughtOnly != options.uncaughtOnly;
+  var pauseStateChanged = this.options.enabled != options.enabled || this.options.uncaughtOnly != options.uncaughtOnly;
 
   this.options = _.merge(this.options, options);
 
-  if (this.initialized && setPauseChanged) {
+  if (this.initialized && pauseStateChanged) {
     updatePauseState(this.options, this.logger);
   }
 }
@@ -86,7 +86,9 @@ function updatePauseState(options, logger) {
   var state = pauseStateFromOptions(options);
   console.log('setPauseOnExceptions', state);
   Locals.session.post('Debugger.setPauseOnExceptions', { state: state}, (err, _result) => {
-    logger.error('error in setPauseOnExceptions', err);
+    if (err) {
+      logger.error('error in setPauseOnExceptions', err);
+    }
   });
 }
 

--- a/test/server.locals.test.js
+++ b/test/server.locals.test.js
@@ -171,12 +171,8 @@ function verifyNestedError(r) {
   var data = addItemStub.getCall(0).args[3].data;
   assert.equal(data.body.trace_chain[0].exception.message, 'test error');
   assert.equal(data.body.trace_chain[1].exception.message, 'nested test error');
-  if (nodeMajorVersion < 10) {
-    // Node 8; locals disabled
-    var length = data.body.trace_chain[0].frames.length;
-    assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
-    assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
-  } else {
+  if (nodeMajorVersion >= 10) {
+    // Node 10+; locals enabled
     var length = data.body.trace_chain[0].frames.length;
     assert.equal(data.body.trace_chain[0].frames[length-1].locals.err, '<Error object>');
     assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
@@ -188,7 +184,12 @@ function verifyNestedError(r) {
     assert.equal(data.body.trace_chain[1].frames[length-2].locals.password, '********');
     assert.equal(data.body.trace_chain[1].frames[length-2].locals.err, '<Error object>');
     assert.equal(data.body.trace_chain[1].frames[length-2].locals.newMessage, 'nested test error');
-  }
+  } else {
+    // Node 8; locals disabled
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+}
   addItemStub.restore();
 }
 

--- a/test/server.locals.test.js
+++ b/test/server.locals.test.js
@@ -131,15 +131,16 @@ function verifyThrownError(r) {
   assert.isTrue(addItemStub.called);
   var data = addItemStub.getCall(0).args[3].data;
   assert.equal(data.body.trace_chain[0].exception.message, 'node error');
-  if (nodeMajorVersion < 10) {
+  if (nodeMajorVersion >= 10) {
+    // Node 10+; locals enabled
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
+  } else {
     // Node 8; locals disabled
     var length = data.body.trace_chain[0].frames.length;
     assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
     assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
-  } else {
-    var length = data.body.trace_chain[0].frames.length;
-    assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
-    assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
   }
   addItemStub.restore();
 }

--- a/test/server.locals.test.js
+++ b/test/server.locals.test.js
@@ -6,6 +6,7 @@ var sinon = require('sinon');
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'test-node-env';
 var Rollbar = require('../src/server/rollbar');
+var logger = require('../src/server/logger');
 var Locals = require('../src/server/locals');
 var localsFixtures = require('./fixtures/locals.fixtures');
 
@@ -22,7 +23,7 @@ async function promiseReject(rollbar, callback) {
 
   Promise.reject(error);
   await wait(500);
-  callback(rollbar);
+  callback(null, rollbar);
 }
 
 async function nodeThrow(rollbar, callback) {
@@ -31,7 +32,20 @@ async function nodeThrow(rollbar, callback) {
     throw error;
   }, 1);
   await wait(500);
-  callback(rollbar);
+  callback(null, rollbar);
+}
+
+async function nodeThrowAndCatch(rollbar, callback) {
+  setTimeout(function () {
+    var error = new Error('caught error');
+    try {
+      throw error;
+    } catch (e) {
+      rollbar.error(e);
+    }
+  }, 1);
+  await wait(500);
+  callback(null, rollbar);
 }
 
 function nestedError(nestedMessage, _password) {
@@ -55,7 +69,7 @@ async function nodeThrowNested(rollbar, callback) {
     throw err;
   }, 1);
   await wait(500);
-  callback(rollbar);
+  callback(null, rollbar);
 }
 
 function fakeSessionPostHandler(responses) {
@@ -86,7 +100,7 @@ async function nodeThrowWithNestedLocals(rollbar, callback) {
     throw error;
   }, 1);
   await wait(500);
-  callback(rollbar);
+  callback(null, rollbar);
 }
 
 function recurse(curr, limit) {
@@ -102,7 +116,7 @@ async function nodeThrowRecursionError(rollbar, callback) {
     recurse(0, 3);
   }, 1);
   await wait(500);
-  callback(rollbar);
+  callback(null, rollbar);
 }
 
 function cloneStack(stack) {
@@ -111,7 +125,198 @@ function cloneStack(stack) {
   return JSON.parse(JSON.stringify(stack));
 }
 
+function verifyThrownError(r) {
+  var addItemStub = r.addItemStub;
+
+  assert.isTrue(addItemStub.called);
+  var data = addItemStub.getCall(0).args[3].data;
+  assert.equal(data.body.trace_chain[0].exception.message, 'node error');
+  if (nodeMajorVersion < 10) {
+    // Node 8; locals disabled
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+  } else {
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
+  }
+  addItemStub.restore();
+}
+
+function verifyCaughtError(r) {
+  var addItemStub = r.addItemStub;
+
+  assert.isTrue(addItemStub.called);
+  var data = addItemStub.getCall(0).args[3].data;
+  assert.equal(data.body.trace_chain[0].exception.message, 'caught error');
+  if (nodeMajorVersion < 10) {
+    // Node 8; locals disabled
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+  } else {
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
+  }
+  addItemStub.restore();
+}
+
+function verifyNestedError(r) {
+  var addItemStub = r.addItemStub;
+
+  assert.isTrue(addItemStub.called);
+  var data = addItemStub.getCall(0).args[3].data;
+  assert.equal(data.body.trace_chain[0].exception.message, 'test error');
+  assert.equal(data.body.trace_chain[1].exception.message, 'nested test error');
+  if (nodeMajorVersion < 10) {
+    // Node 8; locals disabled
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+  } else {
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals.err, '<Error object>');
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
+
+    length = data.body.trace_chain[1].frames.length;
+    assert.equal(data.body.trace_chain[1].frames[length-1].locals.nestedMessage, 'nested test error');
+    assert.equal(data.body.trace_chain[1].frames[length-1].locals.nestedError, '<Error object>');
+    assert.equal(data.body.trace_chain[1].frames[length-2].locals.message, 'test error');
+    assert.equal(data.body.trace_chain[1].frames[length-2].locals.password, '********');
+    assert.equal(data.body.trace_chain[1].frames[length-2].locals.err, '<Error object>');
+    assert.equal(data.body.trace_chain[1].frames[length-2].locals.newMessage, 'nested test error');
+  }
+  addItemStub.restore();
+}
+
+function verifyRejectedPromise(r) {
+  var addItemStub = r.addItemStub;
+
+  assert.isTrue(addItemStub.called);
+  var data = addItemStub.getCall(0).args[3].data;
+  assert.equal(data.body.trace_chain[0].exception.message, 'promise reject');
+  if (nodeMajorVersion < 10) {
+    // Node 8; locals disabled
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+  } else {
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals.rollbar, '<Rollbar object>');
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals.notifier, '<Notifier object>');
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals.r, '<Rollbar object>');
+  }
+  addItemStub.restore();
+}
+
+function verifyDefaultOptions(options) {
+  assert.equal(options.enabled, true);
+  assert.equal(options.uncaughtOnly, true);
+  assert.equal(options.depth, 1);
+  assert.equal(options.maxProperties, 30);
+  assert.equal(options.maxArray, 5);
+}
+
 vows.describe('locals')
+  .addBatch({
+    'enabled': {
+      topic: function() {
+        var rollbar = new Rollbar({
+          accessToken: 'abc123',
+          captureUncaught: true,
+          captureUnhandledRejections: true,
+          locals: { module: Locals, uncaughtOnly: true, depth: 0 }
+        });
+        var notifier = rollbar.client.notifier;
+        rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+        nodeThrow(rollbar, this.callback);
+      },
+      'should include locals': function(_err, r) {
+        verifyThrownError(r);
+      },
+      'then disabled': {
+        topic: function(_err, r) {
+          r.configure({ locals: { enabled: false }});
+          var notifier = r.client.notifier;
+          r.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+          nodeThrowNested(r, this.callback);
+        },
+        'should not include locals': function(_err, r) {
+          var addItemStub = r.addItemStub;
+
+          assert.isTrue(addItemStub.called);
+          var data = addItemStub.getCall(0).args[3].data;
+          assert.equal(data.body.trace_chain[0].exception.message, 'test error');
+          assert.equal(data.body.trace_chain[1].exception.message, 'nested test error');
+          var length = data.body.trace_chain[0].frames.length;
+          assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+          assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+          addItemStub.restore();
+        },
+        'then enabled': {
+          topic: function(_err, r) {
+            r.configure({ locals: { enabled: true, uncaughtOnly: false }});
+            var notifier = r.client.notifier;
+            r.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+            promiseReject(r, this.callback);
+          },
+          'should include locals': function(_err, r) {
+            verifyRejectedPromise(r);
+          },
+        }
+      }
+    }
+  })
+
+  .addBatch({
+    'on caught error': {
+      'uncaughtOnly: true': {
+        topic: function() {
+          var rollbar = new Rollbar({
+            accessToken: 'abc123',
+            captureUncaught: true,
+            captureUnhandledRejections: true,
+            locals: { module: Locals, uncaughtOnly:true, depth: 0 }
+          });
+          var notifier = rollbar.client.notifier;
+          rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+          nodeThrowAndCatch(rollbar, this.callback);
+        },
+        'should not include locals': function(_err, r) {
+          var addItemStub = r.addItemStub;
+
+          assert.isTrue(addItemStub.called);
+          var data = addItemStub.getCall(0).args[3].data;
+          assert.equal(data.body.trace_chain[0].exception.message, 'caught error');
+          var length = data.body.trace_chain[0].frames.length;
+          assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+          assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+
+          addItemStub.restore();
+        },
+        'then uncaughtOnly: false': {
+          topic: function(_err, r) {
+            r.configure({ locals: { uncaughtOnly: false }});
+            var notifier = r.client.notifier;
+            r.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+            nodeThrowAndCatch(r, this.callback);
+          },
+          'should include locals': function(_err, r) {
+            verifyCaughtError(r);
+          }
+        }
+      }
+    }
+  })
+
   .addBatch({
     'on exception': {
       'uncaught': {
@@ -119,108 +324,60 @@ vows.describe('locals')
           var rollbar = new Rollbar({
             accessToken: 'abc123',
             captureUncaught: true,
-            locals: { depth: 0 }
+            captureUnhandledRejections: true,
+            locals: { module: Locals, uncaughtOnly: true, depth: 0 }
           });
           var notifier = rollbar.client.notifier;
           rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
 
           nodeThrow(rollbar, this.callback);
         },
-        'should include locals': function(r) {
-          var addItemStub = r.addItemStub;
-
-          assert.isTrue(addItemStub.called);
-          var data = addItemStub.getCall(0).args[3].data;
-          assert.equal(data.body.trace_chain[0].exception.message, 'node error');
-          if (nodeMajorVersion < 10) {
-            // Node 8; locals disabled
-            var length = data.body.trace_chain[0].frames.length;
-            assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
-            assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
-          } else {
-            var length = data.body.trace_chain[0].frames.length;
-            assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
-            assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
-          }
-          addItemStub.reset();
-          Locals.session = undefined;
-        },
-        'nested': {
-          topic: function() {
-            var rollbar = new Rollbar({
-              accessToken: 'abc123',
-              captureUncaught: true,
-              locals: { depth: 0 }
-            });
-            var notifier = rollbar.client.notifier;
-            rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
-
-            nodeThrowNested(rollbar, this.callback);
-          },
-          'should include locals': function(r) {
-            var addItemStub = r.addItemStub;
-
-            assert.isTrue(addItemStub.called);
-            var data = addItemStub.getCall(0).args[3].data;
-            assert.equal(data.body.trace_chain[0].exception.message, 'test error');
-            assert.equal(data.body.trace_chain[1].exception.message, 'nested test error');
-            if (nodeMajorVersion < 10) {
-              // Node 8; locals disabled
-              var length = data.body.trace_chain[0].frames.length;
-              assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
-              assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
-            } else {
-              var length = data.body.trace_chain[0].frames.length;
-              assert.equal(data.body.trace_chain[0].frames[length-1].locals.err, '<Error object>');
-              assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
-
-              length = data.body.trace_chain[1].frames.length;
-              assert.equal(data.body.trace_chain[1].frames[length-1].locals.nestedMessage, 'nested test error');
-              assert.equal(data.body.trace_chain[1].frames[length-1].locals.nestedError, '<Error object>');
-              assert.equal(data.body.trace_chain[1].frames[length-2].locals.message, 'test error');
-              assert.equal(data.body.trace_chain[1].frames[length-2].locals.password, '********');
-              assert.equal(data.body.trace_chain[1].frames[length-2].locals.err, '<Error object>');
-              assert.equal(data.body.trace_chain[1].frames[length-2].locals.newMessage, 'nested test error');
-            }
-            addItemStub.reset();
-            Locals.session = undefined;
-          },
-          'promise rejection': {
-            topic: function() {
-              var rollbar = new Rollbar({
-                accessToken: 'abc123',
-                captureUnhandledRejections: true,
-                locals: { depth: 0 }
-              });
-              var notifier = rollbar.client.notifier;
-              rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
-
-              promiseReject(rollbar, this.callback);
-            },
-            'should include locals': function(r) {
-              var addItemStub = r.addItemStub;
-
-              assert.isTrue(addItemStub.called);
-              var data = addItemStub.getCall(0).args[3].data;
-              assert.equal(data.body.trace_chain[0].exception.message, 'promise reject');
-              if (nodeMajorVersion < 10) {
-                // Node 8; locals disabled
-                var length = data.body.trace_chain[0].frames.length;
-                assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
-                assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
-              } else {
-                var length = data.body.trace_chain[0].frames.length;
-                assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
-                assert.equal(data.body.trace_chain[0].frames[length-1].locals.rollbar, '<Rollbar object>');
-                assert.equal(data.body.trace_chain[0].frames[length-2].locals.notifier, '<Notifier object>');
-                assert.equal(data.body.trace_chain[0].frames[length-2].locals.rollbar, '<Rollbar object>');
-              }
-              addItemStub.reset();
-              Locals.session = undefined;
-            },
-          }
+        'should include locals': function(_err, r) {
+          verifyThrownError(r);
         }
-      },
+      }
+    }
+  })
+
+  .addBatch({
+    'on exception': {
+      'nested': {
+        topic: function() {
+          var rollbar = new Rollbar({
+            accessToken: 'abc123',
+            captureUncaught: true,
+            locals: { module: Locals, uncaughtOnly: false, depth: 0 }
+          });
+          var notifier = rollbar.client.notifier;
+          rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+          nodeThrowNested(rollbar, this.callback);
+        },
+        'should include locals': function(_err, r) {
+          verifyNestedError(r);
+        },
+      }
+    }
+  })
+
+  .addBatch({
+    'on exception': {
+      'promise rejection': {
+        topic: function() {
+          var r = new Rollbar({
+            accessToken: 'abc123',
+            captureUnhandledRejections: true,
+            locals: { module: Locals, uncaughtOnly: false, depth: 0 }
+          });
+          var notifier = r.client.notifier;
+          r.addItemStub = sinon.stub(notifier.queue, 'addItem');
+
+          promiseReject(r, this.callback);
+        },
+        'should include locals': function(_err, r) {
+          verifyRejectedPromise(r);
+        },
+      }
     }
   })
 
@@ -231,14 +388,14 @@ vows.describe('locals')
           var rollbar = new Rollbar({
             accessToken: 'abc123',
             captureUncaught: true,
-            locals: { depth: 2, maxProperties: 5, maxArray: 2 }
+            locals: { module: Locals, depth: 2, maxProperties: 5, maxArray: 2 }
           });
           var notifier = rollbar.client.notifier;
           rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
 
           nodeThrowWithNestedLocals(rollbar, this.callback);
         },
-        'should include locals': function(r) {
+        'should include locals': function(_err, r) {
           var addItemStub = r.addItemStub;
 
           assert.isTrue(addItemStub.called);
@@ -272,14 +429,14 @@ vows.describe('locals')
           var rollbar = new Rollbar({
             accessToken: 'abc123',
             captureUncaught: true,
-            locals: true
+            locals: Locals
           });
           var notifier = rollbar.client.notifier;
           rollbar.addItemStub = sinon.stub(notifier.queue, 'addItem');
 
           nodeThrowRecursionError(rollbar, this.callback);
         },
-        'should include locals': function(r) {
+        'should include locals': function(_err, r) {
           var addItemStub = r.addItemStub;
 
           assert.isTrue(addItemStub.called);
@@ -304,73 +461,87 @@ vows.describe('locals')
 
   .addBatch({
     'constructor': {
-      'passing no arguments': {
-        topic: function() {
-          return new Locals();
-        },
-        'should use defaults': function(locals) {
-          var options = locals.options;
-
-          assert.equal(options.depth, 1);
-          assert.equal(options.maxProperties, 30);
-          assert.equal(options.maxArray, 5);
-        }
-      },
       'passing true boolean': {
         topic: function() {
-          return new Locals(true);
+          return new Locals(true, logger);
         },
         'should use defaults': function(locals) {
-          var options = locals.options;
-
-          assert.equal(options.depth, 1);
-          assert.equal(options.maxProperties, 30);
-          assert.equal(options.maxArray, 5);
+          verifyDefaultOptions(locals.options);
         }
       },
       'passing false boolean': {
         topic: function() {
-          return new Locals(false);
+          return new Locals(false, logger);
         },
         'should use defaults': function(locals) {
-          var options = locals.options;
-
-          assert.equal(options.depth, 1);
-          assert.equal(options.maxProperties, 30);
-          assert.equal(options.maxArray, 5);
+          verifyDefaultOptions(locals.options);
         }
       },
       'passing empty object': {
         topic: function() {
-          return new Locals({});
+          return new Locals({}, logger);
         },
         'should use defaults': function(locals) {
+          verifyDefaultOptions(locals.options);
+        }
+      },
+      'passing depth option': {
+        topic: function() {
+          return new Locals({ depth: 0 }, logger);
+        },
+        'should use updated depth with remaining defaults': function(locals) {
           var options = locals.options;
 
+          assert.equal(options.enabled, true);
+          assert.equal(options.uncaughtOnly, true);
+          assert.equal(options.depth, 0);
+          assert.equal(options.maxProperties, 30);
+          assert.equal(options.maxArray, 5);
+        }
+      },
+      'passing enabled option': {
+        topic: function() {
+          return new Locals({ enabled: false }, logger);
+        },
+        'should use updated enabled with remaining defaults': function(locals) {
+          var options = locals.options;
+
+          assert.equal(options.enabled, false);
+          assert.equal(options.uncaughtOnly, true);
           assert.equal(options.depth, 1);
           assert.equal(options.maxProperties, 30);
           assert.equal(options.maxArray, 5);
         }
       },
-      'passing depth option': {
+      'passing uncaughtOnly option': {
         topic: function() {
-          return new Locals({ depth: 0 });
+          return new Locals({ uncaughtOnly: false }, logger);
         },
-        'should use updated depth with remaining defaults': function(locals) {
+        'should use updated uncaughtOnly with remaining defaults': function(locals) {
           var options = locals.options;
 
-          assert.equal(options.depth, 0);
+          assert.equal(options.enabled, true);
+          assert.equal(options.uncaughtOnly, false);
+          assert.equal(options.depth, 1);
           assert.equal(options.maxProperties, 30);
           assert.equal(options.maxArray, 5);
         }
       },
       'passing all options': {
         topic: function() {
-          return new Locals({ depth: 2, maxProperties: 15, maxArray: 10 });
+          return new Locals({
+            enabled: false,
+            uncaughtOnly: false,
+            depth: 2,
+            maxProperties: 15,
+            maxArray: 10
+          }, logger);
         },
         'should use updated options': function(locals) {
           var options = locals.options;
 
+          assert.equal(options.enabled, false);
+          assert.equal(options.uncaughtOnly, false);
           assert.equal(options.depth, 2);
           assert.equal(options.maxProperties, 15);
           assert.equal(options.maxArray, 10);
@@ -384,7 +555,7 @@ vows.describe('locals')
   .addBatch({
     'mergeLocals returns error from session.post()': {
       topic: function() {
-        var locals = new Locals();
+        var locals = new Locals({}, logger);
         var err = new Error('post error');
         sinon.stub(Locals.session, 'post').yields(err);
 
@@ -427,7 +598,7 @@ vows.describe('locals')
           ],
         }
 
-        var locals = new Locals({ depth: 0 });
+        var locals = new Locals({ depth: 0 }, logger);
         sinon.stub(Locals.session, 'post').callsFake(fakeSessionPostHandler(getPropertiesResponses));
 
         var key1 = 'key1';
@@ -473,7 +644,7 @@ vows.describe('locals')
           ]
         }
 
-        var locals = new Locals({ depth: 0 });
+        var locals = new Locals({ depth: 0 }, logger);
         sinon.stub(Locals.session, 'post').callsFake(fakeSessionPostHandler(getPropertiesResponses));
 
         var key = 'key';
@@ -522,7 +693,7 @@ vows.describe('locals')
           ]
         }
 
-        var locals = new Locals({ depth: 1 });
+        var locals = new Locals({ depth: 1 }, logger);
         sinon.stub(Locals.session, 'post').callsFake(fakeSessionPostHandler(getPropertiesResponses));
 
         var key = 'key';
@@ -569,7 +740,7 @@ vows.describe('locals')
           ],
         }
 
-        var locals = new Locals();
+        var locals = new Locals({}, logger);
         sinon.stub(Locals.session, 'post').callsFake(fakeSessionPostHandler(getPropertiesResponses));
 
         // Test with no maps present. 'key' won't match anything.
@@ -616,7 +787,7 @@ vows.describe('locals')
           ],
         }
 
-        var locals = new Locals();
+        var locals = new Locals({}, logger);
         sinon.stub(Locals.session, 'post').callsFake(fakeSessionPostHandler(getPropertiesResponses));
 
         var key = 'key';
@@ -649,7 +820,7 @@ vows.describe('locals')
   .addBatch({
     'currentLocalsMap called with no local scopes in map': {
       topic: function() {
-        var locals = new Locals();
+        var locals = new Locals({}, logger);
 
         // Ensure empty map, as vows uses the same class object between tests.
         Locals.currentErrors = new Map();

--- a/test/server.locals.test.js
+++ b/test/server.locals.test.js
@@ -199,18 +199,19 @@ function verifyRejectedPromise(r) {
   assert.isTrue(addItemStub.called);
   var data = addItemStub.getCall(0).args[3].data;
   assert.equal(data.body.trace_chain[0].exception.message, 'promise reject');
-  if (nodeMajorVersion < 10) {
-    // Node 8; locals disabled
-    var length = data.body.trace_chain[0].frames.length;
-    assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
-    assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
-  } else {
+  if (nodeMajorVersion >= 10) {
+    // Node 10+; locals enabled
     var length = data.body.trace_chain[0].frames.length;
     assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
     assert.equal(data.body.trace_chain[0].frames[length-1].locals.rollbar, '<Rollbar object>');
     assert.equal(data.body.trace_chain[0].frames[length-2].locals.notifier, '<Notifier object>');
     assert.equal(data.body.trace_chain[0].frames[length-2].locals.r, '<Rollbar object>');
-  }
+  } else {
+    // Node 8; locals disabled
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
+}
   addItemStub.restore();
 }
 

--- a/test/server.locals.test.js
+++ b/test/server.locals.test.js
@@ -151,15 +151,15 @@ function verifyCaughtError(r) {
   assert.isTrue(addItemStub.called);
   var data = addItemStub.getCall(0).args[3].data;
   assert.equal(data.body.trace_chain[0].exception.message, 'caught error');
-  if (nodeMajorVersion < 10) {
-    // Node 8; locals disabled
-    var length = data.body.trace_chain[0].frames.length;
-    assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
-    assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
-  } else {
+  if (nodeMajorVersion >= 10) {
+    // Node 10+; locals enabled
     var length = data.body.trace_chain[0].frames.length;
     assert.equal(data.body.trace_chain[0].frames[length-1].locals.error, '<Error object>');
     assert.equal(data.body.trace_chain[0].frames[length-2].locals.timer, '<Timeout object>');
+  } else {
+    var length = data.body.trace_chain[0].frames.length;
+    assert.equal(data.body.trace_chain[0].frames[length-1].locals, undefined);
+    assert.equal(data.body.trace_chain[0].frames[length-2].locals, undefined);
   }
   addItemStub.restore();
 }


### PR DESCRIPTION
## Description of the change

* Loads the Locals class as a separate module, so that build environments like vercel/pkg that don't have Inspector can build successfully. (See notes below)
* Adds an `enable` flag that can be toggled dynamically at runtime.
* Adds an `uncaughtOnly` flag that can be toggled dynamically at runtime.

Using the `enable` and `uncaughtOnly` flags at runtime can allow capturing locals for specific code paths or time intervals, while avoiding perf impact at other times.

Usage example:
```js
const Rollbar = require('rollbar');
const Locals = require('rollbar/src/server/locals');

const rollbar = Rollbar.init({
  accessToken: 'server-token',
  captureUncaught: true,
  captureUnhandledRejections: true,
  locals: { module: Locals, enable: true, uncaughtOnly: true }
});
```

### Notes:

To support non-Node build environments (e.g. vercel/pkg), a try/catch around the require('inspector') was considered.
```
try {
  require('inspector);
} catch { /* ... */ }
```
This would allow these environments to build successfully, without needing a separate Locals module. But since the `require('inspector)` might lead to other possible conflicts, even when the locals feature isn't enabled, loading the module separately looked like the most reliably safe option.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes: https://github.com/rollbar/rollbar.js/issues/921

ch79594

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
