### PR TITLE
Replace `object` type defs with dictionary type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,13 +40,14 @@ declare namespace Rollbar {
     ) => void | Promise<TResult>;
     export type MaybeError = Error | undefined | null;
     export type Level = "debug" | "info" | "warning" | "error" | "critical";
+    export type Dictionary = { [key: string]: any};
     /**
      * {@link https://docs.rollbar.com/docs/rollbarjs-configuration-reference#reference}
      */
     export interface Configuration {
         accessToken?: string;
         addErrorContext?: boolean;
-        addRequestData?: (data: object, req: object) => void;
+        addRequestData?: (data: Dictionary, req: Dictionary) => void;
         autoInstrument?: AutoInstrumentOptions;
         captureEmail?: boolean;
         captureIp?: boolean | "anonymize";
@@ -54,7 +55,7 @@ declare namespace Rollbar {
         captureUncaught?: boolean;
         captureUnhandledRejections?: boolean;
         captureUsername?: boolean;
-        checkIgnore?: (isUncaught: boolean, args: LogArgument[], item: object) => boolean;
+        checkIgnore?: (isUncaught: boolean, args: LogArgument[], item: Dictionary) => boolean;
         /**
          * `codeVersion` takes precedence over `code_version`, if provided.
          * `client.javascript.code_version` takes precedence over both top level properties.
@@ -86,7 +87,7 @@ declare namespace Rollbar {
         maxRetries?: number;
         maxTelemetryEvents?: number;
         nodeSourceMaps?: boolean;
-        onSendCallback?: (isUncaught: boolean, args: LogArgument[], item: object) => void;
+        onSendCallback?: (isUncaught: boolean, args: LogArgument[], item: Dictionary) => void;
         overwriteScrubFields?: boolean;
         payload?: Payload;
         reportLevel?: Level;
@@ -101,7 +102,7 @@ declare namespace Rollbar {
         stackTraceLimit?: number;
         telemetryScrubber?: TelemetryScrubber;
         timeout?: number;
-        transform?: (data: object, item: object) => void | Promise<void>;
+        transform?: (data: Dictionary, item: Dictionary) => void | Promise<void>;
         transmit?: boolean;
         uncaughtErrorLevel?: Level;
         verbose?: boolean;
@@ -109,7 +110,7 @@ declare namespace Rollbar {
         wrapGlobalEventHandlers?: boolean;
     }
     export type Callback<TResponse = any> = (err: MaybeError, response: TResponse) => void;
-    export type LogArgument = string | Error | object | Callback | Date | any[] | undefined;
+    export type LogArgument = string | Error | object | Dictionary | Callback | Date | any[] | undefined;
     export interface LogResult {
         uuid: string;
     }
@@ -117,7 +118,7 @@ declare namespace Rollbar {
         level: Level;
         type: string;
         timestamp_ms: number;
-        body: object;
+        body: Dictionary;
         source: string;
         uuid?: string;
     }

--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ declare namespace Rollbar {
     ) => void | Promise<TResult>;
     export type MaybeError = Error | undefined | null;
     export type Level = "debug" | "info" | "warning" | "error" | "critical";
-    export type Dictionary = { [key: string]: any};
+    export type Dictionary = { [key: string]: unknown};
     /**
      * {@link https://docs.rollbar.com/docs/rollbarjs-configuration-reference#reference}
      */


### PR DESCRIPTION
## Description of the change

In many places, the type definitions for callback functions use the `object` type for payload or item arguments. This makes the object opaque and no properties can be accessed in the callback.

This PR updates these to use a generic dictionary type. 

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related issues

Fixes
https://app.shortcut.com/rollbar/story/120642/
https://github.com/rollbar/rollbar.js/issues/985

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
