### PR TITLE
Read timeout from options and pass it to the XMLHttpRequest

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -72,6 +72,7 @@ declare namespace Rollbar {
         locals?: LocalsOptions;
         logLevel?: Level;
         maxItems?: number;
+        maxRetries?: number;
         maxTelemetryEvents?: number;
         nodeSourceMaps?: boolean;
         onSendCallback?: (isUncaught: boolean, args: LogArgument[], item: object) => void;
@@ -87,6 +88,7 @@ declare namespace Rollbar {
         sendConfig?: boolean;
         stackTraceLimit?: number;
         telemetryScrubber?: TelemetryScrubber;
+        timeout?: number;
         transform?: (data: object) => void;
         transmit?: boolean;
         uncaughtErrorLevel?: Level;

--- a/src/apiUtility.js
+++ b/src/apiUtility.js
@@ -24,6 +24,7 @@ function getTransportFromOptions(options, defaults, url) {
   var port = defaults.port;
   var path = defaults.path;
   var search = defaults.search;
+  var timeout = options.timeout;
 
   var proxy = options.proxy;
   if (options.endpoint) {
@@ -35,6 +36,7 @@ function getTransportFromOptions(options, defaults, url) {
     search = opts.search;
   }
   return {
+    timeout: timeout,
     hostname: hostname,
     protocol: protocol,
     port: port,
@@ -49,6 +51,7 @@ function transportOptions(transport, method) {
   var port = transport.port || (protocol === 'http:' ? 80 : protocol === 'https:' ? 443 : undefined);
   var hostname = transport.hostname;
   var path = transport.path;
+  var timeout = transport.timeout;
   if (transport.search) {
     path = path + transport.search;
   }
@@ -59,6 +62,7 @@ function transportOptions(transport, method) {
     protocol = transport.proxy.protocol || protocol;
   }
   return {
+    timeout: timeout,
     protocol: protocol,
     hostname: hostname,
     path: path,

--- a/src/browser/transport.js
+++ b/src/browser/transport.js
@@ -111,6 +111,10 @@ function _proxyRequest(json, callback) {
   );
 }
 
+function _isNumber(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n);
+}
+
 function _makeRequest(accessToken, url, method, data, callback, requestFactory, transportOptions) {
   if (typeof RollbarProxy !== 'undefined') {
     return _proxyRequest(data, callback);
@@ -173,7 +177,7 @@ function _makeRequest(accessToken, url, method, data, callback, requestFactory, 
         request.setRequestHeader('X-Rollbar-Access-Token', accessToken);
       }
 
-      if(transportOptions.timeout) {
+      if(_isNumber(transportOptions.timeout)) {
         request.timeout = transportOptions.timeout;
       }
 

--- a/src/browser/transport.js
+++ b/src/browser/transport.js
@@ -75,17 +75,18 @@ Transport.prototype.postJsonPayload = function (accessToken, options, jsonPayloa
 // so Angular change detection isn't triggered on each API call.
 // This is the equivalent of runOutsideAngular().
 //
-function _makeZoneRequest(accessToken, url, method, data, callback, requestFactory, timeout) {
+function _makeZoneRequest() {
   var gWindow = ((typeof window != 'undefined') && window) || ((typeof self != 'undefined') && self);
   var currentZone = gWindow && gWindow.Zone && gWindow.Zone.current;
+  var args = Array.prototype.slice.call(arguments);
 
   if (currentZone && currentZone._name === 'angular') {
     var rootZone = currentZone._parent;
     rootZone.run(function () {
-      _makeRequest(accessToken, url, method, data, callback, requestFactory, timeout);
+      _makeRequest.apply(undefined, args);
     });
   } else {
-    _makeRequest(accessToken, url, method, data, callback, requestFactory, timeout);
+    _makeRequest.apply(undefined, args);
   }
 }
 

--- a/src/browser/transport.js
+++ b/src/browser/transport.js
@@ -174,7 +174,7 @@ function _makeRequest(accessToken, url, method, data, callback, requestFactory, 
       }
 
       if(transportOptions.timeout) {
-        request.timeout = transportOptions;
+        request.timeout = transportOptions.timeout;
       }
 
       request.onreadystatechange = onreadystatechange;

--- a/src/queue.js
+++ b/src/queue.js
@@ -188,6 +188,12 @@ Queue.prototype._maybeRetry = function(err, item, callback) {
         break;
       }
     }
+    if (shouldRetry && _.isFiniteNumber(this.options.maxRetries)) {
+      item.retries = item.retries ? item.retries + 1 : 1;
+      if (item.retries > this.options.maxRetries) {
+        shouldRetry = false;
+      }
+    }
   }
   if (shouldRetry) {
     this._retryApiRequest(item, callback);

--- a/src/utility.js
+++ b/src/utility.js
@@ -119,6 +119,7 @@ function isString(value) {
  function isFiniteNumber(n) {
   return Number.isFinite(n);
 }
+
 /*
  * isDefined - a convenience function for checking if a value is not equal to undefined
  *

--- a/src/utility.js
+++ b/src/utility.js
@@ -110,6 +110,15 @@ function isString(value) {
   return typeof value === 'string' || value instanceof String
 }
 
+/**
+ * isFiniteNumber - determines whether the passed value is a finite number
+ *
+ * @param {*} n - any value
+ * @returns true if value is a finite number
+ */
+ function isFiniteNumber(n) {
+  return Number.isFinite(n);
+}
 /*
  * isDefined - a convenience function for checking if a value is not equal to undefined
  *
@@ -702,12 +711,13 @@ module.exports = {
   get: get,
   handleOptions: handleOptions,
   isError: isError,
+  isFiniteNumber: isFiniteNumber,
   isFunction: isFunction,
   isIterable: isIterable,
   isNativeFunction: isNativeFunction,
-  isType: isType,
   isObject: isObject,
   isString: isString,
+  isType: isType,
   jsonParse: jsonParse,
   LEVELS: LEVELS,
   makeUnhandledStackInfo: makeUnhandledStackInfo,

--- a/test/apiUtility.test.js
+++ b/test/apiUtility.test.js
@@ -52,7 +52,8 @@ describe('getTransportFromOptions', function() {
       proxy: {
         host: 'whatver.com',
         port: 9090
-      }
+      },
+      timeout: 3000
     };
     var defaults = {
       hostname: 'api.com',
@@ -70,6 +71,7 @@ describe('getTransportFromOptions', function() {
     expect(t.protocol).to.eql(defaults.protocol);
     expect(t.port).to.eql(defaults.port);
     expect(t.proxy).to.eql(options.proxy);
+    expect(t.timeout).to.eql(options.timeout);
   });
   it('should parse the endpoint if given', function() {
     var options = {
@@ -101,6 +103,7 @@ describe('getTransportFromOptions', function() {
     expect(t.protocol).to.eql('http:');
     expect(t.search).to.not.be.ok();
     expect(t.proxy).to.eql(options.proxy);
+    expect(t.timeout).to.eql(undefined);
   });
 });
 
@@ -119,6 +122,7 @@ describe('transportOptions', function() {
     expect(o.path).to.eql('/api/v1/item/');
     expect(o.port).to.eql(5000);
     expect(o.method).to.eql(method);
+    expect(o.timeout).to.eql(undefined);
   });
   it('should use the proxy if given', function() {
     var transport = {
@@ -128,7 +132,8 @@ describe('transportOptions', function() {
       proxy: {
         host: 'b.com',
         port: 8080
-      }
+      },
+      timeout: 3000
     };
     var method = 'GET';
 
@@ -138,6 +143,7 @@ describe('transportOptions', function() {
     expect(o.port).to.eql(8080);
     expect(o.path).to.eql('https://a.com/api/v1/item/');
     expect(o.method).to.eql(method);
+    expect(o.timeout).to.eql(transport.timeout);
   });
 });
 

--- a/test/browser.transport.test.js
+++ b/test/browser.transport.test.js
@@ -32,59 +32,59 @@ describe('post', function() {
     t.post(accessToken, options, payload, callback, requestFactory);
   });
   it('should callback with the right value on success', function(done) {
-    var requestFactory = new requestGenerator('{"err": null, "result": true}', 200);
+    var requestFactory = requestGenerator('{"err": null, "result": true}', 200);
     var callback = function(err, resp) {
       expect(resp).to.be.ok();
       expect(resp.result).to.be.ok();
-      expect(requestFactory.request.timeout).to.equal(options.timeout);
+      expect(requestFactory.getInstance().timeout).to.equal(options.timeout);
       done(err);
     };
-    t.post(accessToken, options, payload, callback, requestFactory.get.bind(requestFactory));
+    t.post(accessToken, options, payload, callback, requestFactory.getInstance);
   });
   it('should callback with the server error if 403', function(done) {
     var response = '{"err": "bad request", "result": null, "message": "fail whale"}'
-    var requestFactory = new requestGenerator(response, 403);
+    var requestFactory = requestGenerator(response, 403);
     var callback = function(err, resp) {
       expect(resp).to.not.be.ok();
       expect(err.message).to.eql('403');
-      expect(requestFactory.request.timeout).to.equal(options.timeout);
+      expect(requestFactory.getInstance().timeout).to.equal(options.timeout);
       done(resp);
     };
-    t.post(accessToken, options, payload, callback, requestFactory.get.bind(requestFactory));
+    t.post(accessToken, options, payload, callback, requestFactory.getInstance);
   });
   it('should callback with the server error if 500', function(done) {
     var response = '{"err": "bad request", "result": null, "message": "500!!!"}'
-    var requestFactory = new requestGenerator(response, 500);
+    var requestFactory = requestGenerator(response, 500);
     var callback = function(err, resp) {
       expect(resp).to.not.be.ok();
       expect(err.message).to.eql('500');
-      expect(requestFactory.request.timeout).to.equal(options.timeout);
+      expect(requestFactory.getInstance().timeout).to.equal(options.timeout);
       done(resp);
     };
-    t.post(accessToken, options, payload, callback, requestFactory.get.bind(requestFactory));
+    t.post(accessToken, options, payload, callback, requestFactory.getInstance);
   });
   it('should callback with a retriable error with a weird status', function(done) {
     var response = '{"err": "bad request"}'
-    var requestFactory = new requestGenerator(response, 12005);
+    var requestFactory = requestGenerator(response, 12005);
     var callback = function(err, resp) {
       expect(resp).to.not.be.ok();
       expect(err.message).to.match(/connection failure/);
       expect(err.code).to.eql('ENOTFOUND');
-      expect(requestFactory.request.timeout).to.equal(options.timeout);
+      expect(requestFactory.getInstance().timeout).to.equal(options.timeout);
       done(resp);
     };
-    t.post(accessToken, options, payload, callback, requestFactory.get.bind(requestFactory));
+    t.post(accessToken, options, payload, callback, requestFactory.getInstance);
   });
   it('should callback with some error if normal sending throws', function(done) {
     var response = '{"err": "bad request"}'
-    var requestFactory = new requestGenerator(response, 500, true);
+    var requestFactory = requestGenerator(response, 500, true);
     var callback = function(err, resp) {
       expect(resp).to.not.be.ok();
       expect(err.message).to.match(/Cannot find a method to transport/);
-      expect(requestFactory.request.timeout).to.equal(options.timeout);
+      expect(requestFactory.getInstance().timeout).to.equal(options.timeout);
       done(resp);
     };
-    t.post(accessToken, options, payload, callback, requestFactory.get.bind(requestFactory));
+    t.post(accessToken, options, payload, callback, requestFactory.getInstance);
   });
 });
 
@@ -120,11 +120,13 @@ TestRequest.prototype.send = function(data) {
 };
 
 var requestGenerator = function(response, status, shouldThrow) {
-  this.response = response;
-  this.status = status;
-  this.shouldThrow = shouldThrow;
-};
-requestGenerator.prototype.get = function() {
-  this.request = new TestRequest(this.response, this.status, this.shouldThrow);
-  return this.request;
+  var request;
+  return {
+    getInstance: function() {
+      if(!request) {
+        request = new TestRequest(response, status, shouldThrow);
+      }
+      return request;
+    }
+  }
 };

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -246,6 +246,21 @@ describe('isError', function() {
   });
 });
 
+describe('isFiniteNumber', function() {
+  [ NaN, null, undefined, 'x' ].forEach(function(value) {
+    it(`should return false for ${value}`, function(done) {
+      expect(_.isFiniteNumber(value)).to.equal(false);
+      done();
+    });
+  });
+  [ -100, 0, 100 ].forEach(function(value) {
+    it(`should return true for ${value}`, function(done) {
+      expect(_.isFiniteNumber(value)).to.equal(true);
+      done();
+    });
+  });
+});
+
 describe('merge', function() {
   it('should work for simple objects', function(done) {
     var o1 = {a: 1, b: 2};


### PR DESCRIPTION

## Description of the change

From https://github.com/rollbar/rollbar.js/issues/948 we decided to add `maxRetries` and `timeout` parameters to the rollbar config:

```javascript
var rollbarConfig = {
      retryInterval: 10000,
      maxRetries: 3, // Only used if retryInterval is set
      timeout: 5000, // HTTP Requests timeout
      ...
    };
```
## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

https://github.com/rollbar/rollbar.js/issues/948

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
