### PR TITLE
Add default payload keys before the custom transform runs

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -502,6 +502,7 @@ function addTransformsToNotifier(notifier, rollbar, gWindow) {
     .addTransform(sharedTransforms.addTelemetryData)
     .addTransform(sharedTransforms.addConfigToPayload)
     .addTransform(transforms.addScrubber(rollbar.scrub))
+    .addTransform(sharedTransforms.addPayloadOptions)
     .addTransform(sharedTransforms.userTransform(logger))
     .addTransform(sharedTransforms.addConfiguredOptions)
     .addTransform(sharedTransforms.addDiagnosticKeys)

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -286,6 +286,7 @@ function addTransformsToNotifier(notifier) {
     .addTransform(sharedTransforms.addTelemetryData)
     .addTransform(sharedTransforms.addConfigToPayload)
     .addTransform(transforms.scrubPayload)
+    .addTransform(sharedTransforms.addPayloadOptions)
     .addTransform(sharedTransforms.userTransform(logger))
     .addTransform(sharedTransforms.addConfiguredOptions)
     .addTransform(sharedTransforms.addDiagnosticKeys)

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -537,6 +537,7 @@ function addTransformsToNotifier(notifier) {
     .addTransform(transforms.addLambdaData)
     .addTransform(sharedTransforms.addConfigToPayload)
     .addTransform(transforms.scrubPayload)
+    .addTransform(sharedTransforms.addPayloadOptions)
     .addTransform(sharedTransforms.userTransform(logger))
     .addTransform(sharedTransforms.addConfiguredOptions)
     .addTransform(sharedTransforms.addDiagnosticKeys)

--- a/src/transforms.js
+++ b/src/transforms.js
@@ -1,12 +1,8 @@
 var _ = require('./utility');
 
 function itemToPayload(item, options, callback) {
-  var payloadOptions = options.payload || {};
-  if (payloadOptions.body) {
-    delete payloadOptions.body;
-  }
+  var data = item.data;
 
-  var data = _.merge(item.data, payloadOptions);
   if (item._isUncaught) {
     data._isUncaught = true;
   }
@@ -14,6 +10,16 @@ function itemToPayload(item, options, callback) {
     data._originalArgs = item._originalArgs;
   }
   callback(null, data);
+}
+
+function addPayloadOptions(item, options, callback) {
+  var payloadOptions = options.payload || {};
+  if (payloadOptions.body) {
+    delete payloadOptions.body;
+  }
+
+  item.data = _.merge(item.data, payloadOptions);
+  callback(null, item);
 }
 
 function addTelemetryData(item, options, callback) {
@@ -139,6 +145,7 @@ function addDiagnosticKeys(item, options, callback) {
 
 module.exports = {
   itemToPayload: itemToPayload,
+  addPayloadOptions: addPayloadOptions,
   addTelemetryData: addTelemetryData,
   addMessageWithError: addMessageWithError,
   userTransform: userTransform,

--- a/test/transforms.test.js
+++ b/test/transforms.test.js
@@ -21,13 +21,20 @@ describe('itemToPayload', function() {
     var args = ['a message', {custom: 'stuff'}];
     var item = itemFromArgs(args);
     item.accessToken = 'abc123';
+    item._isUncaught = true;
+    item._originalArgs = ['c', 3];
+    item.data = {};
     var options = {
       endpoint: 'api.rollbar.com',
       payload: {body: 'hey', x: 42}
     };
     t.itemToPayload(item, options, function(e, i) {
+      expect(i._isUncaught).to.eql(item._isUncaught);
+      expect(i._originalArgs).to.eql(item._originalArgs);
+
+      // This transform shouldn't apply any payload keys.
       expect(i.body).to.not.eql('hey');
-      expect(i.x).to.eql(42);
+      expect(i.x).to.not.eql(42);
       done(e);
     });
   });
@@ -41,6 +48,23 @@ describe('itemToPayload', function() {
     };
     t.itemToPayload(item, options, function(e, i) {
       expect(i.message).to.eql('a message');
+      done(e);
+    });
+  });
+});
+
+describe('addPayloadOptions', function() {
+  it('ignores options.payload.body but merges in other payload options', function(done) {
+    var args = ['a message', {custom: 'stuff'}];
+    var item = itemFromArgs(args);
+    item.accessToken = 'abc123';
+    var options = {
+      endpoint: 'api.rollbar.com',
+      payload: {body: 'hey', x: 42}
+    };
+    t.addPayloadOptions(item, options, function(e, i) {
+      expect(i.data.body).to.not.eql('hey');
+      expect(i.data.x).to.eql(42);
       done(e);
     });
   });


### PR DESCRIPTION
## Description of the change

Currently the defaults from the config override the updated values from the user transform function. Instead, the transform should override the defaults.

This PR adds the default payload options in its own step, so that it is present during the user transform. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes
https://app.shortcut.com/rollbar/story/120633/ 
https://github.com/rollbar/rollbar.js/issues/1026

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
