### PR TITLE
Typescript definition improvement: Added types for payload property

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,6 +40,9 @@ declare namespace Rollbar {
     ) => void | Promise<TResult>;
     export type MaybeError = Error | undefined | null;
     export type Level = "debug" | "info" | "warning" | "error" | "critical";
+    /**
+     * {@link https://docs.rollbar.com/docs/rollbarjs-configuration-reference#reference}
+     */
     export interface Configuration {
         accessToken?: string;
         addErrorContext?: boolean;
@@ -52,7 +55,15 @@ declare namespace Rollbar {
         captureUnhandledRejections?: boolean;
         captureUsername?: boolean;
         checkIgnore?: (isUncaught: boolean, args: LogArgument[], item: object) => boolean;
+        /**
+         * `codeVersion` takes precedence over `code_version`, if provided.
+         * `client.javascript.code_version` takes precedence over both top level properties.
+         */
         codeVersion?: string;
+        /**
+         * `codeVersion` takes precedence over `code_version`, if provided.
+         * `client.javascript.code_version` takes precedence over both top level properties.
+         */
         code_version?: string;
         enabled?: boolean;
         endpoint?: string;
@@ -77,7 +88,7 @@ declare namespace Rollbar {
         nodeSourceMaps?: boolean;
         onSendCallback?: (isUncaught: boolean, args: LogArgument[], item: object) => void;
         overwriteScrubFields?: boolean;
-        payload?: object;
+        payload?: Payload;
         reportLevel?: Level;
         rewriteFilenamePatterns?: string[];
         scrubFields?: string[];
@@ -89,7 +100,7 @@ declare namespace Rollbar {
         stackTraceLimit?: number;
         telemetryScrubber?: TelemetryScrubber;
         timeout?: number;
-        transform?: (data: object, item: object) => void;
+        transform?: (data: object, item: object) => void | Promise<void>;
         transmit?: boolean;
         uncaughtErrorLevel?: Level;
         verbose?: boolean;
@@ -168,5 +179,74 @@ declare namespace Rollbar {
         wrapGlobals?: WrapGlobalsType,
         scrub?: ScrubType,
         truncation?: TruncationType
+    }
+
+    /**
+      * @deprecated number is deprecated for this field
+      */
+     export type DeprecatedNumber = number;
+
+    /**
+     * {@link https://docs.rollbar.com/docs/rollbarjs-configuration-reference#payload-1}
+     */
+    export interface Payload {
+        person?: {
+            id: string | DeprecatedNumber;
+            username?: string;
+            email?: string;
+            [property: string]: any;
+        },
+        context?: any;
+        client?: {
+            javascript?: {
+                /**
+                 * Version control number (i.e. git SHA) of the current revision. Used for linking filenames in stacktraces to GitHub.
+                 * Note: for the purposes of nesting under the payload key, only code_version will correctly set the value in the final item.
+                 * However, if you wish to set this code version at the top level of the configuration object rather than nested under
+                 * the payload key, we will accept both codeVersion and code_version with codeVersion given preference if both happened
+                 * to be defined. Furthermore, if code_version is nested under the payload key this will have the final preference over
+                 * any value set at the top level.
+                 */
+                code_version?: string | DeprecatedNumber;
+                /**
+                 * When true, the Rollbar service will attempt to find and apply source maps to all frames in the stack trace.
+                 * @default false
+                 */
+                source_map_enabled?: boolean;
+                /**
+                 * When true, the Rollbar service will attempt to apply source maps to frames even if they are missing column numbers.
+                 * Works best when the minified javascript file is generated using newlines instead of semicolons.
+                 * @default false
+                 */
+                guess_uncaught_frames?: boolean;
+                [property: string]: any;
+            }
+            [property: string]: any;
+        },
+        /**
+         * The environment that your code is running in.
+         * @default undefined
+         */
+        environment?: string;
+        server?: {
+            /**
+             * @default master
+             */
+            branch?: string;
+            /**
+             * The hostname of the machine that rendered the page.
+             */
+            host?: string;
+            /**
+             * It is used in two different ways: `source maps`, and `source control`.
+             * 
+             * If you are looking for more information on it please go to:
+             * {@link https://docs.rollbar.com/docs/source-maps}
+             * {@link https://docs.rollbar.com/docs/source-control}
+             */
+            root?: string;
+            [property: string]: any;
+        },
+        [property: string]: any;
     }
 }


### PR DESCRIPTION
## Description of the change

Improve typescript type definition.

Added types for Payload instead of using `object`
Added comments with links to documentation
Added comments to aid in understanding code_version
Added optional Promise return type for transform

**Motivation**:
I spent hours trying to troubleshoot and figure out why items were not being matched up with source maps and the typescript definitions left me confused and unsure about how to configure the payload property because the documentation, at times, is not explicit about where a property lives.

For example, this page https://docs.rollbar.com/docs/source-control#serverroot makes it seem like there is a root level configuration option called `server` (which as far as I can tell that is not the case)
And this example seems to show the `server` property in the root (I guess?) https://docs.rollbar.com/docs/source-maps#can-i-still-set-up-source-linking-when-using-source-maps

Either way, the payload property is well defined(ish) in the docs, so there is no reason it should be `object` in the type definition.

I did add `[property: string]: any;` to ever level in the `payload` property and all nested children so that typescript users can supply anything they want, but will get type completion and jsdoc comments for known properties. I wasn't sure how else the payload is used outside what the docs mention.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix [SC-]
- Fix #1

## Checklists

### Development

(These are all N/A since as far as I can tell, there are no tests for the Typescript definition file 😳 )

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
