### PR TITLE
Use es module syntax for replay testing fixtures

### DIFF
--- a/test/fixtures/replay/index.js
+++ b/test/fixtures/replay/index.js
@@ -2,23 +2,20 @@
  * Export all rrweb fixture events in a single module
  */
 
-const types = require('./types');
-const realEvents = require('./rrwebEvents.fixtures');
-const syntheticEvents = require('./rrwebSyntheticEvents.fixtures');
+import * as types from './types.js';
+import { rrwebEvents } from './rrwebEvents.fixtures.js';
+import { syntheticEvents } from './rrwebSyntheticEvents.fixtures.js';
 
-module.exports = {
-  EventType: types.EventType,
-  IncrementalSource: types.IncrementalSource,
-  MouseInteractions: types.MouseInteractions,
-  MediaInteractions: types.MediaInteractions,
-  NodeType: types.NodeType,
-  PointerTypes: types.PointerTypes,
+export const EventType = types.EventType;
+export const IncrementalSource = types.IncrementalSource;
+export const MouseInteractions = types.MouseInteractions;
+export const MediaInteractions = types.MediaInteractions;
+export const NodeType = types.NodeType;
+export const PointerTypes = types.PointerTypes;
 
-  // Event collections
-  realEvents: realEvents.rrwebEvents,
-  syntheticEvents: syntheticEvents.syntheticEvents,
-  allEvents: {
-    ...realEvents.rrwebEvents,
-    ...syntheticEvents.syntheticEvents,
-  },
+// Event collections
+export const realEvents = rrwebEvents;
+export const allEvents = {
+  ...rrwebEvents,
+  ...syntheticEvents,
 };

--- a/test/fixtures/replay/rrwebEvents.fixtures.js
+++ b/test/fixtures/replay/rrwebEvents.fixtures.js
@@ -3,12 +3,13 @@
  * Extracted from real session recordings and categorized by type
  */
 
-const types = require('./types');
-const EventType = types.EventType;
-const IncrementalSource = types.IncrementalSource;
-const MouseInteractions = types.MouseInteractions;
-const NodeType = types.NodeType;
-const PointerTypes = types.PointerTypes;
+import {
+  EventType,
+  IncrementalSource,
+  MouseInteractions,
+  NodeType,
+  PointerTypes,
+} from './types.js';
 
 /**
  * A collection of unique rrweb events for testing
@@ -249,11 +250,4 @@ const rrwebEvents = {
   },
 };
 
-module.exports = {
-  EventType,
-  IncrementalSource,
-  MouseInteractions,
-  NodeType,
-  PointerTypes,
-  rrwebEvents,
-};
+export { rrwebEvents };

--- a/test/fixtures/replay/rrwebSyntheticEvents.fixtures.js
+++ b/test/fixtures/replay/rrwebSyntheticEvents.fixtures.js
@@ -4,13 +4,14 @@
  * type definitions in @rrweb/types to ensure complete test coverage.
  */
 
-const types = require('./types');
-const EventType = types.EventType;
-const IncrementalSource = types.IncrementalSource;
-const MouseInteractions = types.MouseInteractions;
-const MediaInteractions = types.MediaInteractions;
-const NodeType = types.NodeType;
-const PointerTypes = types.PointerTypes;
+import {
+  EventType,
+  IncrementalSource,
+  MouseInteractions,
+  MediaInteractions,
+  NodeType,
+  PointerTypes,
+} from './types.js';
 
 /**
  * Synthetic events created from type definitions for testing
@@ -327,12 +328,4 @@ const syntheticEvents = {
   },
 };
 
-module.exports = {
-  EventType,
-  IncrementalSource,
-  MouseInteractions,
-  MediaInteractions,
-  NodeType,
-  PointerTypes,
-  syntheticEvents,
-};
+export { syntheticEvents };

--- a/test/fixtures/replay/types.js
+++ b/test/fixtures/replay/types.js
@@ -3,7 +3,7 @@
  * Extracted from @rrweb/types/dist/index.d.ts
  */
 
-const EventType = {
+export const EventType = {
   DomContentLoaded: 0,
   Load: 1,
   FullSnapshot: 2,
@@ -13,7 +13,7 @@ const EventType = {
   Plugin: 6,
 };
 
-const IncrementalSource = {
+export const IncrementalSource = {
   Mutation: 0,
   MouseMove: 1,
   MouseInteraction: 2,
@@ -33,7 +33,7 @@ const IncrementalSource = {
   CustomElement: 16,
 };
 
-const MouseInteractions = {
+export const MouseInteractions = {
   MouseUp: 0,
   MouseDown: 1,
   Click: 2,
@@ -47,7 +47,7 @@ const MouseInteractions = {
   TouchCancel: 10,
 };
 
-const MediaInteractions = {
+export const MediaInteractions = {
   Play: 0,
   Pause: 1,
   Seeked: 2,
@@ -55,7 +55,7 @@ const MediaInteractions = {
   RateChange: 4,
 };
 
-const NodeType = {
+export const NodeType = {
   Document: 0,
   DocumentType: 1,
   Element: 2,
@@ -64,7 +64,7 @@ const NodeType = {
   Comment: 5,
 };
 
-const PointerTypes = {
+export const PointerTypes = {
   Mouse: 0,
   Pen: 1,
   Touch: 2,


### PR DESCRIPTION
## Description of the change

This PR refactors the `test/fixtures/replay` module to adopt ES module syntax, replacing CommonJS. It updates all relevant files to use `import` and `export` statements, ensuring consistency and modernizing the codebase.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- [CAT-353/rrweb-integration](https://linear.app/rollbar-inc/issue/CAT-353/rrweb-integration)