### PR TITLE
Add rrweb event fixtures for integration testing

### DIFF
--- a/test/fixtures/replay/index.js
+++ b/test/fixtures/replay/index.js
@@ -1,0 +1,24 @@
+/**
+ * Export all rrweb fixture events in a single module
+ */
+
+const types = require('./types');
+const realEvents = require('./rrwebEvents.fixtures');
+const syntheticEvents = require('./rrwebSyntheticEvents.fixtures');
+
+module.exports = {
+  EventType: types.EventType,
+  IncrementalSource: types.IncrementalSource,
+  MouseInteractions: types.MouseInteractions,
+  MediaInteractions: types.MediaInteractions,
+  NodeType: types.NodeType,
+  PointerTypes: types.PointerTypes,
+
+  // Event collections
+  realEvents: realEvents.rrwebEvents,
+  syntheticEvents: syntheticEvents.syntheticEvents,
+  allEvents: {
+    ...realEvents.rrwebEvents,
+    ...syntheticEvents.syntheticEvents,
+  },
+};

--- a/test/fixtures/replay/rrwebEvents.fixtures.js
+++ b/test/fixtures/replay/rrwebEvents.fixtures.js
@@ -1,0 +1,259 @@
+/**
+ * Fixture with a representative sample of rrweb events
+ * Extracted from real session recordings and categorized by type
+ */
+
+const types = require('./types');
+const EventType = types.EventType;
+const IncrementalSource = types.IncrementalSource;
+const MouseInteractions = types.MouseInteractions;
+const NodeType = types.NodeType;
+const PointerTypes = types.PointerTypes;
+
+/**
+ * A collection of unique rrweb events for testing
+ * Extracted from real recordings
+ */
+const rrwebEvents = {
+  fullSnapshot: {
+    type: EventType.FullSnapshot,
+    data: {
+      node: {
+        type: NodeType.Document,
+        childNodes: [
+          {
+            type: NodeType.DocumentType,
+            name: 'html',
+            publicId: '',
+            systemId: '',
+            id: 2,
+          },
+          {
+            type: NodeType.Element,
+            tagName: 'html',
+            attributes: { lang: 'en' },
+            childNodes: [
+              {
+                type: NodeType.Element,
+                tagName: 'head',
+                attributes: {},
+                childNodes: [],
+                id: 4,
+              },
+              {
+                type: NodeType.Element,
+                tagName: 'body',
+                attributes: {},
+                childNodes: [],
+                id: 5,
+              },
+            ],
+            id: 3,
+          },
+        ],
+        id: 1,
+      },
+      initialOffset: {
+        top: 0,
+        left: 0,
+      },
+    },
+    timestamp: 1744983335278,
+  },
+
+  mouseMove: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseMove,
+      positions: [
+        {
+          x: 178,
+          y: 327,
+          id: 17,
+          timeOffset: 0,
+        },
+        {
+          x: 180,
+          y: 331,
+          id: 17,
+          timeOffset: 100,
+        },
+      ],
+    },
+    timestamp: 1744983335279,
+  },
+
+  mouseInteractionClick: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.Click,
+      id: 17,
+      x: 180,
+      y: 331,
+      pointerType: PointerTypes.Mouse,
+    },
+    timestamp: 1744983335280,
+  },
+
+  mouseInteractionDown: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.MouseDown,
+      id: 17,
+      x: 180,
+      y: 331,
+      pointerType: PointerTypes.Mouse,
+    },
+    timestamp: 1744983335281,
+  },
+
+  mouseInteractionUp: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.MouseUp,
+      id: 17,
+      x: 180,
+      y: 331,
+      pointerType: PointerTypes.Mouse,
+    },
+    timestamp: 1744983335282,
+  },
+
+  scroll: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Scroll,
+      id: 1,
+      x: 0,
+      y: 274,
+    },
+    timestamp: 1744983335283,
+  },
+
+  viewportResize: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.ViewportResize,
+      width: 1721,
+      height: 488,
+    },
+    timestamp: 1744983335284,
+  },
+
+  input: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Input,
+      id: 100,
+      text: 'user input text',
+      isChecked: false,
+      userTriggered: true,
+    },
+    timestamp: 1744983335285,
+  },
+
+  mutation: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Mutation,
+      texts: [],
+      attributes: [
+        {
+          id: 73,
+          attributes: {
+            class: 'active',
+          },
+        },
+      ],
+      removes: [],
+      adds: [
+        {
+          parentId: 5,
+          nextId: null,
+          node: {
+            type: NodeType.Element,
+            tagName: 'div',
+            attributes: {
+              id: 'new-element',
+            },
+            childNodes: [],
+            id: 101,
+          },
+        },
+      ],
+    },
+    timestamp: 1744983335286,
+  },
+
+  selection: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Selection,
+      ranges: [
+        {
+          start: 20,
+          startOffset: 0,
+          end: 20,
+          endOffset: 4,
+        },
+      ],
+    },
+    timestamp: 1744983335287,
+  },
+
+  meta: {
+    type: EventType.Meta,
+    data: {
+      href: 'http://localhost:3001/',
+      width: 1721,
+      height: 470,
+    },
+    timestamp: 1744983335288,
+  },
+
+  custom: {
+    type: EventType.Custom,
+    data: {
+      tag: 'custom-event',
+      payload: {
+        key: 'value',
+      },
+    },
+    timestamp: 1744983335289,
+  },
+
+  plugin: {
+    type: EventType.Plugin,
+    data: {
+      plugin: 'rrweb/console@1',
+      payload: {
+        level: 'log',
+        args: ['Console log message'],
+      },
+    },
+    timestamp: 1744983335290,
+  },
+
+  invalid: {
+    type: 999,
+    data: {},
+    timestamp: 1744983335291,
+  },
+
+  incomplete: {
+    type: EventType.IncrementalSnapshot,
+    // Missing data and timestamp
+  },
+};
+
+module.exports = {
+  EventType,
+  IncrementalSource,
+  MouseInteractions,
+  NodeType,
+  PointerTypes,
+  rrwebEvents,
+};

--- a/test/fixtures/replay/rrwebSyntheticEvents.fixtures.js
+++ b/test/fixtures/replay/rrwebSyntheticEvents.fixtures.js
@@ -1,0 +1,338 @@
+/**
+ * Synthetic rrweb events created from type definitions
+ * These events are NOT from real recordings but are created based on the
+ * type definitions in @rrweb/types to ensure complete test coverage.
+ */
+
+const types = require('./types');
+const EventType = types.EventType;
+const IncrementalSource = types.IncrementalSource;
+const MouseInteractions = types.MouseInteractions;
+const MediaInteractions = types.MediaInteractions;
+const NodeType = types.NodeType;
+const PointerTypes = types.PointerTypes;
+
+/**
+ * Synthetic events created from type definitions for testing
+ * These cover sources and interactions not in the real recordings
+ */
+const syntheticEvents = {
+  domContentLoaded: {
+    type: EventType.DomContentLoaded,
+    data: {}, // Empty object confirmed in rrweb/src/record/index.ts
+    timestamp: 1744983335276,
+  },
+
+  load: {
+    type: EventType.Load,
+    data: {}, // Empty object confirmed in rrweb/src/record/index.ts
+    timestamp: 1744983335277,
+  },
+
+  touchMove: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.TouchMove,
+      positions: [
+        {
+          x: 150,
+          y: 200,
+          id: 20,
+          timeOffset: 0,
+        },
+        {
+          x: 160,
+          y: 210,
+          id: 20,
+          timeOffset: 100,
+        },
+      ],
+    },
+    timestamp: 1744983335300,
+  },
+
+  mediaInteractionPlay: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MediaInteraction,
+      type: MediaInteractions.Play,
+      id: 45,
+      currentTime: 0,
+    },
+    timestamp: 1744983335310,
+  },
+
+  mediaInteractionPause: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MediaInteraction,
+      type: MediaInteractions.Pause,
+      id: 45,
+      currentTime: 30.5,
+    },
+    timestamp: 1744983335320,
+  },
+
+  mediaInteractionSeeked: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MediaInteraction,
+      type: MediaInteractions.Seeked,
+      id: 45,
+      currentTime: 60,
+    },
+    timestamp: 1744983335330,
+  },
+
+  mediaInteractionVolumeChange: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MediaInteraction,
+      type: MediaInteractions.VolumeChange,
+      id: 45,
+      volume: 0.75,
+      muted: false,
+    },
+    timestamp: 1744983335340,
+  },
+
+  mediaInteractionRateChange: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MediaInteraction,
+      type: MediaInteractions.RateChange,
+      id: 45,
+      playbackRate: 1.5,
+    },
+    timestamp: 1744983335350,
+  },
+
+  styleSheetRule: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.StyleSheetRule,
+      styleId: 3,
+      adds: [
+        {
+          rule: '.new-class { color: red; }',
+          index: 1,
+        },
+      ],
+    },
+    timestamp: 1744983335360,
+  },
+
+  canvasMutation: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.CanvasMutation,
+      id: 24,
+      type: 0, // 2D canvas mutation
+      commands: [
+        {
+          property: 'fillStyle',
+          args: ['#ff0000'],
+          setter: true,
+        },
+        {
+          property: 'fillRect',
+          args: [10, 10, 100, 100],
+          setter: false,
+        },
+      ],
+    },
+    timestamp: 1744983335370,
+  },
+
+  font: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Font,
+      family: 'CustomFont',
+      fontSource: "url('path/to/font.woff2')",
+      buffer: false,
+      descriptors: {
+        style: 'normal',
+        weight: '400',
+        display: 'swap',
+      },
+    },
+    timestamp: 1744983335380,
+  },
+
+  log: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Log,
+      level: 'info',
+      trace: [],
+      payload: ['Log message from application'],
+    },
+    timestamp: 1744983335390,
+  },
+
+  drag: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.Drag,
+      positions: [
+        {
+          x: 100,
+          y: 100,
+          id: 50,
+          timeOffset: 0,
+        },
+        {
+          x: 120,
+          y: 120,
+          id: 50,
+          timeOffset: 100,
+        },
+        {
+          x: 140,
+          y: 140,
+          id: 50,
+          timeOffset: 200,
+        },
+      ],
+    },
+    timestamp: 1744983335400,
+  },
+
+  styleDeclaration: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.StyleDeclaration,
+      id: 64,
+      index: [0],
+      set: {
+        property: 'color',
+        value: 'blue',
+        priority: 'important',
+      },
+    },
+    timestamp: 1744983335410,
+  },
+
+  adoptedStyleSheet: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.AdoptedStyleSheet,
+      id: 1,
+      styles: [
+        {
+          id: 1,
+          rules: [
+            {
+              cssText: 'body { margin: 0; padding: 0; }',
+            },
+            {
+              cssText: 'h1 { font-size: 24px; }',
+            },
+          ],
+        },
+      ],
+    },
+    timestamp: 1744983335420,
+  },
+
+  customElement: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.CustomElement,
+      id: 80,
+      mutations: [
+        {
+          type: 'attributes',
+          name: 'data-custom',
+          value: 'new-value',
+        },
+      ],
+    },
+    timestamp: 1744983335430,
+  },
+
+  mouseInteractionDblClick: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.DblClick,
+      id: 73,
+      x: 200,
+      y: 300,
+      pointerType: PointerTypes.Mouse,
+    },
+    timestamp: 1744983335440,
+  },
+
+  mouseInteractionContextMenu: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.ContextMenu,
+      id: 73,
+      x: 200,
+      y: 300,
+      pointerType: PointerTypes.Mouse,
+    },
+    timestamp: 1744983335450,
+  },
+
+  mouseInteractionFocus: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.Focus,
+      id: 73,
+      pointerType: PointerTypes.Mouse,
+    },
+    timestamp: 1744983335460,
+  },
+
+  mouseInteractionBlur: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.Blur,
+      id: 73,
+      pointerType: PointerTypes.Mouse,
+    },
+    timestamp: 1744983335470,
+  },
+
+  mouseInteractionTouchStart: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.TouchStart,
+      id: 73,
+      x: 200,
+      y: 300,
+      pointerType: PointerTypes.Touch,
+    },
+    timestamp: 1744983335480,
+  },
+
+  mouseInteractionTouchEnd: {
+    type: EventType.IncrementalSnapshot,
+    data: {
+      source: IncrementalSource.MouseInteraction,
+      type: MouseInteractions.TouchEnd,
+      id: 73,
+      x: 200,
+      y: 300,
+      pointerType: PointerTypes.Touch,
+    },
+    timestamp: 1744983335490,
+  },
+};
+
+module.exports = {
+  EventType,
+  IncrementalSource,
+  MouseInteractions,
+  MediaInteractions,
+  NodeType,
+  PointerTypes,
+  syntheticEvents,
+};

--- a/test/fixtures/replay/types.js
+++ b/test/fixtures/replay/types.js
@@ -1,0 +1,80 @@
+/**
+ * Shared type definitions for rrweb events
+ * Extracted from @rrweb/types/dist/index.d.ts
+ */
+
+const EventType = {
+  DomContentLoaded: 0,
+  Load: 1,
+  FullSnapshot: 2,
+  IncrementalSnapshot: 3,
+  Meta: 4,
+  Custom: 5,
+  Plugin: 6,
+};
+
+const IncrementalSource = {
+  Mutation: 0,
+  MouseMove: 1,
+  MouseInteraction: 2,
+  Scroll: 3,
+  ViewportResize: 4,
+  Input: 5,
+  TouchMove: 6,
+  MediaInteraction: 7,
+  StyleSheetRule: 8,
+  CanvasMutation: 9,
+  Font: 10,
+  Log: 11,
+  Drag: 12,
+  StyleDeclaration: 13,
+  Selection: 14,
+  AdoptedStyleSheet: 15,
+  CustomElement: 16,
+};
+
+const MouseInteractions = {
+  MouseUp: 0,
+  MouseDown: 1,
+  Click: 2,
+  ContextMenu: 3,
+  DblClick: 4,
+  Focus: 5,
+  Blur: 6,
+  TouchStart: 7,
+  TouchMove_Departed: 8,
+  TouchEnd: 9,
+  TouchCancel: 10,
+};
+
+const MediaInteractions = {
+  Play: 0,
+  Pause: 1,
+  Seeked: 2,
+  VolumeChange: 3,
+  RateChange: 4,
+};
+
+const NodeType = {
+  Document: 0,
+  DocumentType: 1,
+  Element: 2,
+  Text: 3,
+  CDATA: 4,
+  Comment: 5,
+};
+
+const PointerTypes = {
+  Mouse: 0,
+  Pen: 1,
+  Touch: 2,
+};
+
+module.exports = {
+  EventType,
+  IncrementalSource,
+  MouseInteractions,
+  MediaInteractions,
+  NodeType,
+  PointerTypes,
+};


### PR DESCRIPTION
## Description of the change

This pull request introduces a comprehensive set of fixtures and shared type definitions for `rrweb` events to facilitate testing. The changes include the creation of separate modules for real and synthetic `rrweb` events, as well as shared type definitions to standardize event handling across tests.

### New Modules for `rrweb` Events:

* **Centralized Event Export**: Added a new `index.js` file to aggregate and export all `rrweb` event types and collections (`realEvents`, `syntheticEvents`, and `allEvents`) for easier access and reuse in tests.

* **Real Event Fixtures**: Introduced `rrwebEvents.fixtures.js`, which contains a representative sample of `rrweb` events extracted from real session recordings, categorized by type. This includes events like `fullSnapshot`, `mouseMove`, `mutation`, and others.

* **Synthetic Event Fixtures**: Added `rrwebSyntheticEvents.fixtures.js` to define synthetic `rrweb` events that are not derived from real recordings but are created to ensure complete test coverage. Examples include `domContentLoaded`, `mediaInteractionPlay`, and `canvasMutation`.

### Shared Type Definitions:

* **Type Definitions Module**: Created a `types.js` file to define shared type constants such as `EventType`, `IncrementalSource`, `MouseInteractions`, and `NodeType`. These definitions are extracted from `@rrweb/types` and ensure consistency across all event fixtures.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- Fix [CAT-353/rrweb-integration](https://linear.app/rollbar-inc/issue/CAT-353/rrweb-integration)
