### PR TITLE
Fix LocalsSettings type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -154,7 +154,7 @@ declare namespace Rollbar {
     export type LocalsType = typeof Locals;
     export type LocalsOptions = LocalsType | LocalsSettings;
     export interface LocalsSettings {
-        locals: LocalsType,
+        module: LocalsType,
         enabled?: boolean;
         uncaughtOnly?: boolean;
         depth?: number;
@@ -239,7 +239,7 @@ declare namespace Rollbar {
             host?: string;
             /**
              * It is used in two different ways: `source maps`, and `source control`.
-             * 
+             *
              * If you are looking for more information on it please go to:
              * {@link https://docs.rollbar.com/docs/source-maps}
              * {@link https://docs.rollbar.com/docs/source-control}


### PR DESCRIPTION
## Description of the change

The type declaration for `LocalsSettings` has a wrong key name. Fixing this won't break any existing clients, since the code that reads this object doesn't support using the wrong key name.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related issues

Fixes: https://github.com/rollbar/rollbar.js/issues/989

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
