### PR TITLE
don't fail when body is empty

### DIFF
--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -403,8 +403,10 @@ Instrumenter.prototype.instrumentNetwork = function() {
               // Test to ensure body is a Promise, which it should always be.
               if (typeof body.then === 'function') {
                 body.then(function (text) {
-                  if (self.isJsonContentType(metadata.response_content_type)) {
+                  if (text && self.isJsonContentType(metadata.response_content_type)) {
                     metadata.response.body = self.scrubJson(text);
+                  } else {
+                    metadata.response.body = text;
                   }
                 });
               } else {


### PR DESCRIPTION
## Description of the change

This change prevents an error being thrown by the rollbar sdk in a corner case where it thinks a response should be JSON but it is empty.

Both me and [the original author of the fix](https://github.com/rollbar/rollbar.js/pull/1001#issuecomment-1069391850) couldn't cause a test to fail. In my opinion this shouldn't prevent this change from being fixed as it is minimal.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix #999

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
