### PR TITLE
Add trace attributes to item

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -46,7 +46,7 @@ function Rollbar(options, client) {
   }
 
   this.client =
-    client || new Client(this.options, api, logger, this.telemeter, 'browser');
+    client || new Client(this.options, api, logger, this.telemeter, this.tracing, 'browser');
   var gWindow = _gWindow();
   var gDocument = typeof document != 'undefined' && document;
   this.isChrome = gWindow.chrome && gWindow.chrome.runtime; // check .runtime to avoid Edge browsers

--- a/src/react-native/rollbar.js
+++ b/src/react-native/rollbar.js
@@ -30,7 +30,7 @@ function Rollbar(options, client) {
   var api = new API(this.options, transport, urllib, truncation);
   var telemeter = new Telemeter(this.options);
   this.client =
-    client || new Client(this.options, api, logger, telemeter, 'react-native');
+    client || new Client(this.options, api, logger, telemeter, null, 'react-native');
   addTransformsToNotifier(this.client.notifier);
   addPredicatesToQueue(this.client.queue);
   _.setupJSON(polyfillJSON);

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -10,7 +10,7 @@ var _ = require('./utility');
  * @param api
  * @param logger
  */
-function Rollbar(options, api, logger, telemeter, platform) {
+function Rollbar(options, api, logger, telemeter, tracing, platform) {
   this.options = _.merge(options);
   this.logger = logger;
   Rollbar.rateLimiter.configureGlobal(this.options);
@@ -18,6 +18,9 @@ function Rollbar(options, api, logger, telemeter, platform) {
   this.api = api;
   this.queue = new Queue(Rollbar.rateLimiter, api, logger, this.options);
 
+  this.tracing = tracing;
+
+  // Legacy OpenTracing support
   // This must happen before the Notifier is created
   var tracer = this.options.tracer || null;
   if (validateTracer(tracer)) {
@@ -57,6 +60,7 @@ Rollbar.prototype.configure = function (options, payloadData) {
 
   this.options = _.merge(oldOptions, options, payload);
 
+  // Legacy OpenTracing support
   // This must happen before the Notifier is configured
   var tracer = this.options.tracer || null;
   if (validateTracer(tracer)) {
@@ -150,6 +154,9 @@ Rollbar.prototype._log = function (defaultLevel, item) {
     return;
   }
   try {
+    this._addTracingAttributes(item);
+
+    // Legacy OpenTracing support
     this._addTracingInfo(item);
     item.level = item.level || defaultLevel;
     this.telemeter && this.telemeter._captureRollbarItem(item);
@@ -161,6 +168,26 @@ Rollbar.prototype._log = function (defaultLevel, item) {
       callback(e);
     }
     this.logger.error(e);
+  }
+};
+
+Rollbar.prototype._addTracingAttributes = function (item) {
+  if (this.tracing) {
+    const span = this.tracing.getSpan();
+    if (!span) {
+      return;
+    }
+    const attributes = [
+      {key: 'session_id', value: this.tracing.sessionId()},
+      {key: 'span_id', value: span.spanId()},
+      {key: 'trace_id', value: span.traceId()},
+    ];
+    _.addItemAttributes(item, attributes);
+
+    span.addEvent(
+      'rollbar.occurrence',
+      [{key: 'rollbar.occurrence.uuid', value: item.uuid}],
+    );
   }
 };
 

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -172,23 +172,21 @@ Rollbar.prototype._log = function (defaultLevel, item) {
 };
 
 Rollbar.prototype._addTracingAttributes = function (item) {
-  if (this.tracing) {
-    const span = this.tracing.getSpan();
-    if (!span) {
-      return;
-    }
-    const attributes = [
-      {key: 'session_id', value: this.tracing.sessionId()},
-      {key: 'span_id', value: span.spanId()},
-      {key: 'trace_id', value: span.traceId()},
-    ];
-    _.addItemAttributes(item, attributes);
-
-    span.addEvent(
-      'rollbar.occurrence',
-      [{key: 'rollbar.occurrence.uuid', value: item.uuid}],
-    );
+  const span = this.tracing?.getSpan();
+  if (!span) {
+    return;
   }
+  const attributes = [
+    {key: 'session_id', value: this.tracing.sessionId},
+    {key: 'span_id', value: span.spanId},
+    {key: 'trace_id', value: span.traceId},
+  ];
+  _.addItemAttributes(item, attributes);
+
+  span.addEvent(
+    'rollbar.occurrence',
+    [{key: 'rollbar.occurrence.uuid', value: item.uuid}],
+  );
 };
 
 Rollbar.prototype._defaultLogLevel = function () {

--- a/src/server/rollbar.js
+++ b/src/server/rollbar.js
@@ -41,7 +41,7 @@ function Rollbar(options, client) {
   var api = new API(this.options, transport, urllib, truncation, jsonBackup);
   var telemeter = new Telemeter(this.options);
   this.client =
-    client || new Client(this.options, api, logger, telemeter, 'server');
+    client || new Client(this.options, api, logger, telemeter, null, 'server');
   this.instrumenter = new Instrumenter(
     this.options,
     this.client.telemeter,

--- a/src/tracing/span.js
+++ b/src/tracing/span.js
@@ -37,11 +37,11 @@ export class Span {
     return this.span.spanContext;
   }
 
-  spanId() {
+  get spanId() {
     return this.span.spanContext.spanId;
   }
 
-  traceId() {
+  get traceId() {
     return this.span.spanContext.traceId;
   }
 

--- a/src/tracing/span.js
+++ b/src/tracing/span.js
@@ -37,6 +37,14 @@ export class Span {
     return this.span.spanContext;
   }
 
+  spanId() {
+    return this.span.spanContext.spanId;
+  }
+
+  traceId() {
+    return this.span.spanContext.traceId;
+  }
+
   setAttribute(key, value) {
     if (value == null || this.ended) return this;
     if (key.length === 0) return this;

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -23,6 +23,14 @@ export default class Tracing {
     }
   }
 
+  sessionId() {
+    if (this.session) {
+      return this.session.session.id;
+    }
+    return null;
+  }
+
+
   createTracer() {
     this.contextManager = new ContextManager();
     this.exporter = new SpanExporter();

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -23,7 +23,7 @@ export default class Tracing {
     }
   }
 
-  sessionId() {
+  get sessionId() {
     if (this.session) {
       return this.session.session.id;
     }

--- a/src/utility.js
+++ b/src/utility.js
@@ -544,6 +544,8 @@ function createItem(args, logger, notifier, requestKeys, lambdaContext) {
     uuid: uuid4(),
   };
 
+  item.data = item.data || {};
+
   setCustomItemKeys(item, custom);
 
   if (requestKeys && request) {
@@ -639,6 +641,13 @@ function createTelemetryEvent(args) {
   };
 
   return event;
+}
+
+function addItemAttributes(item, attributes) {
+  item.data.attributes = item.data.attributes || [];
+  if (attributes) {
+    item.data.attributes.push(...attributes);
+  }
 }
 
 /*
@@ -794,6 +803,7 @@ module.exports = {
   createItem: createItem,
   addErrorContext: addErrorContext,
   createTelemetryEvent: createTelemetryEvent,
+  addItemAttributes: addItemAttributes,
   filterIp: filterIp,
   formatArgsAsString: formatArgsAsString,
   formatUrl: formatUrl,

--- a/test/tracing/span.test.js
+++ b/test/tracing/span.test.js
@@ -167,6 +167,8 @@ describe('Span()', function () {
   it('should keep valid state', function (done) {
     const span = new Span(spanOptions());
     expect(span.isRecording()).to.equal(true);
+    expect(span.spanId()).to.match(/^[a-f0-9]{16}$/);
+    expect(span.traceId()).to.match(/^[a-f0-9]{32}$/);
 
     span.end();
     expect(span.isRecording()).to.equal(false);

--- a/test/tracing/span.test.js
+++ b/test/tracing/span.test.js
@@ -167,8 +167,8 @@ describe('Span()', function () {
   it('should keep valid state', function (done) {
     const span = new Span(spanOptions());
     expect(span.isRecording()).to.equal(true);
-    expect(span.spanId()).to.match(/^[a-f0-9]{16}$/);
-    expect(span.traceId()).to.match(/^[a-f0-9]{32}$/);
+    expect(span.spanId).to.match(/^[a-f0-9]{16}$/);
+    expect(span.traceId).to.match(/^[a-f0-9]{32}$/);
 
     span.end();
     expect(span.isRecording()).to.equal(false);

--- a/test/tracing/tracing.test.js
+++ b/test/tracing/tracing.test.js
@@ -61,7 +61,7 @@ describe('Tracing()', function () {
     const t = new Tracing(window, options);
     t.initSession()
 
-    expect(t.sessionId()).to.match(/^[a-f0-9]{32}$/);
+    expect(t.sessionId).to.match(/^[a-f0-9]{32}$/);
 
     const span = t.startSpan('test.span');
 

--- a/test/tracing/tracing.test.js
+++ b/test/tracing/tracing.test.js
@@ -61,6 +61,8 @@ describe('Tracing()', function () {
     const t = new Tracing(window, options);
     t.initSession()
 
+    expect(t.sessionId()).to.match(/^[a-f0-9]{32}$/);
+
     const span = t.startSpan('test.span');
 
     expect(span.span.name).to.equal('test.span')


### PR DESCRIPTION
## Description of the change

* Adds a general utility for adding attributes to an occurrence.
* Adds span attributes to the occurrence for session_id, span_id, and trace_id if there is an active span at the time of the occurrence.
* Adds an event to the current span for the occurrence.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

