### PR TITLE
Refactor recorder and replayMap transport flow

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -36,9 +36,9 @@ function Rollbar(options, client) {
     this.tracing.initSession();
   }
 
-  if (Tracing && Recorder && _.isBrowser()) {
+  if (Recorder && _.isBrowser()) {
     const recorderOptions = this.options.recorder;
-    this.recorder = new Recorder(this.tracing, recorderOptions);
+    this.recorder = new Recorder(recorderOptions);
 
     if (recorderOptions.enabled && recorderOptions.autoStart) {
       this.recorder.start();

--- a/test/fixtures/replay/index.js
+++ b/test/fixtures/replay/index.js
@@ -1,9 +1,10 @@
 /**
- * Export all rrweb fixture events in a single module
+ * Export all rrweb fixture events and payloads in a single module
  */
 
 import { rrwebEvents } from './rrwebEvents.fixtures.js';
 import { syntheticEvents } from './rrwebSyntheticEvents.fixtures.js';
+import * as payloads from './payloads.fixtures.js';
 
 // Event collections
 export const realEvents = rrwebEvents;
@@ -11,3 +12,9 @@ export const allEvents = {
   ...rrwebEvents,
   ...syntheticEvents,
 };
+
+// Payload fixtures
+export const standardPayload = payloads.standardPayload;
+export const checkpointPayload = payloads.checkpointPayload;
+export const singleCheckpointPayload = payloads.singleCheckpointPayload;
+export const createPayloadWithReplayId = payloads.createPayloadWithReplayId;

--- a/test/fixtures/replay/payloads.fixtures.js
+++ b/test/fixtures/replay/payloads.fixtures.js
@@ -1,0 +1,158 @@
+/**
+ * Fixtures for OTLP-formatted payloads used in tests
+ */
+import { EventType } from '@rrweb/types';
+
+/**
+ * Standard payload with one event of each type (Meta and FullSnapshot)
+ */
+export const standardPayload = {
+  resourceSpans: [
+    {
+      resource: { attributes: [] },
+      scopeSpans: [
+        {
+          scope: { name: 'rollbar.js', version: '1.0.0' },
+          spans: [
+            {
+              name: 'rrweb-replay-recording',
+              attributes: [
+                { key: 'rollbar.replay.id', value: { stringValue: 'test-replay-id' } }
+              ],
+              events: [
+                {
+                  name: 'rrweb-replay-events',
+                  attributes: [
+                    { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
+                    { key: 'json', value: { stringValue: '{}' } }
+                  ]
+                },
+                {
+                  name: 'rrweb-replay-events',
+                  attributes: [
+                    { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
+                    { key: 'json', value: { stringValue: '{}' } }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+/**
+ * Checkpoint payload with multiple Meta and FullSnapshot events
+ * representing checkpoints in the recording
+ */
+export const checkpointPayload = {
+  resourceSpans: [
+    {
+      resource: { attributes: [] },
+      scopeSpans: [
+        {
+          scope: { name: 'rollbar.js', version: '1.0.0' },
+          spans: [
+            {
+              name: 'rrweb-replay-recording',
+              attributes: [
+                { key: 'rollbar.replay.id', value: { stringValue: 'test-replay-id' } }
+              ],
+              events: [
+                {
+                  name: 'rrweb-replay-events',
+                  attributes: [
+                    { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
+                    { key: 'json', value: { stringValue: '{}' } }
+                  ]
+                },
+                {
+                  name: 'rrweb-replay-events',
+                  attributes: [
+                    { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
+                    { key: 'json', value: { stringValue: '{}' } }
+                  ]
+                },
+                {
+                  name: 'rrweb-replay-events',
+                  attributes: [
+                    { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
+                    { key: 'json', value: { stringValue: '{}' } }
+                  ]
+                },
+                {
+                  name: 'rrweb-replay-events',
+                  attributes: [
+                    { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
+                    { key: 'json', value: { stringValue: '{}' } }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+/**
+ * Single checkpoint payload with just one set of Meta and FullSnapshot events
+ */
+export const singleCheckpointPayload = {
+  resourceSpans: [
+    {
+      resource: { attributes: [] },
+      scopeSpans: [
+        {
+          scope: { name: 'rollbar.js', version: '1.0.0' },
+          spans: [
+            {
+              name: 'rrweb-replay-recording',
+              attributes: [
+                { key: 'rollbar.replay.id', value: { stringValue: 'test-replay-id' } }
+              ],
+              events: [
+                {
+                  name: 'rrweb-replay-events',
+                  attributes: [
+                    { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
+                    { key: 'json', value: { stringValue: '{}' } }
+                  ]
+                },
+                {
+                  name: 'rrweb-replay-events',
+                  attributes: [
+                    { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
+                    { key: 'json', value: { stringValue: '{}' } }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ]
+    }
+  ]
+};
+
+/**
+ * Creates a deep clone of the standardPayload and updates the replay ID
+ * @param {string} replayId - The replay ID to set in the payload
+ * @returns {Object} A new payload object with the specified replay ID
+ */
+export function createPayloadWithReplayId(replayId) {
+  const payload = JSON.parse(JSON.stringify(standardPayload));
+  
+  const idAttr = payload.resourceSpans[0].scopeSpans[0].spans[0].attributes.find(
+    attr => attr.key === 'rollbar.replay.id'
+  );
+  
+  if (idAttr) {
+    idAttr.value.stringValue = replayId;
+  }
+  
+  return payload;
+}

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -75,17 +75,21 @@ describe('Session Replay E2E', function () {
       truncationMock,
     );
 
-    const mockPayload = [{
-      name: 'rrweb-replay-recording',
-      events: [{
-        name: 'rrweb-replay-events',
-        attributes: {
-          eventType: 4,
-          json: '{"data":{"type":"Test"}}',
-        }
-      }],
-      attributes: {}
-    }];
+    const mockPayload = [
+      {
+        name: 'rrweb-replay-recording',
+        events: [
+          {
+            name: 'rrweb-replay-events',
+            attributes: {
+              eventType: 4,
+              json: '{"data":{"type":"Test"}}',
+            },
+          },
+        ],
+        attributes: {},
+      },
+    ];
     recorder = new Recorder(options.recorder, mockRecordFn);
     sinon.stub(recorder, 'dump').callsFake((tracing, replayId) => {
       mockPayload[0].attributes['rollbar.replay.id'] = replayId;
@@ -141,7 +145,8 @@ describe('Session Replay E2E', function () {
 
         setTimeout(() => {
           expect(recorderDumpSpy.called).to.be.true;
-          expect(recorderDumpSpy.calledWith(tracing, errorItem.replayId)).to.be.true;
+          expect(recorderDumpSpy.calledWith(tracing, errorItem.replayId)).to.be
+            .true;
           expect(replayMapSendSpy.calledWith(errorItem.replayId)).to.be.true;
           expect(apiPostSpansSpy.calledOnce).to.be.true;
 
@@ -153,10 +158,16 @@ describe('Session Replay E2E', function () {
             expect(span).to.have.property('name', 'rrweb-replay-recording');
             expect(span).to.have.property('events');
             expect(span.events).to.be.an('array');
-            expect(span.events[0]).to.have.property('name', 'rrweb-replay-events');
+            expect(span.events[0]).to.have.property(
+              'name',
+              'rrweb-replay-events',
+            );
             expect(span.events[0].attributes).to.have.property('eventType');
             expect(span.events[0].attributes).to.have.property('json');
-            expect(span.attributes).to.have.property('rollbar.replay.id', errorItem.replayId);
+            expect(span.attributes).to.have.property(
+              'rollbar.replay.id',
+              errorItem.replayId,
+            );
           }
 
           const transportArgs = transport.post.lastCall.args;
@@ -165,7 +176,7 @@ describe('Session Replay E2E', function () {
           done();
         }, 200);
       });
-    }, 50); // Reduced waiting time with mock recorder
+    }, 50);
   });
 
   it('should integrate with real components in failure scenario', function (done) {

--- a/test/replay/integration/replayMap.test.js
+++ b/test/replay/integration/replayMap.test.js
@@ -51,7 +51,6 @@ describe('ReplayMap API Integration', function () {
     tracing = new Tracing(window, options);
     tracing.initSession();
 
-    // Create a mock payload for the recorder to return
     const mockPayload = [{ id: 'span1', name: 'recording-span' }];
 
     api = new Api(
@@ -85,14 +84,11 @@ describe('ReplayMap API Integration', function () {
     expect(replayId).to.be.a('string');
     expect(replayId.length).to.equal(16); // 8 bytes as hex = 16 characters
 
-    // Wait for processReplay to complete asynchronously
     await new Promise((r) => setTimeout(r, 1000));
 
-    // Verify that recorder.dump was called with the correct parameters
     expect(recorder.dump.calledOnce).to.be.true;
     expect(recorder.dump.calledWith(tracing, replayId)).to.be.true;
 
-    // Verify that the map contains the replay payload
     const payload = replayMap.getSpans(replayId);
     expect(payload).to.not.be.null;
     expect(payload).to.be.an('array');
@@ -102,19 +98,16 @@ describe('ReplayMap API Integration', function () {
   it('should successfully send replay to API', async function () {
     const postSpansSpy = sinon.spy(api, 'postSpans');
 
-    // Create mock payload and add to replayMap
     const replayId = 'test-replay-id';
     const mockPayload = [{ id: 'test-span', name: 'recording-span' }];
     replayMap.setSpans(replayId, mockPayload);
 
-    // Send the replay
     const result = await replayMap.send(replayId);
 
     expect(result).to.be.true;
     expect(postSpansSpy.calledOnce).to.be.true;
     expect(postSpansSpy.calledWith(mockPayload)).to.be.true;
 
-    // Verify the map entry was removed
     expect(replayMap.getSpans(replayId)).to.be.null;
   });
 
@@ -133,7 +126,6 @@ describe('ReplayMap API Integration', function () {
     expect(result).to.be.false;
     expect(consoleSpy.calledWith('Error sending replay:', apiError)).to.be.true;
 
-    // Verify the map entry was still removed despite the error
     expect(replayMap.getSpans(replayId)).to.be.null;
   });
 
@@ -149,14 +141,12 @@ describe('ReplayMap API Integration', function () {
     expect(result).to.be.true;
     expect(postSpansSpy.called).to.be.false;
 
-    // Verify the map entry was removed
     expect(replayMap.getSpans(replayId)).to.be.null;
   });
 
   it('should generate unique replay IDs', function () {
     const replayIds = new Set();
 
-    // Mock _processReplay to avoid actual processing
     sinon.stub(replayMap, '_processReplay').resolves();
 
     for (let i = 0; i < 100; i++) {

--- a/test/replay/integration/sessionRecording.test.js
+++ b/test/replay/integration/sessionRecording.test.js
@@ -95,7 +95,7 @@ describe('Session Replay Integration', function () {
 
       expect(payload).to.not.be.null;
       expect(payload).to.be.an('object');
-      expect(payload).to.equal(standardPayload);
+      expect(payload).to.deep.equal(standardPayload);
 
       const events = payload.resourceSpans[0].scopeSpans[0].spans[0].events;
       expect(events.length).to.be.greaterThan(0);
@@ -134,7 +134,7 @@ describe('Session Replay Integration', function () {
       const payload = recorder.dump(tracing, replayId);
 
       expect(payload).to.not.be.null;
-      expect(payload).to.equal(checkpointPayload);
+      expect(payload).to.deep.equal(checkpointPayload);
 
       const events = payload.resourceSpans[0].scopeSpans[0].spans[0].events;
 
@@ -178,7 +178,7 @@ describe('Session Replay Integration', function () {
       const payload = recorder.dump(tracing, replayId);
 
       expect(payload).to.not.be.null;
-      expect(payload).to.equal(singleCheckpointPayload);
+      expect(payload).to.deep.equal(singleCheckpointPayload);
 
       const events = payload.resourceSpans[0].scopeSpans[0].spans[0].events;
 

--- a/test/replay/integration/sessionRecording.test.js
+++ b/test/replay/integration/sessionRecording.test.js
@@ -24,7 +24,7 @@ import {
   standardPayload,
   checkpointPayload,
   singleCheckpointPayload,
-  createPayloadWithReplayId
+  createPayloadWithReplayId,
 } from '../../fixtures/replay';
 
 const options = {
@@ -69,9 +69,9 @@ describe('Session Replay Integration', function () {
   beforeEach(function () {
     tracing = new Tracing(window, options);
     tracing.initSession();
-    
+
     tracing.exporter = {
-      toPayload: sinon.stub().returns(standardPayload)
+      toPayload: sinon.stub().returns(standardPayload),
     };
   });
 
@@ -92,19 +92,19 @@ describe('Session Replay Integration', function () {
     const dumpRecording = () => {
       const replayId = 'test-replay-id';
       const payload = recorder.dump(tracing, replayId);
-      
+
       expect(payload).to.not.be.null;
       expect(payload).to.be.an('object');
       expect(payload).to.equal(standardPayload);
-      
+
       const events = payload.resourceSpans[0].scopeSpans[0].spans[0].events;
       expect(events.length).to.be.greaterThan(0);
       expect(events.every((e) => e.name === 'rrweb-replay-events')).to.be.true;
 
       const eventAttrs = events[0].attributes;
-      const eventTypeAttr = eventAttrs.find(attr => attr.key === 'eventType');
-      const jsonAttr = eventAttrs.find(attr => attr.key === 'json');
-      
+      const eventTypeAttr = eventAttrs.find((attr) => attr.key === 'eventType');
+      const jsonAttr = eventAttrs.find((attr) => attr.key === 'json');
+
       expect(eventTypeAttr).to.exist;
       expect(jsonAttr).to.exist;
 
@@ -116,9 +116,9 @@ describe('Session Replay Integration', function () {
 
   it('should handle checkouts correctly', function (done) {
     tracing.exporter = {
-      toPayload: sinon.stub().returns(checkpointPayload)
+      toPayload: sinon.stub().returns(checkpointPayload),
     };
-    
+
     recorder = new Recorder(
       {
         ...options.recorder,
@@ -132,22 +132,24 @@ describe('Session Replay Integration', function () {
     const dumpRecording = () => {
       const replayId = 'test-replay-id';
       const payload = recorder.dump(tracing, replayId);
-      
+
       expect(payload).to.not.be.null;
       expect(payload).to.equal(checkpointPayload);
-      
+
       const events = payload.resourceSpans[0].scopeSpans[0].spans[0].events;
 
-      const eventTypes = events.map(event => {
-        const eventTypeAttr = event.attributes.find(attr => attr.key === 'eventType');
+      const eventTypes = events.map((event) => {
+        const eventTypeAttr = event.attributes.find(
+          (attr) => attr.key === 'eventType',
+        );
         return eventTypeAttr ? eventTypeAttr.value.stringValue : null;
       });
 
       expect(
-        eventTypes.filter(type => type === String(EventType.Meta)),
+        eventTypes.filter((type) => type === String(EventType.Meta)),
       ).to.have.lengthOf(2);
       expect(
-        eventTypes.filter(type => type === String(EventType.FullSnapshot)),
+        eventTypes.filter((type) => type === String(EventType.FullSnapshot)),
       ).to.have.lengthOf(2);
 
       done();
@@ -158,9 +160,9 @@ describe('Session Replay Integration', function () {
 
   it('should handle no checkouts correctly', function (done) {
     tracing.exporter = {
-      toPayload: sinon.stub().returns(singleCheckpointPayload)
+      toPayload: sinon.stub().returns(singleCheckpointPayload),
     };
-    
+
     recorder = new Recorder(
       {
         ...options.recorder,
@@ -174,22 +176,24 @@ describe('Session Replay Integration', function () {
     const dumpRecording = () => {
       const replayId = 'test-replay-id';
       const payload = recorder.dump(tracing, replayId);
-      
+
       expect(payload).to.not.be.null;
       expect(payload).to.equal(singleCheckpointPayload);
-      
+
       const events = payload.resourceSpans[0].scopeSpans[0].spans[0].events;
 
-      const eventTypes = events.map(event => {
-        const eventTypeAttr = event.attributes.find(attr => attr.key === 'eventType');
+      const eventTypes = events.map((event) => {
+        const eventTypeAttr = event.attributes.find(
+          (attr) => attr.key === 'eventType',
+        );
         return eventTypeAttr ? eventTypeAttr.value.stringValue : null;
       });
 
       expect(
-        eventTypes.filter(type => type === String(EventType.Meta)),
+        eventTypes.filter((type) => type === String(EventType.Meta)),
       ).to.have.lengthOf(1);
       expect(
-        eventTypes.filter(type => type === String(EventType.FullSnapshot)),
+        eventTypes.filter((type) => type === String(EventType.FullSnapshot)),
       ).to.have.lengthOf(1);
 
       done();
@@ -218,7 +222,7 @@ describe('Session Replay Transport Integration', function () {
     tracing.initSession();
 
     tracing.exporter = {
-      toPayload: sinon.stub().returns(standardPayload)
+      toPayload: sinon.stub().returns(standardPayload),
     };
 
     api = new Api(
@@ -229,7 +233,7 @@ describe('Session Replay Transport Integration', function () {
     );
 
     recorder = new Recorder(options.recorder, mockRecordFn);
-    
+
     sinon.stub(recorder, 'dump').callsFake((tracing, replayId) => {
       return createPayloadWithReplayId(replayId);
     });
@@ -358,12 +362,14 @@ describe('Session Replay Transport Integration', function () {
     expect(sendSpy.calledOnce).to.be.true;
     expect(sendSpy.calledWith(errorItem.replayId)).to.be.true;
     expect(postSpansSpy.calledOnce).to.be.true;
-    
+
     expect(recorder.dump.called).to.be.true;
     expect(recorder.dump.calledWith(tracing, errorItem.replayId)).to.be.true;
     const callArgs = postSpansSpy.firstCall.args;
     expect(callArgs[0]).to.be.an('object');
-    expect(callArgs[0].resourceSpans[0].scopeSpans[0].spans[0].name).to.equal('rrweb-replay-recording');
+    expect(callArgs[0].resourceSpans[0].scopeSpans[0].spans[0].name).to.equal(
+      'rrweb-replay-recording',
+    );
   });
 
   it('should not add replayId when replayMap is not provided', function (done) {


### PR DESCRIPTION
## Description of the change

This PR refactors `ReplayMap` and `Recorder` following the comments in https://github.com/rollbar/rollbar.js/pull/1185.

So, several changes have been made:
- Reliance in `spanExportQueue` has been eliminated as this is going to be private.
- Decoupled the exporter from the `ReplayMap`.
- `Recorder.dump` now returns the final payload instead of acting as an opaque side-effect that creates the span.
- Decoupled `tracing` from `Recorder`, `tracing` object can be passed to the `dump` function directly.
- `context` cannot be passed and its taken from the active contextManager in the tracing object passed.

Further breakdowns can be done in Recorder and ReplayMap to improve modularity, but that'll come in the future.

All tests were updated to reflect the refactoring.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- [CAT-355/enable-tracesession-transport-to-moxapi](https://linear.app/rollbar-inc/issue/CAT-355/enable-tracesession-transport-to-moxapi)
