### PR TITLE
fix: remove is_js dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -428,12 +428,6 @@
       "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
       "dev": true
     },
-    "Base64": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
-      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
-      "dev": true
-    },
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
@@ -460,7 +454,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "after": {
       "version": "0.8.2",
@@ -493,13 +488,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "ansi-colors": {
       "version": "3.2.4",
@@ -951,6 +948,12 @@
           }
         }
       }
+    },
+    "Base64": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/Base64/-/Base64-0.2.1.tgz",
+      "integrity": "sha1-ujpCMHCOGGcFBl5mur3Uw1z2ACg=",
+      "dev": true
     },
     "base64-arraybuffer": {
       "version": "0.1.4",
@@ -2349,7 +2352,8 @@
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -2385,7 +2389,8 @@
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
           "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         }
       }
     },
@@ -3595,7 +3600,8 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-concat/-/grunt-contrib-concat-0.3.0.tgz",
       "integrity": "sha1-SPoNQzbSm2U62CJaa9b4VrRIPjI=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "grunt-contrib-connect": {
       "version": "2.1.0",
@@ -3629,7 +3635,8 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/grunt-contrib-copy/-/grunt-contrib-copy-0.5.0.tgz",
       "integrity": "sha1-QQB1rEWlhWuhkbHMclclRQ1KAhU=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "grunt-contrib-jshint": {
       "version": "2.1.0",
@@ -4749,11 +4756,6 @@
       "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=",
       "dev": true
     },
-    "is_js": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
-      "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
-    },
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -5112,7 +5114,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/karma-chai/-/karma-chai-0.1.0.tgz",
       "integrity": "sha1-vuWtQEAFF4Ea40u5RfdikJEIt5o=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-chrome-launcher": {
       "version": "2.2.0",
@@ -5143,13 +5146,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/karma-html2js-preprocessor/-/karma-html2js-preprocessor-1.1.0.tgz",
       "integrity": "sha1-/Ant8Eu+K7bu6boZaPgmtziAIL0=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-jquery": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/karma-jquery/-/karma-jquery-0.1.0.tgz",
       "integrity": "sha1-fcRzfY2kKNfTxkVcQgER3MAhf7Y=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-mocha": {
       "version": "2.0.1",
@@ -5221,19 +5226,22 @@
       "version": "0.2.6",
       "resolved": "https://registry.npmjs.org/karma-requirejs/-/karma-requirejs-0.2.6.tgz",
       "integrity": "sha1-GncMZPkBMgo4nGW0lEdGMmNy3vg=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-safari-launcher": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/karma-safari-launcher/-/karma-safari-launcher-0.1.1.tgz",
       "integrity": "sha1-pjgKzKtgpYP91iT0G5o/EP30EAg=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-sinon": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/karma-sinon/-/karma-sinon-1.0.5.tgz",
       "integrity": "sha1-TjRD8oMP3s/2JNN0cWPxIX2qKpo=",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "karma-sourcemap-loader": {
       "version": "0.3.8",
@@ -7259,8 +7267,7 @@
     "request-ip": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-3.3.0.tgz",
-      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA==",
-      "dev": true
+      "integrity": "sha512-cA6Xh6e0fDBBBwH77SLJaJPBmD3nWVAcF9/XAcsrIHdjhFzFiB5aNQFytdjCGPezU3ROwrR11IddKAM08vohxA=="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -8165,6 +8172,15 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
     "string-template": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
@@ -8217,15 +8233,6 @@
       "requires": {
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.3"
-      }
-    },
-    "string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "~5.1.0"
       }
     },
     "strip-ansi": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,13 @@
     "url": "http://github.com/rollbar/rollbar.js"
   },
   "description": "Effortlessly track and debug errors in your JavaScript applications with Rollbar. This package includes advanced error tracking features and an intuitive interface to help you identify and fix issues more quickly.",
-  "keywords": ["error", "tracking", "logging", "debugging", "javascript"],
+  "keywords": [
+    "error",
+    "tracking",
+    "logging",
+    "debugging",
+    "javascript"
+  ],
   "license": "MIT",
   "main": "src/server/rollbar.js",
   "browser": "dist/rollbar.umd.min.js",


### PR DESCRIPTION
## Description of the change

https://github.com/rollbar/rollbar.js/pull/1111 bumped `request-ip` in an attempt to resolve a security vulnerability in one of its packagess (`is_js`). `request-ip` no longer depends on `is_js`, but it was not removed from this lock file. Not an npm expert, not sure why.

I ran the following command to remove `is_js` from the lock file (it is not specified in the `package.json` and is not transitively referenced; so it should not be in the lock file)

```bash
npm uninstall --lockfile-version 1 --save is_js
```

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

https://github.com/rollbar/rollbar.js/pull/1111

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
