### PR TITLE
Typescript: make type for person.id nullable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -191,7 +191,7 @@ declare namespace Rollbar {
      */
     export interface Payload {
         person?: {
-            id: string | DeprecatedNumber;
+            id: string | DeprecatedNumber | null;
             username?: string;
             email?: string;
             [property: string]: any;


### PR DESCRIPTION
## Description of the change

`person.id` in the Rollbar config should be nullable as documented.

Example:
```
    payload: {
      person: {
        id: null
      }
    }
```
This PR makes the Typescript type definition nullable.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes https://github.com/rollbar/rollbar.js/issues/1058

https://app.shortcut.com/rollbar/story/120519

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
