### PR TITLE
Fix transform declaration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -89,7 +89,7 @@ declare namespace Rollbar {
         stackTraceLimit?: number;
         telemetryScrubber?: TelemetryScrubber;
         timeout?: number;
-        transform?: (data: object) => void;
+        transform?: (data: object, item: object) => void;
         transmit?: boolean;
         uncaughtErrorLevel?: Level;
         verbose?: boolean;


### PR DESCRIPTION
## Description of the change

Willing to add Rollbar to a project, I noticed that we are missing the declaration of `item` in the `transform` since the PR #650.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
