### PR TITLE
Add isBrowser check for to prevent recording in non-browser envs

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -36,7 +36,7 @@ function Rollbar(options, client) {
     this.tracing.initSession();
   }
 
-  if (Tracing && Recorder) {
+  if (Tracing && Recorder && _.isBrowser()) {
     const recorderOptions = this.options.recorder;
     this.recorder = new Recorder(this.tracing, recorderOptions);
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -167,6 +167,15 @@ function isPromise(p) {
   return isObject(p) && isType(p.then, 'function');
 }
 
+/**
+ * isBrowser - a convenience function for checking if the code is running in a browser
+ *
+ * @returns true if the code is running in a browser environment
+ */
+function isBrowser() {
+  return typeof window !== 'undefined';
+}
+
 function redact() {
   return '********';
 }
@@ -799,6 +808,7 @@ module.exports = {
   isString: isString,
   isType: isType,
   isPromise: isPromise,
+  isBrowser: isBrowser,
   jsonParse: jsonParse,
   LEVELS: LEVELS,
   makeUnhandledStackInfo: makeUnhandledStackInfo,


### PR DESCRIPTION
## Description of the change

Don't record sessions in non-browser environments.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Part of [CAT-353/rrweb-integration](https://linear.app/rollbar-inc/issue/CAT-353/rrweb-integration)
