### PR TITLE
Apply ignoredMessages filter to trace_chain occurrences

### DIFF
--- a/src/predicates.js
+++ b/src/predicates.js
@@ -142,8 +142,7 @@ function messageIsIgnored(logger) {
       for (i = 0; i < len; i++) {
         rIgnoredMessage = new RegExp(ignoredMessages[i], 'gi');
 
-        var messagesLength = messages.length;
-        for (j = 0; j < messagesLength; j++) {
+        for (j = 0; j < messages.length; j++) {
           messageIsIgnored = rIgnoredMessage.test(messages[j]);
 
           if (messageIsIgnored) {

--- a/src/predicates.js
+++ b/src/predicates.js
@@ -122,9 +122,7 @@ function urlIsOnAList(item, settings, safeOrBlock, logger) {
 
 function messageIsIgnored(logger) {
   return function(item, settings) {
-    var exceptionMessage, i, ignoredMessages,
-        len, messageIsIgnored, rIgnoredMessage,
-        body, traceMessage, bodyMessage;
+    var i, j, ignoredMessages, len, messageIsIgnored, rIgnoredMessage, messages;
 
     try {
       messageIsIgnored = false;
@@ -134,23 +132,23 @@ function messageIsIgnored(logger) {
         return true;
       }
 
-      body = item.body;
-      traceMessage = _.get(body, 'trace.exception.message');
-      bodyMessage = _.get(body, 'message.body');
+      messages = messagesFromItem(item);
 
-      exceptionMessage = traceMessage || bodyMessage;
-
-      if (!exceptionMessage){
+      if (messages.length === 0){
         return true;
       }
 
       len = ignoredMessages.length;
       for (i = 0; i < len; i++) {
         rIgnoredMessage = new RegExp(ignoredMessages[i], 'gi');
-        messageIsIgnored = rIgnoredMessage.test(exceptionMessage);
 
-        if (messageIsIgnored) {
-          break;
+        var messagesLength = messages.length;
+        for (j = 0; j < messagesLength; j++) {
+          messageIsIgnored = rIgnoredMessage.test(messages[j]);
+
+          if (messageIsIgnored) {
+            return false;
+          }
         }
       }
     } catch(e)
@@ -160,8 +158,31 @@ function messageIsIgnored(logger) {
       logger.error('Error while reading your configuration\'s ignoredMessages option. Removing custom ignoredMessages.');
     }
 
-    return !messageIsIgnored;
+    return true;
   }
+}
+
+function messagesFromItem(item) {
+  var body = item.body;
+  var messages = [];
+
+  // The payload schema only allows one of trace_chain, message, or trace.
+  // However, existing test cases are based on having both trace and message present.
+  // So here we preserve the ability to collect strings from any combination of these keys.
+  if (body.trace_chain) {
+    var traceChain = body.trace_chain;
+    for (var i = 0; i < traceChain.length; i++) {
+      var trace = traceChain[i];
+      messages.push(_.get(trace, 'exception.message'));
+    }
+  }
+  if (body.trace) {
+    messages.push(_.get(body, 'trace.exception.message'));
+  }
+  if (body.message) {
+    messages.push(_.get(body, 'message.body'));
+  }
+  return messages;
 }
 
 module.exports = {

--- a/test/predicates.test.js
+++ b/test/predicates.test.js
@@ -416,7 +416,7 @@ describe('messageIsIgnored', function() {
     };
     expect(p.messageIsIgnored(logger)(item, settings)).to.not.be.ok();
   });
-  it('true if both trace and body message but ignoredMessages only match body', function() {
+  it('false if both trace and body message but ignoredMessages only match body', function() {
     var item = {
       level: 'critical',
       body: {
@@ -428,7 +428,7 @@ describe('messageIsIgnored', function() {
       reportLevel: 'debug',
       ignoredMessages: ['fuzz', 'stuff']
     };
-    expect(p.messageIsIgnored(logger)(item, settings)).to.be.ok();
+    expect(p.messageIsIgnored(logger)(item, settings)).to.not.be.ok();
   });
   it('false if ignoredMessages match something in body exception message', function() {
     var item = {
@@ -436,6 +436,54 @@ describe('messageIsIgnored', function() {
       body: {
         trace: {frames: []},
         message: {body: 'fuzz'}
+      }
+    };
+    var settings = {
+      reportLevel: 'debug',
+      ignoredMessages: ['stuff', 'fuzz']
+    };
+    expect(p.messageIsIgnored(logger)(item, settings)).to.not.be.ok();
+  });
+  it("true if trace_chain doesn't match", function() {
+    var item = {
+      level: 'critical',
+      body: {
+        trace_chain: [
+          {exception: {message: 'inner bork'}},
+          {exception: {message: 'outer bork'}}
+        ]
+      }
+    };
+    var settings = {
+      reportLevel: 'debug',
+      ignoredMessages: ['stuff', 'fuzz']
+    };
+    expect(p.messageIsIgnored(logger)(item, settings)).to.be.ok();
+  });
+  it("false if first trace_chain trace matches", function() {
+    var item = {
+      level: 'critical',
+      body: {
+        trace_chain: [
+          {exception: {message: 'inner stuff'}},
+          {exception: {message: 'outer bork'}}
+        ]
+      }
+    };
+    var settings = {
+      reportLevel: 'debug',
+      ignoredMessages: ['stuff', 'fuzz']
+    };
+    expect(p.messageIsIgnored(logger)(item, settings)).to.not.be.ok();
+  });
+  it("false if last trace_chain trace matches", function() {
+    var item = {
+      level: 'critical',
+      body: {
+        trace_chain: [
+          {exception: {message: 'inner bork'}},
+          {exception: {message: 'outer fuzz'}}
+        ]
       }
     };
     var settings = {


### PR DESCRIPTION
## Description of the change

Previously when matching the `ignoredMessages` array to the item, `trace_chain` items were skipped. This PR adds matching for `trace_chain` messages. 

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

ch78345

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [x] Issue from task tracker has a link to this pull request 
