### PR TITLE
Don't look for for non-top frame locals in node >=18 during locals tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,27 +2,42 @@ name: Rollbar.js CI
 
 on:
   push:
-    branches: [ master ]
-    tags: [ v* ]
+    branches: [master]
+    tags: [v*]
   pull_request:
-    branches: [ master ]
+    branches: [master]
 
 jobs:
   build:
     runs-on: ubuntu-20.04
+
     strategy:
       matrix:
-        node-version: [10, 12, 14, 16]
+        include:
+          - node: 14
+            npm: ^8
+          - node: 16
+            npm: ^8
+          - node: 18
+            npm: ^9
+          - node: 20
+            npm: ^10
+          - node: latest
+            npm: latest
 
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Install node.js
-        uses: actions/setup-node@v2-beta
+      - name: Set up node ${{ matrix.node }}
+        uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: ${{ matrix.node }}
+
+      - name: Update npm
+        run: npm install -g npm@${{ matrix.npm }}
 
       - name: npm install
         run: npm install


### PR DESCRIPTION
## Description of the change

This PR fixes a failing test running over false assumptions around node/v8 locals in stack traces.

After careful testing, beginning Node.js 18, it seems locals are _only_ present in top frames. However, I wasn't able to pinpoint documentation about this.

> [!NOTE]
> This PR also updates CI to run installs and tests under lts nodes 14 through latest.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
