### PR TITLE
Add rrweb event logging to console for debugging

### DIFF
--- a/src/browser/replay/defaults.js
+++ b/src/browser/replay/defaults.js
@@ -5,6 +5,9 @@
 module.exports = {
   enabled: false, // Whether recording is enabled
   autoStart: true, // Start recording automatically when Rollbar initializes
+  debug: {
+    logEmits: false, // Whether to log emitted events
+  },
 
   // Recording options
   inlineStylesheet: true, // Whether to inline stylesheets to improve replay accuracy

--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -140,7 +140,7 @@ export default class Recorder {
 
     this.#stopFn = this.#recordFn({
       emit: (event, isCheckout) => {
-        if (this.options.debug.logEmits) {
+        if (this.options.debug?.logEmits) {
           this._logEvent(event, isCheckout);
         }
 

--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -140,6 +140,10 @@ export default class Recorder {
 
     this.#stopFn = this.#recordFn({
       emit: (event, isCheckout) => {
+        if (this.options.debug.logEmits) {
+          this._logEvent(event, isCheckout);
+        }
+
         if (isCheckout) {
           this.#events.previous = this.#events.current;
           this.#events.current = [];
@@ -147,7 +151,7 @@ export default class Recorder {
 
         this.#events.current.push(event);
       },
-      checkoutEveryNms: 300000, // 5 minutes
+      checkoutEveryNms: 5 * 60 * 1000, // 5 minutes
       ...this.options,
     });
 
@@ -177,5 +181,25 @@ export default class Recorder {
       previous: [],
       current: [],
     };
+  }
+
+  _logEvent(event, isCheckout) {
+    console.log(
+      `Recorder: ${isCheckout ? 'checkout' : ''} event\n`,
+      ((e) => {
+        const seen = new WeakSet();
+        return JSON.stringify(
+          e,
+          (_, v) => {
+            if (typeof v === 'object' && v !== null) {
+              if (seen.has(v)) return '[Circular]';
+              seen.add(v);
+            }
+            return v;
+          },
+          2,
+        );
+      })(event),
+    );
   }
 }


### PR DESCRIPTION
## Description of the change

* Added a new `debug` configuration option in `src/browser/replay/defaults.js` to enable or disable logging of emitted events. (`logEmits` is set to `false` by default).
* Implemented a `_logEvent` method in `src/browser/replay/recorder.js` to log emitted events in a readable JSON format, handling circular references gracefully. This method is invoked when `logEmits` is enabled in the debug configuration.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Part of [CAT-353/rrweb-integration](https://linear.app/rollbar-inc/issue/CAT-353/rrweb-integration)
