### PR TITLE
Session recording otel to otlp export

### DIFF
--- a/src/tracing/exporter.js
+++ b/src/tracing/exporter.js
@@ -1,7 +1,189 @@
+import hrtime from './hrtime';
+
+/**
+ * SpanExporter is responsible for exporting ReadableSpan objects
+ * and transforming them into the OTLP-compatible format.
+ */
 export class SpanExporter {
+  /**
+   * Export spans to the span export queue
+   *
+   * @param {Array} spans - Array of ReadableSpan objects to export
+   * @param {Function} _resultCallback - Optional callback (not used)
+   */
   export(spans, _resultCallback) {
     console.log(spans); // console exporter, TODO: make optional
     spanExportQueue.push(...spans);
+  }
+
+  /**
+   * Transforms an array of ReadableSpan objects into the OTLP format payload
+   * compatible with the Rollbar API. This follows the OpenTelemetry protocol
+   * specification for traces.
+   *
+   * @param {Array} spans - Array of ReadableSpan objects to transform
+   * @param {Object} options - Additional options for the transformation
+   * @param {Object} options.resource - Resource information
+   * @returns {Object} OTLP format payload for API transmission
+   */
+  toPayload(options = {}) {
+    const spans = spanExportQueue.slice();
+
+    if (!spans || !spans.length) {
+      return { resourceSpans: [] };
+    }
+
+    const resource = options.resource || (spans[0] && spans[0].resource) || {};
+
+    const scopeMap = new Map();
+
+    for (const span of spans) {
+      const scopeKey = span.instrumentationScope
+        ? `${span.instrumentationScope.name}:${span.instrumentationScope.version}`
+        : 'default:1.0.0';
+
+      if (!scopeMap.has(scopeKey)) {
+        scopeMap.set(scopeKey, {
+          scope: span.instrumentationScope || {
+            name: 'default',
+            version: '1.0.0',
+            attributes: [],
+          },
+          spans: [],
+        });
+      }
+
+      scopeMap.get(scopeKey).spans.push(this._transformSpan(span));
+    }
+
+    return {
+      resourceSpans: [
+        {
+          resource: this._transformResource(resource),
+          scopeSpans: Array.from(scopeMap.values()).map((scopeData) => ({
+            scope: this._transformInstrumentationScope(scopeData.scope),
+            spans: scopeData.spans,
+          })),
+        },
+      ],
+    };
+  }
+
+  /**
+   * Transforms a ReadableSpan into the OTLP Span format
+   *
+   * @private
+   * @param {Object} span - ReadableSpan object to transform
+   * @returns {Object} OTLP Span format
+   */
+  _transformSpan(span) {
+    const transformAttributes = (attributes) => {
+      return Object.entries(attributes || {}).map(([key, value]) => ({
+        key,
+        value: this._transformAnyValue(value),
+      }));
+    };
+
+    const transformEvents = (events) => {
+      return (events || []).map((event) => ({
+        timeUnixNano: hrtime.toNanos(event.time),
+        name: event.name,
+        attributes: transformAttributes(event.attributes),
+      }));
+    };
+
+    return {
+      traceId: span.spanContext.traceId,
+      spanId: span.spanContext.spanId,
+      parentSpanId: span.parentSpanId || '',
+      name: span.name,
+      kind: span.kind || 1, // INTERNAL by default
+      startTimeUnixNano: hrtime.toNanos(span.startTime),
+      endTimeUnixNano: hrtime.toNanos(span.endTime),
+      attributes: transformAttributes(span.attributes),
+      events: transformEvents(span.events),
+    };
+  }
+
+  /**
+   * Transforms a resource object into OTLP Resource format
+   *
+   * @private
+   * @param {Object} resource - Resource information
+   * @returns {Object} OTLP Resource format
+   */
+  _transformResource(resource) {
+    const attributes = resource.attributes || {};
+    const keyValues = Object.entries(attributes).map(([key, value]) => ({
+      key,
+      value: this._transformAnyValue(value),
+    }));
+
+    return {
+      attributes: keyValues,
+    };
+  }
+
+  /**
+   * Transforms an instrumentation scope into OTLP InstrumentationScope format
+   *
+   * @private
+   * @param {Object} scope - Instrumentation scope information
+   * @returns {Object} OTLP InstrumentationScope format
+   */
+  _transformInstrumentationScope(scope) {
+    return {
+      name: scope.name || '',
+      version: scope.version || '',
+      attributes: (scope.attributes || []).map((attr) => ({
+        key: attr.key,
+        value: this._transformAnyValue(attr.value),
+      })),
+    };
+  }
+
+  /**
+   * Transforms a JavaScript value into an OTLP AnyValue
+   *
+   * @private
+   * @param {any} value - Value to transform
+   * @returns {Object} OTLP AnyValue format
+   */
+  _transformAnyValue(value) {
+    if (value === null || value === undefined) {
+      return { stringValue: '' };
+    }
+
+    const type = typeof value;
+
+    if (type === 'string') {
+      return { stringValue: value };
+    } else if (type === 'number') {
+      if (Number.isInteger(value)) {
+        return { intValue: value.toString() };
+      } else {
+        return { doubleValue: value };
+      }
+    } else if (type === 'boolean') {
+      return { boolValue: value };
+    } else if (Array.isArray(value)) {
+      return {
+        arrayValue: {
+          values: value.map((v) => this._transformAnyValue(v)),
+        },
+      };
+    } else if (type === 'object') {
+      return {
+        kvlistValue: {
+          values: Object.entries(value).map(([k, v]) => ({
+            key: k,
+            value: this._transformAnyValue(v),
+          })),
+        },
+      };
+    }
+
+    return { stringValue: String(value) };
   }
 }
 

--- a/src/tracing/hrtime.js
+++ b/src/tracing/hrtime.js
@@ -26,6 +26,16 @@ function toMillis(hrtime) {
 }
 
 /**
+ * Convert an OpenTelemetry hrtime tuple back to a duration in nanoseconds.
+ *
+ * @param {[number, number]} hrtime - The hrtime tuple [seconds, nanoseconds].
+ * @returns {number} The total duration in nanoseconds.
+ */
+function toNanos(hrtime) {
+  return hrtime[0] * 1e9 + hrtime[1];
+}
+
+/**
  * Adds two OpenTelemetry hrtime tuples.
  *
  * @param {[number, number]} a - The first hrtime tuple [s, ns].
@@ -85,4 +95,4 @@ function isHrTime(value) {
  * hrtime.now();
  * hrtime.isHrTime([0, 1000]);
  */
-export default { fromMillis, toMillis, add, now, isHrTime };
+export default { fromMillis, toMillis, toNanos, add, now, isHrTime };

--- a/test/fixtures/replay/payloads.fixtures.js
+++ b/test/fixtures/replay/payloads.fixtures.js
@@ -12,16 +12,23 @@ export const standardPayload = {
       resource: { attributes: [] },
       scopeSpans: [
         {
-          scope: { name: 'rollbar.js', version: '1.0.0' },
+          scope: { name: 'rollbar.js', version: '1.0.0', attributes: [] },
           spans: [
             {
               name: 'rrweb-replay-recording',
+              traceId: 'abcdef1234567890abcdef1234567890',
+              spanId: '1234567890abcdef',
+              parentSpanId: '',
+              kind: 1,
+              startTimeUnixNano: '1600000000000000000',
+              endTimeUnixNano: '1600000100000000000',
               attributes: [
                 { key: 'rollbar.replay.id', value: { stringValue: 'test-replay-id' } }
               ],
               events: [
                 {
                   name: 'rrweb-replay-events',
+                  timeUnixNano: '1600000050000000000',
                   attributes: [
                     { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
                     { key: 'json', value: { stringValue: '{}' } }
@@ -29,6 +36,7 @@ export const standardPayload = {
                 },
                 {
                   name: 'rrweb-replay-events',
+                  timeUnixNano: '1600000060000000000',
                   attributes: [
                     { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
                     { key: 'json', value: { stringValue: '{}' } }
@@ -53,16 +61,23 @@ export const checkpointPayload = {
       resource: { attributes: [] },
       scopeSpans: [
         {
-          scope: { name: 'rollbar.js', version: '1.0.0' },
+          scope: { name: 'rollbar.js', version: '1.0.0', attributes: [] },
           spans: [
             {
               name: 'rrweb-replay-recording',
+              traceId: 'abcdef1234567890abcdef1234567890',
+              spanId: '1234567890abcdef',
+              parentSpanId: '',
+              kind: 1,
+              startTimeUnixNano: '1600000000000000000',
+              endTimeUnixNano: '1600000400000000000',
               attributes: [
                 { key: 'rollbar.replay.id', value: { stringValue: 'test-replay-id' } }
               ],
               events: [
                 {
                   name: 'rrweb-replay-events',
+                  timeUnixNano: '1600000050000000000',
                   attributes: [
                     { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
                     { key: 'json', value: { stringValue: '{}' } }
@@ -70,6 +85,7 @@ export const checkpointPayload = {
                 },
                 {
                   name: 'rrweb-replay-events',
+                  timeUnixNano: '1600000060000000000',
                   attributes: [
                     { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
                     { key: 'json', value: { stringValue: '{}' } }
@@ -77,6 +93,7 @@ export const checkpointPayload = {
                 },
                 {
                   name: 'rrweb-replay-events',
+                  timeUnixNano: '1600000250000000000',
                   attributes: [
                     { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
                     { key: 'json', value: { stringValue: '{}' } }
@@ -84,6 +101,7 @@ export const checkpointPayload = {
                 },
                 {
                   name: 'rrweb-replay-events',
+                  timeUnixNano: '1600000260000000000',
                   attributes: [
                     { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
                     { key: 'json', value: { stringValue: '{}' } }
@@ -107,16 +125,23 @@ export const singleCheckpointPayload = {
       resource: { attributes: [] },
       scopeSpans: [
         {
-          scope: { name: 'rollbar.js', version: '1.0.0' },
+          scope: { name: 'rollbar.js', version: '1.0.0', attributes: [] },
           spans: [
             {
               name: 'rrweb-replay-recording',
+              traceId: 'abcdef1234567890abcdef1234567890',
+              spanId: '1234567890abcdef',
+              parentSpanId: '',
+              kind: 1,
+              startTimeUnixNano: '1600000000000000000',
+              endTimeUnixNano: '1600000100000000000',
               attributes: [
                 { key: 'rollbar.replay.id', value: { stringValue: 'test-replay-id' } }
               ],
               events: [
                 {
                   name: 'rrweb-replay-events',
+                  timeUnixNano: '1600000050000000000',
                   attributes: [
                     { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
                     { key: 'json', value: { stringValue: '{}' } }
@@ -124,6 +149,7 @@ export const singleCheckpointPayload = {
                 },
                 {
                   name: 'rrweb-replay-events',
+                  timeUnixNano: '1600000060000000000',
                   attributes: [
                     { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
                     { key: 'json', value: { stringValue: '{}' } }

--- a/test/tracing/exporter.toPayload.test.js
+++ b/test/tracing/exporter.toPayload.test.js
@@ -1,0 +1,426 @@
+/* globals describe */
+/* globals it */
+/* globals beforeEach */
+/* globals afterEach */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { EventType } from '@rrweb/types';
+
+import { SpanExporter, spanExportQueue } from '../../src/tracing/exporter.js';
+import hrtime from '../../src/tracing/hrtime.js';
+import id from '../../src/tracing/id.js';
+import { standardPayload } from '../fixtures/replay/payloads.fixtures.js';
+
+describe('SpanExporter.toPayload()', function () {
+  let exporter;
+  let hrtimeStub;
+  let idStub;
+
+  beforeEach(function () {
+    spanExportQueue.length = 0;
+    exporter = new SpanExporter();
+
+    hrtimeStub = sinon.stub(hrtime, 'now').returns([1, 2]);
+    sinon.stub(hrtime, 'toNanos').returns(1000000000);
+    idStub = sinon.stub(id, 'gen').returns('1234567890abcdef');
+  });
+
+  afterEach(function () {
+    spanExportQueue.length = 0;
+    sinon.restore();
+  });
+
+  it('should return empty resourceSpans when queue is empty', function () {
+    const payload = exporter.toPayload();
+    expect(payload).to.deep.equal({ resourceSpans: [] });
+  });
+
+  it('should transform a simple span into OTLP format', function () {
+    const mockSpan = {
+      name: 'test-span',
+      spanContext: {
+        traceId: 'abcdef1234567890abcdef1234567890',
+        spanId: '1234567890abcdef',
+      },
+      startTime: hrtime.now(),
+      endTime: hrtime.now(),
+      attributes: {
+        'test.attribute': 'test-value',
+      },
+      events: [],
+      resource: {
+        attributes: {
+          'service.name': 'test-service',
+        },
+      },
+    };
+
+    spanExportQueue.push(mockSpan);
+    const payload = exporter.toPayload();
+
+    expect(payload).to.have.property('resourceSpans').that.is.an('array');
+    expect(payload.resourceSpans).to.have.lengthOf(1);
+    expect(payload.resourceSpans[0]).to.have.property('resource');
+    expect(payload.resourceSpans[0]).to.have.property('scopeSpans').that.is.an('array');
+    expect(payload.resourceSpans[0].scopeSpans).to.have.lengthOf(1);
+
+    // Verify span data
+    const transformedSpan = payload.resourceSpans[0].scopeSpans[0].spans[0];
+    expect(transformedSpan).to.have.property('name', 'test-span');
+    expect(transformedSpan).to.have.property('traceId', 'abcdef1234567890abcdef1234567890');
+    expect(transformedSpan).to.have.property('spanId', '1234567890abcdef');
+    
+    // Verify attributes
+    expect(transformedSpan).to.have.property('attributes').that.is.an('array');
+    const attribute = transformedSpan.attributes.find(attr => attr.key === 'test.attribute');
+    expect(attribute).to.exist;
+    expect(attribute.value).to.have.property('stringValue', 'test-value');
+  });
+
+  it('should handle spans with different attribute types correctly', function () {
+    const mockSpan = {
+      name: 'attribute-test-span',
+      spanContext: {
+        traceId: 'abcdef1234567890abcdef1234567890',
+        spanId: '1234567890abcdef',
+      },
+      startTime: hrtime.now(),
+      endTime: hrtime.now(),
+      attributes: {
+        stringAttr: 'string-value',
+        intAttr: 42,
+        floatAttr: 3.14,
+        boolAttr: true,
+        nullAttr: null,
+        arrayAttr: [1, 'two', true],
+        objectAttr: { nested: 'value' },
+      },
+      events: [],
+      resource: {
+        attributes: {},
+      },
+    };
+
+    spanExportQueue.push(mockSpan);
+    const payload = exporter.toPayload();
+    const attributes = payload.resourceSpans[0].scopeSpans[0].spans[0].attributes;
+
+    const stringAttr = attributes.find(a => a.key === 'stringAttr');
+    expect(stringAttr.value).to.have.property('stringValue', 'string-value');
+    
+    const intAttr = attributes.find(a => a.key === 'intAttr');
+    expect(intAttr.value).to.have.property('intValue', '42');
+    
+    const floatAttr = attributes.find(a => a.key === 'floatAttr');
+    expect(floatAttr.value).to.have.property('doubleValue', 3.14);
+    
+    const boolAttr = attributes.find(a => a.key === 'boolAttr');
+    expect(boolAttr.value).to.have.property('boolValue', true);
+    
+    const nullAttr = attributes.find(a => a.key === 'nullAttr');
+    expect(nullAttr.value).to.have.property('stringValue', '');
+    
+    const arrayAttr = attributes.find(a => a.key === 'arrayAttr');
+    expect(arrayAttr.value).to.have.property('arrayValue');
+    expect(arrayAttr.value.arrayValue.values).to.have.lengthOf(3);
+    
+    const objectAttr = attributes.find(a => a.key === 'objectAttr');
+    expect(objectAttr.value).to.have.property('kvlistValue');
+  });
+
+  it('should handle spans with events correctly', function () {
+    const eventTime = hrtime.now();
+
+    const mockSpan = {
+      name: 'event-test-span',
+      spanContext: {
+        traceId: 'abcdef1234567890abcdef1234567890',
+        spanId: '1234567890abcdef',
+      },
+      startTime: hrtime.now(),
+      endTime: hrtime.now(),
+      attributes: {},
+      events: [
+        {
+          name: 'test-event-1',
+          time: eventTime,
+          attributes: {
+            'event.key1': 'value1',
+          },
+        },
+        {
+          name: 'test-event-2',
+          time: eventTime,
+          attributes: {
+            'event.key2': 'value2',
+          },
+        },
+      ],
+      resource: {
+        attributes: {},
+      },
+    };
+
+    spanExportQueue.push(mockSpan);
+    const payload = exporter.toPayload();
+    const events = payload.resourceSpans[0].scopeSpans[0].spans[0].events;
+    
+    expect(events).to.have.lengthOf(2);
+    expect(events[0]).to.have.property('name', 'test-event-1');
+    expect(events[1]).to.have.property('name', 'test-event-2');
+    
+    expect(events[0]).to.have.property('timeUnixNano').that.is.a('number');
+    
+    const eventAttribute = events[0].attributes.find(a => a.key === 'event.key1');
+    expect(eventAttribute).to.exist;
+    expect(eventAttribute.value).to.have.property('stringValue', 'value1');
+  });
+
+  it('should handle multiple spans with different scopes', function () {
+    const span1 = {
+      name: 'span1',
+      spanContext: {
+        traceId: 'abcdef1234567890abcdef1234567890',
+        spanId: '1111111111111111',
+      },
+      startTime: hrtime.now(),
+      endTime: hrtime.now(),
+      attributes: {},
+      events: [],
+      instrumentationScope: {
+        name: 'scope1',
+        version: '1.0.0',
+      },
+      resource: {
+        attributes: {},
+      },
+    };
+    
+    const span2 = {
+      name: 'span2',
+      spanContext: {
+        traceId: 'abcdef1234567890abcdef1234567890',
+        spanId: '2222222222222222',
+      },
+      startTime: hrtime.now(),
+      endTime: hrtime.now(),
+      attributes: {},
+      events: [],
+      instrumentationScope: {
+        name: 'scope2',
+        version: '1.0.0',
+      },
+      resource: {
+        attributes: {},
+      },
+    };
+    
+    const span3 = {
+      name: 'span3',
+      spanContext: {
+        traceId: 'abcdef1234567890abcdef1234567890',
+        spanId: '3333333333333333',
+      },
+      startTime: hrtime.now(),
+      endTime: hrtime.now(),
+      attributes: {},
+      events: [],
+      instrumentationScope: {
+        name: 'scope1',
+        version: '1.0.0',
+      },
+      resource: {
+        attributes: {},
+      },
+    };
+
+    spanExportQueue.push(span1, span2, span3);
+    const payload = exporter.toPayload();
+
+    expect(payload.resourceSpans).to.have.lengthOf(1);
+    expect(payload.resourceSpans[0].scopeSpans).to.have.lengthOf(2);
+
+    const scope1 = payload.resourceSpans[0].scopeSpans.find(s => s.scope.name === 'scope1');
+    const scope2 = payload.resourceSpans[0].scopeSpans.find(s => s.scope.name === 'scope2');
+
+    expect(scope1).to.exist;
+    expect(scope2).to.exist;
+
+    expect(scope1.spans).to.have.lengthOf(2);
+    expect(scope2.spans).to.have.lengthOf(1);
+  });
+
+  it('should use default scope for spans without instrumentation scope', function () {
+    const mockSpan = {
+      name: 'no-scope-span',
+      spanContext: {
+        traceId: 'abcdef1234567890abcdef1234567890',
+        spanId: '1234567890abcdef',
+      },
+      startTime: hrtime.now(),
+      endTime: hrtime.now(),
+      attributes: {},
+      events: [],
+      resource: {
+        attributes: {},
+      },
+      // No instrumentationScope property
+    };
+
+    spanExportQueue.push(mockSpan);
+    const payload = exporter.toPayload();
+    
+    const scope = payload.resourceSpans[0].scopeSpans[0].scope;
+    expect(scope).to.deep.equal({
+      name: 'default',
+      version: '1.0.0',
+      attributes: [],
+    });
+  });
+
+  it('should use resource from options if provided', function () {
+    const mockSpan = {
+      name: 'resource-test-span',
+      spanContext: {
+        traceId: 'abcdef1234567890abcdef1234567890',
+        spanId: '1234567890abcdef',
+      },
+      startTime: hrtime.now(),
+      endTime: hrtime.now(),
+      attributes: {},
+      events: [],
+      resource: {
+        attributes: {
+          'span.resource': 'value',
+        },
+      },
+    };
+
+    spanExportQueue.push(mockSpan);
+    
+    const options = {
+      resource: {
+        attributes: {
+          'options.resource': 'override',
+        },
+      },
+    };
+    
+    const payload = exporter.toPayload(options);
+    const resourceAttrs = payload.resourceSpans[0].resource.attributes;
+
+    const optionsAttr = resourceAttrs.find(a => a.key === 'options.resource');
+    expect(optionsAttr).to.exist;
+    expect(optionsAttr.value).to.have.property('stringValue', 'override');
+
+    const spanAttr = resourceAttrs.find(a => a.key === 'span.resource');
+    expect(spanAttr).to.not.exist;
+  });
+
+  it('should produce a payload compatible with standardPayload fixture', function () {
+    const span = {
+      name: 'rrweb-replay-recording',
+      spanContext: {
+        traceId: 'abcdef1234567890abcdef1234567890',
+        spanId: '1234567890abcdef',
+      },
+      startTime: hrtime.now(),
+      endTime: hrtime.now(),
+      attributes: {
+        'rollbar.replay.id': 'test-replay-id',
+      },
+      events: [
+        {
+          name: 'rrweb-replay-events',
+          time: hrtime.now(),
+          attributes: {
+            'eventType': String(EventType.Meta),
+            'json': '{}',
+          },
+        },
+        {
+          name: 'rrweb-replay-events',
+          time: hrtime.now(),
+          attributes: {
+            'eventType': String(EventType.FullSnapshot),
+            'json': '{}',
+          },
+        },
+      ],
+      instrumentationScope: {
+        name: 'rollbar.js',
+        version: '1.0.0',
+      },
+      resource: {
+        attributes: {},
+      },
+    };
+
+    spanExportQueue.push(span);
+    const payload = exporter.toPayload();
+
+    // Create a standardPayload-based expected object with the stubbed IDs
+    const expected = JSON.parse(JSON.stringify(standardPayload));
+
+    // Verify specific fields match before deep comparison
+    const actualSpan = payload.resourceSpans[0].scopeSpans[0].spans[0];
+
+    // IDs should match our mock data
+    expect(actualSpan.traceId).to.equal('abcdef1234567890abcdef1234567890');
+    expect(actualSpan.spanId).to.equal('1234567890abcdef');
+
+    // Timestamps should be consistent
+    expect(actualSpan.startTimeUnixNano).to.equal(1000000000);
+    expect(actualSpan.endTimeUnixNano).to.equal(1000000000);
+
+    // Event timestamps should be consistent
+    actualSpan.events.forEach(event => {
+      expect(event.timeUnixNano).to.equal(1000000000);
+    });
+
+    // Create a modified copy of payload and standardPayload for structure comparison
+    // that ignores the dynamic values we've already verified separately
+    function createComparablePayload(payload) {
+      const clone = JSON.parse(JSON.stringify(payload));
+
+      // Remove fields with dynamic values that we verified separately
+      const span = clone.resourceSpans[0].scopeSpans[0].spans[0];
+      delete span.traceId;
+      delete span.spanId;
+      delete span.parentSpanId;
+      delete span.startTimeUnixNano;
+      delete span.endTimeUnixNano;
+      delete span.kind;
+
+      span.events.forEach(event => {
+        delete event.timeUnixNano;
+      });
+
+      return clone;
+    }
+
+    const comparablePayload = createComparablePayload(payload);
+    const comparableStandard = createComparablePayload(standardPayload);
+
+    // Log the actual values to debug the difference
+    console.log('Actual events:', JSON.stringify(comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].events, null, 2));
+    console.log('Expected events:', JSON.stringify(comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].events, null, 2));
+
+    // Log the scope objects to debug differences
+    console.log('Actual scope:', JSON.stringify(comparablePayload.resourceSpans[0].scopeSpans[0].scope, null, 2));
+    console.log('Expected scope:', JSON.stringify(comparableStandard.resourceSpans[0].scopeSpans[0].scope, null, 2));
+
+    expect(comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].name)
+      .to.deep.equal(comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].name, 'Span names should match');
+
+    expect(comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].attributes)
+      .to.deep.equal(comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].attributes, 'Span attributes should match');
+
+    expect(comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].events)
+      .to.deep.equal(comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].events, 'Span events should match');
+
+    // Verify the structure is identical between our payload and the standard
+    expect(comparablePayload).to.deep.equal(comparableStandard, 'Complete payload structure should match');
+  });
+});


### PR DESCRIPTION
## Description of the change

This PR adds a `toPayload` function to `SpanExporter` to transform spans into the OTLP format.

Integration tests are missing, will work on them on the next PR.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

[CAT-355/enable-tracesession-transport-to-moxapi](https://linear.app/rollbar-inc/issue/CAT-355/enable-tracesession-transport-to-moxapi)