### PR TITLE
Add check for missing headers object

### DIFF
--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -385,7 +385,9 @@ Instrumenter.prototype.instrumentNetwork = function() {
         return orig.apply(this, args).then(function (resp) {
           metadata.end_time_ms = _.now();
           metadata.status_code = resp.status;
-          metadata.response_content_type = resp.headers.get('Content-Type');
+          if (resp.headers && typeof resp.headers.get === 'function') {
+            metadata.response_content_type = resp.headers.get('Content-Type');
+          }
           var headers = null;
           if (self.autoInstrument.networkResponseHeaders) {
             headers = self.fetchHeaders(resp.headers, self.autoInstrument.networkResponseHeaders);


### PR DESCRIPTION
## Description of the change

There are compiled environments that partially support the fetch API. More specifically, the `Response` object either doesn't implement the `headers` property or the `Headers` object doesn't implement the `get()` method.

This PR adds a guard around the access to to `response.headers.get()`. When headers can't be retrieved, it is safe to leave `metadata.response_content_type` undefined, which is what this PR does.

There are other places `response.headers` is used, but only if the telemetry option `networkResponseHeaders` is set. When targeting an environment that doesn't implement this part of the fetch API, the `networkResponseHeaders` option should be left unset.

Testing:
The conditions for the negative case (no headers object) is difficult to replicate, as `Response` and `Headers` are both implemented natively on Chrome and can't be stubbed or modified as far as I know.

The test for the positive case, specifically the test that shows scrubbing was performed on the response body, is currently blocked on a Headless Chrome compatibility issue. This was tested manually and passed. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

Fixes: https://github.com/rollbar/rollbar.js/issues/930
ch80956

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
