### PR TITLE
Extract tracing's `hexId` to dedicated `id` module

### DIFF
--- a/src/browser/replay/replayMap.js
+++ b/src/browser/replay/replayMap.js
@@ -1,4 +1,5 @@
 import { spanExportQueue } from '../../tracing/exporter.js';
+import id from '../../tracing/id.js';
 
 /**
  * ReplayMap - Manages the mapping between error occurrences and their associated
@@ -83,7 +84,7 @@ export default class ReplayMap {
    */
   add() {
     // 8 bytes hexId matches the span ID size in the tracing system
-    const replayId = this.#tracing.hexId(8);
+    const replayId = id.gen(8);
 
     this._processReplay(replayId).catch((error) => {
       console.error('Failed to process replay:', error);

--- a/src/tracing/id.js
+++ b/src/tracing/id.js
@@ -1,0 +1,24 @@
+/**
+ * Generate a random hexadecimal ID of specified byte length
+ *
+ * @param {number} bytes - Number of bytes for the ID (default: 16)
+ * @returns {string} - Hexadecimal string representation
+ */
+function gen(bytes = 16) {
+  let randomBytes = new Uint8Array(bytes);
+  crypto.getRandomValues(randomBytes);
+  let randHex = Array.from(randomBytes, (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+  return randHex;
+}
+
+/**
+ * Tracing id generation utils
+ *
+ * @example
+ * import id from './id.js';
+ *
+ * const spanId = id.gen(8); // => "a1b2c3d4e5f6..."
+ */
+export default { gen };

--- a/src/tracing/session.js
+++ b/src/tracing/session.js
@@ -1,3 +1,5 @@
+import id from './id.js';
+
 const SESSION_KEY = 'RollbarSession';
 
 export class Session {
@@ -32,7 +34,7 @@ export class Session {
 
   createSession() {
     this.session = {
-      id: this.tracing.hexId(),
+      id: id.gen(),
       createdAt: Date.now(),
     };
 

--- a/src/tracing/tracer.js
+++ b/src/tracing/tracer.js
@@ -1,4 +1,5 @@
 import { Span } from './span.js';
+import id from './id.js';
 
 export class Tracer {
   constructor(tracing, spanProcessor) {
@@ -13,7 +14,7 @@ export class Tracer {
   ) {
     const parentSpan = this.tracing.getSpan(context);
     const parentSpanContext = parentSpan?.spanContext();
-    const spanId = this.tracing.hexId(8);
+    const spanId = id.gen(8);
     let traceId;
     let traceFlags = 0;
     let traceState = null;
@@ -23,7 +24,7 @@ export class Tracer {
       traceState = parentSpanContext.traceState;
       parentSpanId = parentSpanContext.spanId;
     } else {
-      traceId = this.tracing.hexId(16);
+      traceId = id.gen(16);
     }
 
     const kind = 0;

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -62,11 +62,4 @@ export default class Tracing {
     const span = this.startSpan(name, options);
     return this.with(this.setSpan(this.contextManager.active(), span), fn, thisArg, span);
   }
-
-  hexId(bytes = 16) {
-    let randomBytes = new Uint8Array(bytes);
-    crypto.getRandomValues(randomBytes);
-    let randHex = Array.from(randomBytes, byte => byte.toString(16).padStart(2, '0')).join('');
-    return randHex;
-  }
 }

--- a/test/replay/unit/replayMap.test.js
+++ b/test/replay/unit/replayMap.test.js
@@ -12,6 +12,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import ReplayMap from '../../../src/browser/replay/replayMap.js';
 import { spanExportQueue } from '../../../src/tracing/exporter.js';
+import id from '../../../src/tracing/id.js';
 
 // Mock objects for testing
 class MockSpan {
@@ -60,6 +61,9 @@ describe('ReplayMap', function () {
   beforeEach(function () {
     // Clear the spanExportQueue before each test
     spanExportQueue.length = 0;
+
+    // Stub id.gen to return a predictable value
+    sinon.stub(id, 'gen').returns('1234567890abcdef');
 
     mockRecorder = new MockRecorder();
     mockExporter = new MockExporter();
@@ -190,7 +194,7 @@ describe('ReplayMap', function () {
       const replayId = replayMap.add();
 
       expect(replayId).to.equal('1234567890abcdef');
-      expect(mockTracing.hexId.calledWith(8)).to.be.true;
+      expect(id.gen.calledWith(8)).to.be.true;
       expect(processStub.calledWith(replayId)).to.be.true;
     });
 

--- a/test/tracing/id.test.js
+++ b/test/tracing/id.test.js
@@ -1,0 +1,26 @@
+/* globals describe */
+/* globals it */
+
+import { expect } from 'chai';
+import id from '../../src/tracing/id.js';
+
+describe('id', function () {
+  it('should generate random hex id of specified byte length', function (done) {
+    const id8 = id.gen(8);
+    const id16 = id.gen(16);
+    const id32 = id.gen(32);
+    
+    expect(id8).to.match(/^[a-f0-9]{16}$/);
+    expect(id16).to.match(/^[a-f0-9]{32}$/);
+    expect(id32).to.match(/^[a-f0-9]{64}$/);
+    
+    // Default should be 16 bytes (32 hex chars)
+    const defaultId = id.gen();
+    expect(defaultId).to.match(/^[a-f0-9]{32}$/);
+    
+    // Should generate different IDs
+    expect(id.gen()).to.not.equal(id.gen());
+    
+    done();
+  });
+});

--- a/test/tracing/tracing.test.js
+++ b/test/tracing/tracing.test.js
@@ -42,7 +42,6 @@ describe('Tracing()', function () {
     expect(t).to.have.property('setSpan').and.to.be.a('function');
     expect(t).to.have.property('with').and.to.be.a('function');
     expect(t).to.have.property('withSpan').and.to.be.a('function');
-    expect(t).to.have.property('hexId').and.to.be.a('function');
 
     expect(t.contextManager).to.be.an.instanceOf(ContextManager);
     expect(t.session).to.be.an.instanceOf(Session);


### PR DESCRIPTION
## Description of the change

Extracted hexId into its own module `id.js` module with a `gen` function to generate the random hexadecimal IDs.

#### Reasoning
- Not used by tracing
- There are Ids that use the same mechanism but aren't structurally bound to otel or tracing (replay ids, session ids)
- I needed to generate replay ids to unit test dump, the unit test was isolated, and I didn't have (nor wanted) a tracing instance.
- We can unit test id generation isolatedly (there were no tests for it).

> [!WARNING]
> Not super happy with the naming scheme, open to suggestions. I favor concise, that's why I went with this, but maybe it's too much.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- [CAT-355/enable-tracesession-transport-to-moxapi](https://linear.app/rollbar-inc/issue/CAT-355/enable-tracesession-transport-to-moxapi)
