### PR TITLE
fix: Handle the formatting of array arguments

### DIFF
--- a/src/utility.js
+++ b/src/utility.js
@@ -1,6 +1,7 @@
 var merge = require('./merge');
 
 var RollbarJSON = {};
+
 function setupJSON(polyfillJSON) {
   if (isFunction(RollbarJSON.stringify) && isFunction(RollbarJSON.parse)) {
     return;
@@ -450,6 +451,7 @@ function nonCircularClone(obj) {
     }
     return result;
   }
+
   return clone(obj, seen);
 }
 
@@ -689,6 +691,18 @@ function formatArgsAsString(args) {
   for (i = 0, len = args.length; i < len; ++i) {
     arg = args[i];
     switch (typeName(arg)) {
+      case 'array':
+        var trimLimit = 10;
+        var trimmedArgs = arg.slice(0, trimLimit);
+        var argsToFormat =
+          trimmedArgs.length === trimLimit
+            ? trimmedArgs.concat(
+                '...output trimmed to ' + trimLimit + ' items...',
+              )
+            : trimmedArgs;
+
+        arg = '[' + formatArgsAsString(argsToFormat) + ']';
+        break;
       case 'object':
         arg = stringify(arg);
         arg = arg.error || arg.value;

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -902,6 +902,23 @@ describe('formatArgsAsString', function () {
 
     expect(result).to.eql('1 {"a":42}');
   });
+
+  it('should handle arrays gracefully', function () {
+    var args = [1, [{ a: 42 }], [{ b: 43 }, null, 'foo', [1, 2]]];
+    var result = _.formatArgsAsString(args);
+
+    expect(result).to.eql('1 [{"a":42}] [{"b":43} null foo [1 2]]');
+  });
+
+  it('should trim large arrays to the list of 10 items', function () {
+    var args = [1, [2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13]];
+    var result = _.formatArgsAsString(args);
+
+    expect(result).to.eql(
+      '1 [2 3 4 5 6 7 8 9 10 11 ...output trimmed to 10 items...]',
+    );
+  });
+
   it('should handle strings', function () {
     var args = [1, 'foo'];
     var result = _.formatArgsAsString(args);
@@ -915,12 +932,12 @@ describe('formatArgsAsString', function () {
     expect(result).to.eql('');
   });
   /*
-   * PhantomJS does not support Symbol yet
-  it('should handle symbols', function() {
-    var args = [1, Symbol('hello')];
-    var result = _.formatArgsAsString(args);
+     * PhantomJS does not support Symbol yet
+    it('should handle symbols', function() {
+      var args = [1, Symbol('hello')];
+      var result = _.formatArgsAsString(args);
 
-    expect(result).to.eql('1 symbol(\'hello\')');
-  });
-  */
+      expect(result).to.eql('1 symbol(\'hello\')');
+    });
+    */
 });


### PR DESCRIPTION
## Description of the change

We are using `rollbar.js` in our application, and because of internal monkey-patching of `console.warn` some instances of invariants triggered by `apollo-client` crash rollbar and our application as a result.

When `apollo-client` logs those invariants via `console.warn` it has some of the arguments specified as array of objects, which get through the `formatArgsAsString` inside rollbar, which does not really handle arrays anyhow and crashes.

This change adds graceful handling of the arrays via a simple recursive call, trimming the array to the first 10 items not to cause any significant overhead on processing.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

> Shortcut stories and GitHub issues (delete irrelevant)

- Fix for Symbols https://github.com/rollbar/rollbar.js/pull/635/

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [x] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
