### PR TITLE
Support error cause

### DIFF
--- a/src/browser/transforms.js
+++ b/src/browser/transforms.js
@@ -42,8 +42,8 @@ function addErrorContext(item) {
 
   chain.push(err);
 
-  while (err.nested) {
-    err = err.nested;
+  while (err.nested || err.cause) {
+    err = err.nested || err.cause;
     chain.push(err);
   }
 

--- a/src/errorParser.js
+++ b/src/errorParser.js
@@ -64,11 +64,11 @@ function Stack(exception, skip) {
 function parse(e, skip) {
   var err = e;
 
-  if (err.nested) {
+  if (err.nested || err.cause) {
     var traceChain = [];
     while (err) {
       traceChain.push(new Stack(err, skip));
-      err = err.nested;
+      err = err.nested || err.cause;
 
       skip = 0; // Only apply skip value to primary error
     }

--- a/src/server/transforms.js
+++ b/src/server/transforms.js
@@ -85,7 +85,7 @@ function handleItemWithError(item, options, callback) {
   var chain = [];
   do {
     errors.push(err);
-    err = err.nested;
+    err = err.nested || err.cause;
   } while (err);
   item.stackInfo = chain;
 


### PR DESCRIPTION
## Description of the change

This PR adds support for the Error cause option enabled in Node 16.9, Chrome 93, and other browsers. (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error/Error#browser_compatibility)

This PR leaves the existing `Error.nested` functionality for back compatibility with existing Rollbar.js usage and with earlier Node and browser versions. When `Error.nested` is present, it is preferred, preserving existing behavior.


## Type of change

- [x] New feature (non-breaking change that adds functionality)


## Related issues

Fixes https://github.com/rollbar/rollbar.js/issues/1010

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
