### PR TITLE
Enable uncaught error capture for web workers

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -264,7 +264,9 @@ Rollbar.prototype.handleUncaughtException = function(message, url, lineno, colno
 
   // Chrome will always send 5+ arguments and error will be valid or null, not undefined.
   // If error is undefined, we have a different caller.
-  if (this.options.inspectAnonymousErrors && this.isChrome && (error === null)) {
+  // Chrome also sends errors from web workers with null error, but does not invoke
+  // prepareStackTrace() for these. Test for empty url to skip them.
+  if (this.options.inspectAnonymousErrors && this.isChrome && error === null && url === '') {
     return 'anonymous';
   }
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -358,8 +358,8 @@ function makeUnhandledStackInfo(
   };
   location.func = errorParser.guessFunctionName(location.url, location.line);
   location.context = errorParser.gatherContext(location.url, location.line);
-  var href = document && document.location && document.location.href;
-  var useragent = window && window.navigator && window.navigator.userAgent;
+  var href = typeof document !== 'undefined' && document && document.location && document.location.href;
+  var useragent = typeof window !== 'undefined' && window && window.navigator && window.navigator.userAgent;
   return {
     'mode': mode,
     'message': error ? String(error) : (message || backupMessage),


### PR DESCRIPTION
## Description of the change

* Safely check for undefined `window` and `document`, so non-window global objects work correctly. With this bug fixed, `captureUncaught` can be set in a Web Worker’s Rollbar instance and errors will be reported with full stack information.
* Add an additional check when identifying Chrome "anonymous" errors, skipping uncaught errors from web workers that have null Error objects but do not get sent to `prepareStackTrace()`.

Currently there aren't tests specifically for web workers. I looked into whether this is possible with the current Karma test framework, and ran into problems stubbing interfaces in the separate worker context. For now the functionality has been tested manually.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes ch80345

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
