### PR TITLE
feat: Support `URL` object in `fetch` / `XHR` telemetry

### DIFF
--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -179,7 +179,7 @@ Instrumenter.prototype.instrumentNetwork = function() {
     var xhrp = this._window.XMLHttpRequest.prototype;
     replace(xhrp, 'open', function(orig) {
       return function(method, url) {
-        var isUrlObject = typeof URL !== 'undefined' && url instanceof URL
+        var isUrlObject = _isUrlObject(url)
         if (_.isType(url, 'string') || isUrlObject) {
           url = isUrlObject ? url.toString() : url;
           if (this.__rollbar_xhr) {
@@ -344,8 +344,9 @@ Instrumenter.prototype.instrumentNetwork = function() {
         var input = args[0];
         var method = 'GET';
         var url;
-        if (_.isType(input, 'string')) {
-          url = input;
+        var isUrlObject = _isUrlObject(input)
+        if (_.isType(input, 'string') || isUrlObject) {
+          url = isUrlObject ? input.toString() : input;
         } else if (input) {
           url = input.url;
           if (input.method) {
@@ -771,5 +772,9 @@ Instrumenter.prototype.removeListeners = function(section) {
     r();
   }
 };
+
+function _isUrlObject(input) {
+  return typeof URL !== 'undefined' && input instanceof URL
+}
 
 module.exports = Instrumenter;

--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -179,7 +179,9 @@ Instrumenter.prototype.instrumentNetwork = function() {
     var xhrp = this._window.XMLHttpRequest.prototype;
     replace(xhrp, 'open', function(orig) {
       return function(method, url) {
-        if (_.isType(url, 'string')) {
+        var isUrlObject = typeof URL !== 'undefined' && url instanceof URL
+        if (_.isType(url, 'string') || isUrlObject) {
+          url = isUrlObject ? url.toString() : url;
           if (this.__rollbar_xhr) {
             this.__rollbar_xhr.method = method;
             this.__rollbar_xhr.url = url;

--- a/test/browser.telemetry.test.js
+++ b/test/browser.telemetry.test.js
@@ -1,0 +1,41 @@
+/* globals expect */
+/* globals describe */
+/* globals it */
+/* globals sinon */
+
+var Instrumenter = require('../src/browser/telemetry');
+
+describe('instrumentNetwork', function () {
+  it('should capture XHR requests with string URL', function (done) {
+    var callback = sinon.spy();
+    var mockWindow = {
+      XMLHttpRequest: function () { }
+    }
+
+    mockWindow.XMLHttpRequest.prototype.open = function () { }
+    mockWindow.XMLHttpRequest.prototype.send = function () { }
+
+    var i = new Instrumenter({ scrubFields: [] }, { captureNetwork: callback }, { wrap: function () { }, client: { notifier: { diagnostic: {} } } }, mockWindow);
+    i.instrumentNetwork()
+
+    var xhr = new mockWindow.XMLHttpRequest();
+    xhr.open('GET', 'http://first.call')
+    xhr.send()
+    xhr.onreadystatechange()
+
+    expect(callback.callCount).to.eql(1)
+    expect(callback.args[0][0].url).to.eql('http://first.call')
+
+    i.deinstrumentNetwork()
+    i.instrumentNetwork()
+
+    var xhr = new mockWindow.XMLHttpRequest();
+    xhr.open('GET', new URL('http://second.call'))
+    xhr.send()
+    xhr.onreadystatechange()
+    expect(callback.callCount).to.eql(2)
+    expect(callback.args[1][0].url).to.eql('http://second.call/')
+
+    done()
+  })
+})

--- a/test/browser.telemetry.test.js
+++ b/test/browser.telemetry.test.js
@@ -8,17 +8,17 @@ var Instrumenter = require('../src/browser/telemetry');
 describe('instrumentNetwork', function () {
   it('should capture XHR requests with string URL', function (done) {
     var callback = sinon.spy();
-    var mockWindow = {
+    var windowMock = {
       XMLHttpRequest: function () { }
     }
 
-    mockWindow.XMLHttpRequest.prototype.open = function () { }
-    mockWindow.XMLHttpRequest.prototype.send = function () { }
+    windowMock.XMLHttpRequest.prototype.open = function () { }
+    windowMock.XMLHttpRequest.prototype.send = function () { }
 
-    var i = new Instrumenter({ scrubFields: [] }, { captureNetwork: callback }, { wrap: function () { }, client: { notifier: { diagnostic: {} } } }, mockWindow);
+    var i = createInstrumenter(callback, windowMock)
     i.instrumentNetwork()
 
-    var xhr = new mockWindow.XMLHttpRequest();
+    var xhr = new windowMock.XMLHttpRequest();
     xhr.open('GET', 'http://first.call')
     xhr.send()
     xhr.onreadystatechange()
@@ -27,9 +27,9 @@ describe('instrumentNetwork', function () {
     expect(callback.args[0][0].url).to.eql('http://first.call')
 
     i.deinstrumentNetwork()
+    i = createInstrumenter(callback, windowMock)
     i.instrumentNetwork()
-
-    var xhr = new mockWindow.XMLHttpRequest();
+    var xhr = new windowMock.XMLHttpRequest();
     xhr.open('GET', new URL('http://second.call'))
     xhr.send()
     xhr.onreadystatechange()
@@ -38,4 +38,32 @@ describe('instrumentNetwork', function () {
 
     done()
   })
+
+  it('should capture XHR requests with string URL', function (done) {
+    var callback = sinon.spy();
+    var windowMock = {
+      fetch: function () { return Promise.resolve() }
+    }
+
+    var i = createInstrumenter(callback, windowMock);
+    i.instrumentNetwork()
+
+    windowMock.fetch('http://first.call')
+    expect(callback.callCount).to.eql(1)
+    expect(callback.args[0][0].url).to.eql('http://first.call')
+
+    i.deinstrumentNetwork()
+    i = createInstrumenter(callback, windowMock)
+    i.instrumentNetwork()
+
+    windowMock.fetch(new URL('http://second.call'))
+    expect(callback.callCount).to.eql(2)
+    expect(callback.args[1][0].url).to.eql('http://second.call/')
+
+    done()
+  })
 })
+
+function createInstrumenter(callback, windowMock) {
+  return new Instrumenter({ scrubFields: [] }, { captureNetwork: callback }, { wrap: function () { }, client: { notifier: { diagnostic: {} } } }, windowMock);
+}


### PR DESCRIPTION
## Description of the change

> Please include a summary of the change and which issues are fixed.
> Please also include relevant motivation and context.

At Fingerprint.js we have experienced several issues with our customers who use Rollbar. Some telemetry events weren't captured due to unsupported `URL` type in `fetch` / `XHR` (see Parameter section - the `URL` type is valid argument type for `fetch`).

I added support to rollbar`Instrumenter` and covered this behaviour with unit tests.

`fetch` and `XHR` support any object with [stringifier](https://developer.mozilla.org/en-US/docs/Glossary/Stringifier), so I can extend this condition to any object with `toString` method, thought it might be not really useful. Feel free to discuss the solution

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

I didn't create particular issue for Rollbar, but It's similar to what had with Honeybadger: [issue](https://github.com/honeybadger-io/honeybadger-js/issues/1058#issuecomment-1522164267), [PR](https://github.com/honeybadger-io/honeybadger-js/pull/1079)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
