### PR TITLE
Fix Vue 3 loop

### DIFF
--- a/examples/vuejs3/src/rollbar.js
+++ b/examples/vuejs3/src/rollbar.js
@@ -7,11 +7,23 @@ const rollbar = new Rollbar(config);
 export default {
   install(app) {
     app.config.errorHandler = (error, vm, info) => {
-      rollbar.error(error, { vueComponent: vm, info });
-      if (app.config.devtools) {
-        console.error(error);
-      }
-    };
+      
+      // In case the error is from the router or am helper
+      // calling vm could generate a loop and freeze the browser
+      // rollbar.error(error, { vueComponent: vm, info });
+      
+      rollbar.error(error, { info });
+      
+      if (app.config.devtools) console.error(error);
+    }
+
+    
+    app.config.warningHandler = (error, vm, info) => {
+      rollbar.warning(error, { info });
+      
+      if (app.config.devtools) console.log('just a warning, but!,error)
+    }
+    
     app.provide('rollbar', rollbar);
   },
 };


### PR DESCRIPTION
Fix loop in vue 3

## Description of the change

> in **Vue 3**: when rollbar is triggered by a throw error from inside a helper or the router
> (I suspect also some other odd placed) including the vm variable can generate an infinte loop
> The (proxy) data included in vm are not really needed for debug purposes

> Allso added new. tiny feature to fire on warnings from vue

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #1126

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x ] All tests related to the changed code pass in development

### Code review

- [ ] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
