### PR TITLE
Use esm syntax for replay defaults and related maintenance

### DIFF
--- a/src/browser/replay/defaults.js
+++ b/src/browser/replay/defaults.js
@@ -2,7 +2,7 @@
  * Default options for the rrweb recorder
  * See https://github.com/rrweb-io/rrweb/blob/master/guide.md#options for details
  */
-module.exports = {
+export default {
   enabled: false, // Whether recording is enabled
   autoStart: true, // Start recording automatically when Rollbar initializes
   debug: {

--- a/test/fixtures/replay/rrwebEvents.fixtures.js
+++ b/test/fixtures/replay/rrwebEvents.fixtures.js
@@ -15,7 +15,7 @@ import {
  * A collection of unique rrweb events for testing
  * Extracted from real recordings
  */
-const rrwebEvents = {
+export const rrwebEvents = {
   fullSnapshot: {
     type: EventType.FullSnapshot,
     data: {
@@ -249,5 +249,3 @@ const rrwebEvents = {
     // Missing data and timestamp
   },
 };
-
-export { rrwebEvents };

--- a/test/fixtures/replay/rrwebSyntheticEvents.fixtures.js
+++ b/test/fixtures/replay/rrwebSyntheticEvents.fixtures.js
@@ -9,7 +9,6 @@ import {
   IncrementalSource,
   MouseInteractions,
   MediaInteractions,
-  NodeType,
   PointerTypes,
 } from './types.js';
 
@@ -17,7 +16,7 @@ import {
  * Synthetic events created from type definitions for testing
  * These cover sources and interactions not in the real recordings
  */
-const syntheticEvents = {
+export const syntheticEvents = {
   domContentLoaded: {
     type: EventType.DomContentLoaded,
     data: {}, // Empty object confirmed in rrweb/src/record/index.ts
@@ -327,5 +326,3 @@ const syntheticEvents = {
     timestamp: 1744983335490,
   },
 };
-
-export { syntheticEvents };

--- a/test/fixtures/replay/types.js
+++ b/test/fixtures/replay/types.js
@@ -69,12 +69,3 @@ export const PointerTypes = {
   Pen: 1,
   Touch: 2,
 };
-
-module.exports = {
-  EventType,
-  IncrementalSource,
-  MouseInteractions,
-  MediaInteractions,
-  NodeType,
-  PointerTypes,
-};


### PR DESCRIPTION
## Description of the change

_Description by Copilot._

This pull request refactors the module export structure across several files to adopt ES module syntax (`export`/`import`) instead of CommonJS (`module.exports`). The changes improve consistency, readability, and alignment with modern JavaScript standards.

### Refactoring to ES module syntax:

* [`src/browser/replay/defaults.js`](diffhunk://#diff-9350acc39773b09c02790ea03425fd52ecbf3501255f2d65788d54339c3a5507L5-R5): Replaced `module.exports` with `export default` for the default options object.
* [`test/fixtures/replay/rrwebEvents.fixtures.js`](diffhunk://#diff-ce692015d4c535f2f40b0b3bafdfc74a32156f6e731f7ba7b52aa35b2bb38fdeL18-R18): Converted `rrwebEvents` from a CommonJS export to an ES module export using `export const`. Removed the redundant `export { rrwebEvents };` statement. [[1]](diffhunk://#diff-ce692015d4c535f2f40b0b3bafdfc74a32156f6e731f7ba7b52aa35b2bb38fdeL18-R18) [[2]](diffhunk://#diff-ce692015d4c535f2f40b0b3bafdfc74a32156f6e731f7ba7b52aa35b2bb38fdeL252-L253)
* [`test/fixtures/replay/rrwebSyntheticEvents.fixtures.js`](diffhunk://#diff-648f8b6fd39798e802cdfdcdfb0453c25446861149e9299d45208ea108d6b4f9L12-R19): Updated `syntheticEvents` to use `export const` and removed the redundant `export { syntheticEvents };` statement. [[1]](diffhunk://#diff-648f8b6fd39798e802cdfdcdfb0453c25446861149e9299d45208ea108d6b4f9L12-R19) [[2]](diffhunk://#diff-648f8b6fd39798e802cdfdcdfb0453c25446861149e9299d45208ea108d6b4f9L330-L331)
* [`test/fixtures/replay/types.js`](diffhunk://#diff-7834706f22d5f84620b436e3fb8ec8b63e1e279b1bfeb04589421b7ed1194b7fL72-L80): Removed the `module.exports` block entirely, as individual exports (`export const`) are already defined for each type.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- [CAT-353/rrweb-integration](https://linear.app/rollbar-inc/issue/CAT-353/rrweb-integration)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
