### PR TITLE
Update `ignoredMessages` type definition.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -75,7 +75,7 @@ declare namespace Rollbar {
         hostBlockList?: string[];
         hostWhiteList?: string[]; // deprecated
         hostSafeList?: string[];
-        ignoredMessages?: string[];
+        ignoredMessages?: (string | RegExp)[];
         ignoreDuplicateErrors?: boolean;
         includeItemsInTelemetry?: boolean;
         inspectAnonymousErrors?: boolean;


### PR DESCRIPTION
## Description of the change

According to [the documentation](https://docs.rollbar.com/docs/javascript#ignoring-specific-exception-messages), it is possible to give regular expressions for `ignoredMessages`. However, this option was typed as `string[]`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- https://docs.rollbar.com/docs/javascript#ignoring-specific-exception-messages

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
