### PR TITLE
fix: make rollbar compatible with webpack

### DIFF
--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -1,7 +1,8 @@
 var util = require('util');
 var os = require('os');
+var path = require('path');
 
-var packageJson = require('../../package.json');
+var packageJson = require(path.join(__dirname, '../../package.json'));
 var Client = require('../rollbar');
 var _ = require('../utility');
 var API = require('../api');


### PR DESCRIPTION
## Description of the change

Rollbar is not working when using `@vercel/ncc` to build. It points to the project package.json, instead of rollbar's one, therefore getting:

```
TypeError: Cannot read property 'server' of undefined at Object.3029 (/var/webpack:/node_modules/rollbar/src/server/rollbar.js:659:1)
```

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
