### PR TITLE
Fix server autoinstrument mergeOptions behavior in node v20+

### DIFF
--- a/src/server/telemetry/urlHelpers.js
+++ b/src/server/telemetry/urlHelpers.js
@@ -1,4 +1,3 @@
-var url = require('url');
 var { URL } = require('url');
 var merge = require('../../merge');
 
@@ -12,11 +11,7 @@ function mergeOptions(input, options, cb) {
   if (typeof input === 'string') {
     const urlStr = input;
     input = urlToHttpOptions(new URL(urlStr));
-  } else if (
-    input &&
-    input[url.searchParamsSymbol] &&
-    input[url.searchParamsSymbol][url.searchParamsSymbol]
-  ) {
+  } else if (input && input instanceof URL) {
     // url.URL instance
     input = urlToHttpOptions(input);
   } else {

--- a/test/server.telemetry.test.js
+++ b/test/server.telemetry.test.js
@@ -9,6 +9,8 @@ var https = require('https');
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'test-node-env';
 var Rollbar = require('../src/server/rollbar');
+var { mergeOptions } = require('../src/server/telemetry/urlHelpers');
+const { URL } = require('url');
 
 function wait(ms) {
   return new Promise((resolve) => {
@@ -410,6 +412,31 @@ vows
         assert.deepStrictEqual(telemetry[3].body.error, 'Error: dns error');
 
         addItemStub.restore();
+      },
+    },
+  })
+  .addBatch({
+    'while using autoinstrument': {
+      topic: function () {
+        const optionsUsingStringUrl = mergeOptions(
+          'http://example.com/api/users',
+          { method: 'GET', headers: testHeaders1 },
+        );
+        const optionsUsingClassUrl = mergeOptions(
+          new URL('http://example.com/api/users'),
+          { method: 'GET', headers: testHeaders1 },
+        );
+
+        return {
+          optionsUsingStringUrl,
+          optionsUsingClassUrl,
+        };
+      },
+      'mergeOptions should correctly handle URL and options': function ({
+        optionsUsingStringUrl,
+        optionsUsingClassUrl,
+      }) {
+        assert.deepStrictEqual(optionsUsingStringUrl, optionsUsingClassUrl);
       },
     },
   })


### PR DESCRIPTION
## Description of the change

### Problem/Impact

`rollbar.js`, with autoInstrument turned on, will break all http/https requests in node v20+ that use `URL` as the first parameter to the request method.

The impact of this should be pretty large as the very popular [got package](https://www.npmjs.com/package/got) uses this fn signature under the hood for all of it's requests.

### Context

In node v20, [changes were made to the initialization of urlSearchParams](https://github.com/nodejs/node/commit/e3bb66813260440545a1fd4412f588f2ad1f18fe) causing a need to update how to sniff out what a URL is. Node made the underlying modification within their code, however rollbar.js has not updated it's `mergeOptions` function which was originally modeled off the nodejs internals that were changed.

### Solution

Node internally, now appears to be using a new internal method `isURL` however it does not appear that it is exposed. I chose to update the check to use `instanceof`. I'm not sure if/why there would be a necessity for a more complex approach to checking (perhaps performance?).

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #1103

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
