### PR TITLE
Remove is_js library from package-lock.json

### DIFF
--- a/examples/angular2/package-lock.json
+++ b/examples/angular2/package-lock.json
@@ -17495,11 +17495,6 @@
           "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
           "integrity": "sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0="
         },
-        "is_js": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
-          "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0="
-        },
         "isarray": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
@@ -21957,10 +21952,7 @@
         "request-ip": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-2.0.2.tgz",
-          "integrity": "sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4=",
-          "requires": {
-            "is_js": "^0.9.0"
-          }
+          "integrity": "sha1-3urm1K8hdoSX24zQX6NxQ/jxJX4="
         },
         "request-progress": {
           "version": "2.0.1",


### PR DESCRIPTION
## Description of the change

Remove is_js library, for security reasons

## Type of change

- [x] Maintenance

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fixes [this story](https://app.shortcut.com/rollbar/story/131887/rollbar-js-remove-usage-of-is-js-from-rollbar-js-sdk#activity-133676)

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
