### PR TITLE
Extracted hrtime utilities in tracing to its own module

### DIFF
--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -1,6 +1,8 @@
 import { record as rrwebRecordFn } from '@rrweb/record';
 import { EventType } from '@rrweb/types';
 
+import hrtime from '../../tracing/hrtime.js';
+
 export default class Recorder {
   #tracing;
   #options;
@@ -77,9 +79,7 @@ export default class Recorder {
       event.timestamp < earliestEvent.timestamp ? event : earliestEvent,
     );
 
-    recordingSpan.span.startTime = recordingSpan.toHrTime(
-      earliestEvent.timestamp,
-    );
+    recordingSpan.span.startTime = hrtime.fromMillis(earliestEvent.timestamp);
 
     for (const event of events) {
       recordingSpan.addEvent(
@@ -88,7 +88,7 @@ export default class Recorder {
           eventType: event.type,
           json: JSON.stringify(event.data),
         },
-        recordingSpan.toHrTime(event.timestamp),
+        hrtime.fromMillis(event.timestamp),
       );
     }
 

--- a/src/tracing/hrtime.js
+++ b/src/tracing/hrtime.js
@@ -1,0 +1,88 @@
+/**
+ * @module hrtime
+ *
+ * @description Methods for handling OpenTelemetry hrtime.
+ */
+
+/**
+ * Convert a duration in milliseconds to an OpenTelemetry hrtime tuple.
+ *
+ * @param {number} millis - The duration in milliseconds.
+ * @returns {[number, number]} An array where the first element is seconds
+ *   and the second is nanoseconds.
+ */
+function fromMillis(millis) {
+  return [Math.trunc(millis / 1000), Math.round((millis % 1000) * 1e6)];
+}
+
+/**
+ * Convert an OpenTelemetry hrtime tuple back to a duration in milliseconds.
+ *
+ * @param {[number, number]} hrtime - The hrtime tuple [seconds, nanoseconds].
+ * @returns {number} The total duration in milliseconds.
+ */
+function toMillis(hrtime) {
+  return hrtime[0] * 1e3 + Math.round(hrtime[1] / 1e6);
+}
+
+/**
+ * Adds two OpenTelemetry hrtime tuples.
+ *
+ * @param {[number, number]} a - The first hrtime tuple [s, ns].
+ * @param {[number, number]} b - The second hrtime tuple [s, ns].
+ * @returns {[number, number]} Summed hrtime tuple, normalized.
+ *
+ */
+function add(a, b) {
+  return [a[0] + b[0] + Math.trunc((a[1] + b[1]) / 1e9), (a[1] + b[1]) % 1e9];
+}
+
+/**
+ * Get the current high-resolution time as an OpenTelemetry hrtime tuple.
+ *
+ * Uses the Performance API (timeOrigin + now()).
+ *
+ * @returns {[number, number]} The current hrtime tuple [s, ns].
+ */
+function now() {
+  return add(fromMillis(performance.timeOrigin), fromMillis(performance.now()));
+}
+
+/**
+ * Check if a value is a valid OpenTelemetry hrtime tuple.
+ *
+ * An hrtime tuple is an Array of exactly two numbers:
+ *   [seconds, nanoseconds]
+ *
+ * @param {*} value – anything to test
+ * @returns {boolean} true if `value` is a [number, number] array of length 2
+ *
+ * @example
+ * isHrTime([ 1, 500 ]);         // true
+ * isHrTime([ 0, 1e9 ]);         // true
+ * isHrTime([ '1', 500 ]);       // false
+ * isHrTime({ 0: 1, 1: 500 });   // false
+ */
+function isHrTime(value) {
+  return (
+    Array.isArray(value) &&
+    value.length === 2 &&
+    typeof value[0] === 'number' &&
+    typeof value[1] === 'number'
+  );
+}
+
+/**
+ * Methods for handling hrtime. OpenTelemetry uses the [seconds, nanoseconds]
+ * format for hrtime in the `ReadableSpan` interface.
+ *
+ * @example
+ * import hrtime from '@tracing/hrtime.js';
+ *
+ * hrtime.fromMillis(1000);
+ * hrtime.toMillis([0, 1000]);
+ * hrtime.add([0, 0], [0, 1000]);
+ * hrtime.now();
+ * hrtime.isHrTime([0, 1000]);
+ */
+export default { fromMillis, toMillis, add, now, isHrTime };

--- a/src/tracing/span.js
+++ b/src/tracing/span.js
@@ -1,6 +1,8 @@
+import hrtime from './hrtime.js';
+
 export class Span {
   constructor(options) {
-    this.initReadableSpan(options)
+    this.initReadableSpan(options);
 
     this.spanProcessor = options.spanProcessor;
     this.spanProcessor.onStart(this, options.context);
@@ -17,10 +19,10 @@ export class Span {
       kind: options.kind,
       spanContext: options.spanContext,
       parentSpanId: options.parentSpanId,
-      startTime: options.startTime || this.hrTimeNow(),
+      startTime: options.startTime || hrtime.now(),
       endTime: [0, 0],
-      status: {code: 0, message: ''},
-      attributes: {'session.id': options.session.id},
+      status: { code: 0, message: '' },
+      attributes: { 'session.id': options.session.id },
       links: [],
       events: [],
       duration: 0,
@@ -30,7 +32,7 @@ export class Span {
       droppedAttributesCount: 0,
       droppedEventsCount: 0,
       droppedLinksCount: 0,
-    }
+    };
   }
 
   spanContext() {
@@ -66,7 +68,7 @@ export class Span {
     this.span.events.push({
       name,
       attributes,
-      time: time || this.hrTimeNow(),
+      time: time || hrtime.now(),
       droppedAttributesCount: 0,
     });
 
@@ -79,29 +81,9 @@ export class Span {
 
   end(attributes, time) {
     if (attributes) this.setAttributes(attributes);
-    this.span.endTime = time || this.hrTimeNow();
+    this.span.endTime = time || hrtime.now();
     this.span.ended = true;
     this.spanProcessor.onEnd(this);
-  }
-
-  /*
-   * Methods for handling hrtime.
-   * OpenTelemetry uses the [seconds, nanoseconds] format for hrtime in the
-   * ReadableSpan interface.
-   */
-  toHrTime(millis) {
-    return [Math.trunc(millis / 1000), Math.round((millis % 1000) * 1e6)];
-  }
-
-  sumHrTime(a, b) {
-    return [a[0] + b[0] + Math.trunc((a[1] + b[1]) / 1e9), (a[1] + b[1]) % 1e9];
-  }
-
-  hrTimeNow() {
-    return this.sumHrTime(
-      this.toHrTime(performance.timeOrigin),
-      this.toHrTime(performance.now())
-    );
   }
 
   export() {

--- a/test/browser.replay.recorder.test.js
+++ b/test/browser.replay.recorder.test.js
@@ -19,10 +19,6 @@ describe('Recorder', function () {
   beforeEach(function () {
     mockSpan = {
       addEvent: sinon.spy(),
-      toHrTime: (timestamp) => [
-        Math.floor(timestamp / 1000),
-        (timestamp % 1000) * 1000000,
-      ],
       span: { startTime: null },
       end: sinon.spy(),
     };

--- a/test/tracing/span.test.js
+++ b/test/tracing/span.test.js
@@ -7,6 +7,7 @@ import { Span } from '../../src/tracing/span.js';
 import { SpanExporter, spanExportQueue } from '../../src/tracing/exporter.js';
 import { SpanProcessor } from '../../src/tracing/spanProcessor.js';
 import { ROOT_CONTEXT } from '../../src/tracing/context.js';
+import hrtime from '../../src/tracing/hrtime.js';
 
 const spanOptions = function (options = {}) {
   const exporter = new SpanExporter();
@@ -41,7 +42,7 @@ const spanOptions = function (options = {}) {
     spanProcessor: spanProcessor,
     ...options,
   };
-}
+};
 
 const expectReadableSpan = function (span, overrides = {}) {
   const expected = {
@@ -92,11 +93,15 @@ const expectReadableSpan = function (span, overrides = {}) {
   expect(span.span.duration).to.equal(expected.duration);
   expect(span.span.ended).to.equal(expected.ended);
   expect(span.span.resource).to.deep.equal(expected.resource);
-  expect(span.span.instrumentationScope).to.deep.equal(expected.instrumentationScope);
-  expect(span.span.droppedAttributesCount).to.equal(expected.droppedAttributesCount);
+  expect(span.span.instrumentationScope).to.deep.equal(
+    expected.instrumentationScope,
+  );
+  expect(span.span.droppedAttributesCount).to.equal(
+    expected.droppedAttributesCount,
+  );
   expect(span.span.droppedEventsCount).to.equal(expected.droppedEventsCount);
   expect(span.span.droppedLinksCount).to.equal(expected.droppedLinksCount);
-}
+};
 
 describe('Span()', function () {
   it('should create a readable span', function (done) {
@@ -111,7 +116,7 @@ describe('Span()', function () {
     };
     span.setAttributes(attributes);
 
-    const eventTime = span.hrTimeNow()
+    const eventTime = hrtime.now();
     const events = [
       {
         name: 'event1',
@@ -143,7 +148,7 @@ describe('Span()', function () {
 
     expectReadableSpan(span, overrides);
 
-    const endTime = span.hrTimeNow()
+    const endTime = hrtime.now();
     const endAttributes = {
       key3: 'value3',
       key4: 'value4',
@@ -162,7 +167,6 @@ describe('Span()', function () {
 
     done();
   });
-
 
   it('should keep valid state', function (done) {
     const span = new Span(spanOptions());


### PR DESCRIPTION
## Description of the change

This PR introduces a dedicated utility module, `hrtime.js` and a new way to interface with it:
```js
import hrtime from '@tracing/hrtime.js';

hrtime.fromMillis(1000);
hrtime.toMillis([0, 1000]);
hrtime.add([0, 0], [0, 1000]);
hrtime.now();
hrtime.isHrTime([0, 1000]);
```

The reason is that I've been needing to use this in multiple modules and I don't see why its access should be dependent upon an instance of `Span`.

- Renames `sum` to `add` to follow OTEL convention @ https://github.com/open-telemetry/opentelemetry-js/blob/0c21db4621fd981200cc731d676d1a87162ee0d9/packages/opentelemetry-core/src/common/time.ts#L173-L183

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
