### PR TITLE
Added missing retryInterval type definition in configuration

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,6 +90,7 @@ declare namespace Rollbar {
         overwriteScrubFields?: boolean;
         payload?: Payload;
         reportLevel?: Level;
+        retryInterval?: number;
         rewriteFilenamePatterns?: string[];
         scrubFields?: string[];
         scrubHeaders?: string[];


### PR DESCRIPTION
## Description of the change

Added missing retryInterval type definition in configuration - https://github.com/rollbar/rollbar.js/issues/1032

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
