### PR TITLE
Add CSP listener on document, not window

### DIFF
--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -729,16 +729,16 @@ Instrumenter.prototype.handleCspError = function(message) {
 }
 
 Instrumenter.prototype.deinstrumentContentSecurityPolicy = function() {
-  if (!('addEventListener' in this._window)) { return; }
+  if (!('addEventListener' in this._document)) { return; }
 
   this.removeListeners('contentsecuritypolicy');
 };
 
 Instrumenter.prototype.instrumentContentSecurityPolicy = function() {
-  if (!('addEventListener' in this._window)) { return; }
+  if (!('addEventListener' in this._document)) { return; }
 
   var cspHandler = this.handleCspEvent.bind(this);
-  this.addListener('contentsecuritypolicy', this._window, 'securitypolicyviolation', null, cspHandler, false);
+  this.addListener('contentsecuritypolicy', this._document, 'securitypolicyviolation', null, cspHandler, false);
 };
 
 Instrumenter.prototype.addListener = function(section, obj, type, altType, handler, capture) {


### PR DESCRIPTION
## Description of the change

Adding the `securitypolicyviolation` listener to the window object works on some browsers, including chrome, and headless chrome used in the tests. However, it doesn't work on Safari, and the spec requires it to be added to the document object, not the window object. https://developer.mozilla.org/en-US/docs/Web/API/SecurityPolicyViolationEvent

This PR adds the listener to the document instead of the window.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes https://github.com/rollbar/rollbar.js/issues/978

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
