### PR TITLE
Typescript: add retryInterval to Configuration definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -90,6 +90,7 @@ declare namespace Rollbar {
         overwriteScrubFields?: boolean;
         payload?: Payload;
         reportLevel?: Level;
+        retryInterval?: number | null;
         rewriteFilenamePatterns?: string[];
         scrubFields?: string[];
         scrubHeaders?: string[];


### PR DESCRIPTION
## Description of the change

Adds missing type definition for `retryInterval` in the Configuration object.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes https://github.com/rollbar/rollbar.js/issues/1032

https://app.shortcut.com/rollbar/story/120521/

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
