### PR TITLE
Provide `this` to closure

### DIFF
--- a/src/browser/transport.js
+++ b/src/browser/transport.js
@@ -88,8 +88,9 @@ Transport.prototype._makeZoneRequest = function () {
 
   if (currentZone && currentZone._name === 'angular') {
     var rootZone = currentZone._parent;
+    var self = this;
     rootZone.run(function () {
-      this._makeRequest.apply(undefined, args);
+      self._makeRequest.apply(undefined, args);
     });
   } else {
     this._makeRequest.apply(undefined, args);


### PR DESCRIPTION
## Description of the change

Provides the outer `this` to the closure function. This affects Angular users.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

## Related issues

Fixes
https://github.com/rollbar/rollbar.js/issues/1080
https://app.shortcut.com/rollbar/story/120687/

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] Issue from task tracker has a link to this pull request
- [x] Changes have been reviewed by at least one other engineer
