### PR TITLE
Fixed telemetry queue shorten calculation on reconfigure.

### DIFF
--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -15,8 +15,8 @@ Telemeter.prototype.configure = function(options) {
   var maxTelemetryEvents = this.options.maxTelemetryEvents || MAX_EVENTS;
   var newMaxEvents = Math.max(0, Math.min(maxTelemetryEvents, MAX_EVENTS));
   var deleteCount = 0;
-  if (this.maxQueueSize > newMaxEvents) {
-    deleteCount = this.maxQueueSize - newMaxEvents;
+  if (this.queue.length > newMaxEvents) {
+    deleteCount = this.queue.length - newMaxEvents;
   }
   this.maxQueueSize = newMaxEvents;
   this.queue.splice(0, deleteCount);


### PR DESCRIPTION
## Description of the change

I am working on implementing Telemetry in the PHP SDK and using JS as a reference implementation. I found what looks like bug in the telemetry queue size calculation when telemetry is reconfigured here:

https://github.com/rollbar/rollbar.js/blob/e964ecbdb16a4d2b8b5feaa8b70a2ec327648ed0/src/telemetry.js#L12-L23

Specifically, `deleteCount = this.maxQueueSize - newMaxEvents;` looks a little suspicious. If the previous max was 100 and the new max is 80 our delete count would be 20.

We then would remove 20 items from the beginning of the queue without checking the length of the queue. So, if 10 items where in the queue we would effectively empty it. Even thought our new max is 80 and the current length of 10 is well under that.

This PR fixes that by using at the length of the queue instead of the `maxQueueSize` property.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

None

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
