### PR TITLE
Add path aliases for cleaner imports

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -82,6 +82,17 @@ module.exports = function (config) {
           },
         ],
       },
+      resolve: {
+        alias: {
+          '@rollbar': path.resolve(__dirname, 'src'),
+          '@browser': path.resolve(__dirname, 'src/browser'),
+          '@server': path.resolve(__dirname, 'src/server'),
+          '@tracing': path.resolve(__dirname, 'src/tracing'),
+          '@utility': path.resolve(__dirname, 'src/utility'),
+          '@react-native': path.resolve(__dirname, 'src/react-native')
+        },
+        extensions: ['.js', '.json']
+      },
     },
 
     webpackMiddleware: {

--- a/src/browser/replay/replayMap.js
+++ b/src/browser/replay/replayMap.js
@@ -1,4 +1,4 @@
-import { spanExportQueue } from '../../tracing/exporter.js';
+import { spanExportQueue } from '@tracing/exporter.js';
 
 /**
  * ReplayMap - Manages the mapping between error occurrences and their associated

--- a/test/replay/integration/api.spans.test.js
+++ b/test/replay/integration/api.spans.test.js
@@ -10,7 +10,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import Api from '../../../src/api.js';
+import Api from '@rollbar/api.js';
 
 describe('API Span Transport', function () {
   let api;

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -10,14 +10,14 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import Tracing from '../../../src/tracing/tracing.js';
-import { SpanExporter } from '../../../src/tracing/exporter.js';
-import { spanExportQueue } from '../../../src/tracing/exporter.js';
-import Recorder from '../../../src/browser/replay/recorder.js';
-import ReplayMap from '../../../src/browser/replay/replayMap.js';
-import recorderDefaults from '../../../src/browser/replay/defaults.js';
-import Api from '../../../src/api.js';
-import Queue from '../../../src/queue.js';
+import Tracing from '@tracing/tracing.js';
+import { SpanExporter } from '@tracing/exporter.js';
+import { spanExportQueue } from '@tracing/exporter.js';
+import Recorder from '@browser/replay/recorder.js';
+import ReplayMap from '@browser/replay/replayMap.js';
+import recorderDefaults from '@browser/replay/defaults.js';
+import Api from '@rollbar/api.js';
+import Queue from '@rollbar/queue.js';
 import { mockRecordFn } from '../util';
 
 const options = {

--- a/test/replay/integration/queue.replayMap.test.js
+++ b/test/replay/integration/queue.replayMap.test.js
@@ -10,8 +10,8 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import Queue from '../../../src/queue.js';
-import Api from '../../../src/api.js';
+import Queue from '@rollbar/queue.js';
+import Api from '@rollbar/api.js';
 
 describe('Queue ReplayMap Integration', function () {
   let queue;

--- a/test/replay/integration/replayMap.test.js
+++ b/test/replay/integration/replayMap.test.js
@@ -10,12 +10,12 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import ReplayMap from '../../../src/browser/replay/replayMap.js';
-import Recorder from '../../../src/browser/replay/recorder.js';
-import Tracing from '../../../src/tracing/tracing.js';
-import { SpanExporter } from '../../../src/tracing/exporter.js';
-import { spanExportQueue } from '../../../src/tracing/exporter.js';
-import Api from '../../../src/api.js';
+import ReplayMap from '@browser/replay/replayMap.js';
+import Recorder from '@browser/replay/recorder.js';
+import Tracing from '@tracing/tracing.js';
+import { SpanExporter } from '@tracing/exporter.js';
+import { spanExportQueue } from '@tracing/exporter.js';
+import Api from '@rollbar/api.js';
 import { mockRecordFn } from '../util';
 
 const options = {

--- a/test/replay/integration/sessionRecording.test.js
+++ b/test/replay/integration/sessionRecording.test.js
@@ -11,17 +11,17 @@ import { expect } from 'chai';
 import { EventType } from '@rrweb/types';
 import sinon from 'sinon';
 
-import Tracing from '../../../src/tracing/tracing.js';
-import { Span } from '../../../src/tracing/span.js';
-import { Context } from '../../../src/tracing/context.js';
-import { SpanExporter } from '../../../src/tracing/exporter.js';
-import Recorder from '../../../src/browser/replay/recorder.js';
-import ReplayMap from '../../../src/browser/replay/replayMap.js';
-import recorderDefaults from '../../../src/browser/replay/defaults.js';
-import { spanExportQueue } from '../../../src/tracing/exporter.js';
+import Tracing from '@tracing/tracing.js';
+import { Span } from '@tracing/span.js';
+import { Context } from '@tracing/context.js';
+import { SpanExporter } from '@tracing/exporter.js';
+import Recorder from '@browser/replay/recorder.js';
+import ReplayMap from '@browser/replay/replayMap.js';
+import recorderDefaults from '@browser/replay/defaults.js';
+import { spanExportQueue } from '@tracing/exporter.js';
 import { mockRecordFn } from '../util';
-import Api from '../../../src/api.js';
-import Queue from '../../../src/queue.js';
+import Api from '@rollbar/api.js';
+import Queue from '@rollbar/queue.js';
 
 const options = {
   enabled: true,

--- a/test/replay/unit/api.postSpans.test.js
+++ b/test/replay/unit/api.postSpans.test.js
@@ -12,7 +12,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 // We need to use require since the API module is a CommonJS module
-const Api = require('../../../src/api');
+const Api = require('@rollbar/api');
 
 describe('Api', function () {
   let api;

--- a/test/replay/unit/queue.replayMap.test.js
+++ b/test/replay/unit/queue.replayMap.test.js
@@ -12,7 +12,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 // We need to use require since the Queue module is CommonJS
-const Queue = require('../../../src/queue');
+const Queue = require('@rollbar/queue');
 
 // Mock ReplayMap implementation
 class MockReplayMap {

--- a/test/replay/unit/replayMap.test.js
+++ b/test/replay/unit/replayMap.test.js
@@ -10,8 +10,8 @@
 
 import { expect } from 'chai';
 import sinon from 'sinon';
-import ReplayMap from '../../../src/browser/replay/replayMap.js';
-import { spanExportQueue } from '../../../src/tracing/exporter.js';
+import ReplayMap from '@browser/replay/replayMap.js';
+import { spanExportQueue } from '@tracing/exporter.js';
 
 // Mock objects for testing
 class MockSpan {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ var defaults = require('./defaults');
 var TerserPlugin = require('terser-webpack-plugin');
 
 var outputPath = path.resolve(__dirname, 'dist');
+var srcPath = path.resolve(__dirname, 'src');
 
 var defaultsPlugin = new webpack.DefinePlugin(defaults);
 var uglifyPlugin = new TerserPlugin({
@@ -29,6 +30,17 @@ var snippetConfig = {
         exclude: [/node_modules/, /vendor/],
       },
     ],
+  },
+  resolve: {
+    alias: {
+      '@rollbar': srcPath,
+      '@browser': path.resolve(srcPath, 'browser'),
+      '@server': path.resolve(srcPath, 'server'),
+      '@tracing': path.resolve(srcPath, 'tracing'),
+      '@utility': path.resolve(srcPath, 'utility'),
+      '@react-native': path.resolve(srcPath, 'react-native')
+    },
+    extensions: ['.js', '.json']
   },
 };
 
@@ -72,6 +84,17 @@ var vanillaConfigBase = {
       },
     ],
   },
+  resolve: {
+    alias: {
+      '@rollbar': srcPath,
+      '@browser': path.resolve(srcPath, 'browser'),
+      '@server': path.resolve(srcPath, 'server'),
+      '@tracing': path.resolve(srcPath, 'tracing'),
+      '@utility': path.resolve(srcPath, 'utility'),
+      '@react-native': path.resolve(srcPath, 'react-native')
+    },
+    extensions: ['.js', '.json']
+  },
 };
 
 var UMDConfigBase = {
@@ -94,6 +117,17 @@ var UMDConfigBase = {
         exclude: [/node_modules/, /vendor/],
       },
     ],
+  },
+  resolve: {
+    alias: {
+      '@rollbar': srcPath,
+      '@browser': path.resolve(srcPath, 'browser'),
+      '@server': path.resolve(srcPath, 'server'),
+      '@tracing': path.resolve(srcPath, 'tracing'),
+      '@utility': path.resolve(srcPath, 'utility'),
+      '@react-native': path.resolve(srcPath, 'react-native')
+    },
+    extensions: ['.js', '.json']
   },
 };
 


### PR DESCRIPTION
## Description of the change

I was getting tired of the relative subdirs when doing imports and checked if there's an idiomatic way of improving how we can refer to different paths without crawling for directories. Turns out there's, path aliases.

Added some configuration and updated the imports and it seems to be working just fine. Although I don't know if this could generate other issues for SDK users.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release