### PR TITLE
Allow captureIp without a window object

### DIFF
--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -79,20 +79,25 @@ function addBaseInfo(item, options, callback) {
 
 function addRequestInfo(window) {
   return function(item, options, callback) {
-    if (!window || !window.location) {
-      return callback(null, item);
+    var requestInfo = {};
+
+    if (window && window.location) {
+      requestInfo.url = window.location.href;
+      requestInfo.query_string = window.location.search;
     }
+
     var remoteString = '$remote_ip';
     if (!options.captureIp) {
       remoteString = null;
     } else if (options.captureIp !== true) {
       remoteString += '_anonymize';
     }
-    _.set(item, 'data.request', {
-      url: window.location.href,
-      query_string: window.location.search,
-      user_ip: remoteString
-    });
+    if (remoteString) requestInfo.user_ip = remoteString;
+
+    if (Object.keys(requestInfo).length > 0) {
+      _.set(item, 'data.request', requestInfo);
+    }
+
     callback(null, item);
   };
 }

--- a/test/browser.transforms.test.js
+++ b/test/browser.transforms.test.js
@@ -222,9 +222,10 @@ describe('addRequestInfo', function() {
   it('should use window info to set request properties', function(done) {
     var args = ['a message'];
     var item = itemFromArgs(args);
-    var options = {};
+    var options = { captureIp: 'anonymize' };
     t.addRequestInfo(window)(item, options, function(e, i) {
       expect(i.data.request).to.be.ok();
+      expect(i.data.request.user_ip).to.eql('$remote_ip_anonymize');
       done(e);
     });
   });
@@ -236,6 +237,19 @@ describe('addRequestInfo', function() {
     var w = null;
     t.addRequestInfo(w)(item, options, function(e, i) {
       expect(i.data.request).to.not.be.ok();
+      done(e);
+    });
+  });
+  it('should honor captureIp without window', function(done) {
+    var args = ['a message'];
+    var item = itemFromArgs(args);
+    item.data = {};
+    var options = { captureIp: true };
+    var w = null;
+    t.addRequestInfo(w)(item, options, function(e, i) {
+      expect(i.data.request.url).to.not.be.ok();
+      expect(i.data.request.query_string).to.not.be.ok();
+      expect(i.data.request.user_ip).to.eql('$remote_ip');
       done(e);
     });
   });


### PR DESCRIPTION
## Description of the change

The user IP address is optionally captured at the Rollbar API. The SDK sends a token in the payload signaling whether the captured IP should be added to the payload. This token is added to the payload `request` object, which is only added if a browser window object is detected. (The other keys in the request object depend on `window.location`.)

Setting this token doesn't rely on the `window` object and should be allowed. This is relevant for Electron apps, and for any other client side environment that doesn't support `window.location`.

This PR allows the request object to be sent with the user IP token, regardless of the presence of `window` or `window.location`. Tests are added for this condition, as well as for generally correct behavior when `config.captureIp` is set. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes https://github.com/rollbar/rollbar.js/issues/963

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
