### PR TITLE
React + React Native compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         node-version: [8, 10, 12, 14, 16]

--- a/index.d.ts
+++ b/index.d.ts
@@ -27,6 +27,9 @@ declare class Rollbar {
 
     public errorHandler(): Rollbar.ExpressErrorHandler;
 
+    // Used with rollbar-react for rollbar-react-native compatibility.
+    public rollbar: Rollbar;
+
     // Exposed only for testing, should be changed via the configure method
     // DO NOT MODIFY DIRECTLY
     public options: Rollbar.Configuration;

--- a/index.d.ts
+++ b/index.d.ts
@@ -52,6 +52,7 @@ declare namespace Rollbar {
         addErrorContext?: boolean;
         addRequestData?: (data: Dictionary, req: Dictionary) => void;
         autoInstrument?: AutoInstrumentOptions;
+        captureDeviceInfo?: boolean;
         captureEmail?: boolean;
         captureIp?: boolean | "anonymize";
         captureLambdaTimeouts?: boolean;

--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -41,6 +41,9 @@ function Rollbar(options, client) {
     this.instrumenter.instrument();
   }
   _.setupJSON(polyfillJSON);
+
+  // Used with rollbar-react for rollbar-react-native compatibility.
+  this.rollbar = this;
 }
 
 var _instance = null;


### PR DESCRIPTION
## Description of the change

Enables code compatibility between Rollbar-react, Rollbar.js and Rollbar-react-native, including Typescript compatibility.

Allows the same initialization, whether the target is web/JS only or JS + Native.
```javascript
const rollbarReactNative = new Client({/* config */})
const rollbar = rollbarReactNative.rollbar

export default function App() {
  return (
    <Provider instance={rollbar} />
  )
}
```

**How this works**
When rollbar-react-native detects it is on a web-only target, it returns a browser-js instance. When it is on a web + native target, it returns a rollbar-react-native instance with a browser-js instance at the `rollbar` property.

This PR allows the app code to access the browser-js instance at the `rollbar` property regardless of which instance type is returned.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Related issues

Fixes https://app.shortcut.com/rollbar/story/121632

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


