### PR TITLE
Added ability to use async transforms

### DIFF
--- a/src/transforms.js
+++ b/src/transforms.js
@@ -63,7 +63,10 @@ function userTransform(logger) {
     }
     if(_.isPromise(response)) {
       response.then(function (promisedItem) {
-        callback(null, promisedItem || newItem);
+        if(promisedItem) {
+          newItem.data = promisedItem;
+        }
+        callback(null, newItem);
       }, function (error) {
         callback(error, item);
       });

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -50,9 +50,10 @@ function addMessageWithError(item, options, callback) {
 function userTransform(logger) {
   return function(item, options, callback) {
     var newItem = _.merge(item);
+    var response = null;
     try {
       if (_.isFunction(options.transform)) {
-        options.transform(newItem.data, item);
+        response = options.transform(newItem.data, item);
       }
     } catch (e) {
       options.transform = null;
@@ -60,7 +61,15 @@ function userTransform(logger) {
       callback(null, item);
       return;
     }
-    callback(null, newItem);
+    if(_.isPromise(response)) {
+      response.then(function (promisedItem) {
+        callback(null, promisedItem || newItem);
+      }, function (error) {
+        callback(error, item);
+      });
+    } else {
+      callback(null, newItem);
+    }
   }
 }
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -153,6 +153,15 @@ function isError(e) {
   return isType(e, 'error') || isType(e, 'exception');
 }
 
+/* isPromise - a convenience function for checking if a value is a promise
+ *
+ * @param p - any value
+ * @returns true if f is a function, otherwise false
+ */
+function isPromise(p) {
+  return isObject(p) && isType(p.then, 'function');
+}
+
 function redact() {
   return '********';
 }
@@ -719,6 +728,7 @@ module.exports = {
   isObject: isObject,
   isString: isString,
   isType: isType,
+  isPromise: isPromise,
   jsonParse: jsonParse,
   LEVELS: LEVELS,
   makeUnhandledStackInfo: makeUnhandledStackInfo,


### PR DESCRIPTION
## Added ability to use async transforms

> This change allows a promise to be returned from the options.transform function.  The existing codebase
> currently throws away the return value of the transform function, but the new code allows async behavior
> to be executed in the transform function, invoking the callback when the async behavior has settled.

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

### Development

- [X] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [X] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
