### PR TITLE
Handle circular references in custom data

### DIFF
--- a/test/server.rollbar.test.js
+++ b/test/server.rollbar.test.js
@@ -278,7 +278,7 @@ vows.describe('rollbar')
             var item = r.client.logCalls[r.client.logCalls.length - 1].item;
             assert.equal(item.message, message);
             assert.equal(item.request, request);
-            assert.equal(item.custom, custom);
+            assert.deepStrictEqual(item.custom, custom);
             item.callback();
             assert.isTrue(callbackCalled);
           }
@@ -332,7 +332,7 @@ vows.describe('rollbar')
             var item = r.client.logCalls[r.client.logCalls.length - 1].item
             assert.equal(item.message, message)
             assert.equal(item.request, request)
-            assert.equal(item.custom, custom)
+            assert.deepStrictEqual(item.custom, custom)
           },
           'should work with request and custom and callback': function(r) {
             var message = 'hello'
@@ -346,7 +346,7 @@ vows.describe('rollbar')
             var item = r.client.logCalls[r.client.logCalls.length - 1].item
             assert.equal(item.message, message)
             assert.equal(item.request, request)
-            assert.equal(item.custom, custom)
+            assert.deepStrictEqual(item.custom, custom)
             item.callback();
             assert.isTrue(callbackCalled);
           }
@@ -399,7 +399,7 @@ vows.describe('rollbar')
             var item = r.client.logCalls[r.client.logCalls.length - 1].item
             assert.equal(item.err, err)
             assert.equal(item.request, request)
-            assert.equal(item.custom, custom)
+            assert.deepStrictEqual(item.custom, custom)
             item.callback();
             assert.isTrue(callbackCalled);
           }
@@ -453,7 +453,7 @@ vows.describe('rollbar')
             var item = r.client.logCalls[r.client.logCalls.length - 1].item
             assert.equal(item.err, err)
             assert.equal(item.request, request)
-            assert.equal(item.custom, custom)
+            assert.deepStrictEqual(item.custom, custom)
           },
           'should work with request and custom and callback': function(r) {
             var err = new Error('hello!')
@@ -467,7 +467,7 @@ vows.describe('rollbar')
             var item = r.client.logCalls[r.client.logCalls.length - 1].item
             assert.equal(item.err, err)
             assert.equal(item.request, request)
-            assert.equal(item.custom, custom)
+            assert.deepStrictEqual(item.custom, custom)
             item.callback();
             assert.isTrue(callbackCalled);
           }


### PR DESCRIPTION
## Description of the change

This PR guards against circular references in user data (e.g. custom data object) by cloning the data and removing the circular references.

**Why is this necessary?**
The linked issue report (https://github.com/rollbar/rollbar.js/issues/955) notes that the merge function in Rollbar.js errors on the circular references. But JSON serialization will also fail, even if it didn't fail during merge. The circular reference causes an infinite traversal and stack overflow.

**Why can't this be solved within the merge function?**
That's the first solution I considered. It would have had the advantage of adding circular reference protection everywhere merge is used. However, merge doesn't traverse arrays (except the root, if it is an array), and adding array traversal would change its existing behavior. If there are circular references behind an array, merge will succeed, but JSON serialization will fail.

**Why use deepStrictEqual in the node.js tests?**
`assert.equal`, as was previously used for those tests, asserts an identical object reference, not exactly equal objects. Now that the code path clones the user data, the previous assert fails. As a side note, most cases of `assert.equal` in the node.js tests should really be `assert.deepStrictEqual`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related issues

Fixes https://github.com/rollbar/rollbar.js/issues/955

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
