### PR TITLE
Prevent error when fetch response has empty body

### DIFF
--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -403,8 +403,10 @@ Instrumenter.prototype.instrumentNetwork = function() {
               // Test to ensure body is a Promise, which it should always be.
               if (typeof body.then === 'function') {
                 body.then(function (text) {
-                  if (self.isJsonContentType(metadata.response_content_type)) {
+                  if (text && self.isJsonContentType(metadata.response_content_type)) {
                     metadata.response.body = self.scrubJson(text);
+                  } else {
+                    metadata.response.body = text
                   }
                 });
               } else {


### PR DESCRIPTION
## Description of the change

Fixes #999 

When using the fetch API, if the server responds with a successful response and a content type of json, the body is parsed as JSON. However, if the body is empty, this causes a JSON parsing error.


## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix #999 

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
