### PR TITLE
Update postSpans

### DIFF
--- a/src/apiUtility.js
+++ b/src/apiUtility.js
@@ -1,8 +1,8 @@
 var _ = require('./utility');
 
-function buildPayload(accessToken, data, jsonBackup) {
+function buildPayload(data) {
   if (!_.isType(data.context, 'string')) {
-    var contextResult = _.stringify(data.context, jsonBackup);
+    var contextResult = _.stringify(data.context);
     if (contextResult.error) {
       data.context = "Error: could not serialize 'context'";
     } else {
@@ -13,7 +13,6 @@ function buildPayload(accessToken, data, jsonBackup) {
     }
   }
   return {
-    access_token: accessToken,
     data: data,
   };
 }

--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -13,6 +13,7 @@ var predicates = require('./predicates');
 var sharedPredicates = require('../predicates');
 var errorParser = require('../errorParser');
 const recorderDefaults = require('./replay/defaults');
+const tracingDefaults = require('../tracing/defaults');
 
 function Rollbar(options, client) {
   this.options = _.handleOptions(defaultOptions, options, null, logger);
@@ -620,6 +621,7 @@ var defaultOptions = {
   ignoreDuplicateErrors: true,
   wrapGlobalEventHandlers: false,
   recorder: recorderDefaults,
+  tracing: tracingDefaults,
 };
 
 module.exports = Rollbar;

--- a/src/tracing/defaults.js
+++ b/src/tracing/defaults.js
@@ -1,0 +1,7 @@
+/**
+ * Default tracing options
+ */
+export default {
+  enabled: false,
+  endpoint: 'api.rollbar.com/api/1/session/',
+}

--- a/test/apiUtility.test.js
+++ b/test/apiUtility.test.js
@@ -11,9 +11,8 @@ describe('buildPayload', function () {
   it('should package up the input into a payload', function () {
     var token = 'abc123';
     var data = { context: 'not an object', other: 'stuff' };
-    var payload = u.buildPayload(token, data);
+    var payload = u.buildPayload(data);
 
-    expect(payload.access_token).to.eql(token);
     expect(payload.data).to.eql(data);
   });
   it('should stringify context', function () {
@@ -23,7 +22,7 @@ describe('buildPayload', function () {
       context: context,
       other: 'stuff',
     };
-    var payload = u.buildPayload(token, data);
+    var payload = u.buildPayload(data);
 
     expect(payload.data.context).to.not.eql(context);
     expect(payload.data.context).to.eql('{"a":1,"b":"other"}');
@@ -38,7 +37,7 @@ describe('buildPayload', function () {
       context: context,
       other: 'stuff',
     };
-    var payload = u.buildPayload(token, data);
+    var payload = u.buildPayload(data);
 
     expect(payload.data.context).to.not.eql(context);
     expect(payload.data.context.length).to.eql(255);

--- a/test/browser.core.test.js
+++ b/test/browser.core.test.js
@@ -47,7 +47,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('test error');
       expect(body.data.notifier.diagnostic.raw_error.message).to.eql(
         'test error',
@@ -95,7 +94,6 @@ describe('options.captureUncaught', function () {
 
         var body = JSON.parse(server.requests[0].requestBody);
 
-        expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
         expect(body.data.body.trace.exception.message).to.eql('test error');
         expect(body.data.notifier.diagnostic.is_anonymous).to.not.be.ok();
 
@@ -149,7 +147,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('anon error');
       expect(body.data.notifier.diagnostic.is_anonymous).to.eql(true);
 
@@ -190,7 +187,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('test error');
 
       // karma doesn't unload the browser between tests, so the onerror handler
@@ -231,7 +227,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('test error');
 
       // karma doesn't unload the browser between tests, so the onerror handler
@@ -263,7 +258,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace_chain[0].exception.message).to.eql(
         'test DOMException',
       );
@@ -300,7 +294,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('deep stack error');
       expect(body.data.body.trace.frames.length).to.be.above(20);
 
@@ -354,7 +347,6 @@ describe('options.captureUnhandledRejections', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('test reject');
       expect(body.data.notifier.diagnostic.is_uncaught).to.eql(true);
 
@@ -389,7 +381,6 @@ describe('options.captureUnhandledRejections', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('test reject');
 
       server.requests.length = 0;

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -353,7 +353,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('test error');
       expect(body.data.notifier.diagnostic.raw_error.message).to.eql(
         'test error',
@@ -401,7 +400,6 @@ describe('options.captureUncaught', function () {
 
         var body = JSON.parse(server.requests[0].requestBody);
 
-        expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
         expect(body.data.body.trace.exception.message).to.eql('test error');
         expect(body.data.notifier.diagnostic.is_anonymous).to.not.be.ok();
 
@@ -455,7 +453,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('anon error');
       expect(body.data.notifier.diagnostic.is_anonymous).to.eql(true);
 
@@ -496,7 +493,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('test error');
 
       // karma doesn't unload the browser between tests, so the onerror handler
@@ -537,7 +533,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('test error');
 
       // karma doesn't unload the browser between tests, so the onerror handler
@@ -569,7 +564,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace_chain[0].exception.message).to.eql(
         'test DOMException',
       );
@@ -606,7 +600,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('deep stack error');
       expect(body.data.body.trace.frames.length).to.be.above(20);
 
@@ -642,7 +635,6 @@ describe('options.captureUncaught', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql(
         'event handler error',
       );
@@ -698,7 +690,6 @@ describe('options.captureUnhandledRejections', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('test reject');
       expect(body.data.notifier.diagnostic.is_uncaught).to.eql(true);
 
@@ -733,7 +724,6 @@ describe('options.captureUnhandledRejections', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql('test reject');
 
       server.requests.length = 0;
@@ -1061,7 +1051,6 @@ describe('onerror', function () {
 
       var body = JSON.parse(server.requests[0].requestBody);
 
-      expect(body.access_token).to.eql('POST_CLIENT_ITEM_TOKEN');
       expect(body.data.body.trace.exception.message).to.eql(
         'testing window.onerror',
       );

--- a/test/replay/integration/api.spans.test.js
+++ b/test/replay/integration/api.spans.test.js
@@ -55,27 +55,27 @@ describe('API Span Transport', function () {
   });
 
   it('should format spans payload correctly', async function () {
-    const spans = [
-      {
-        id: 'span-1',
-        name: 'recording-span-1',
-        attributes: { 'attr.key': 'value' },
-      },
-      {
-        id: 'span-2',
-        name: 'recording-span-2',
-        events: [{ name: 'event-1', attributes: { type: 'click' } }],
-      },
-    ];
+    const spans = {
+      resourceSpans: [
+        {
+          id: 'span-1',
+          name: 'recording-span-1',
+          attributes: { 'attr.key': 'value' },
+        },
+        {
+          id: 'span-2',
+          name: 'recording-span-2',
+          events: [{ name: 'event-1', attributes: { type: 'click' } }],
+        },
+      ],
+    }
 
     await api.postSpans(spans);
 
     const payload = transport.post.firstCall.args[2];
 
-    expect(payload).to.have.property('access_token', accessToken);
-    expect(payload).to.have.property('data');
-    expect(payload.data).to.have.property('resourceSpans');
-    expect(payload.data.resourceSpans).to.deep.equal(spans);
+    expect(payload).to.have.property('resourceSpans');
+    expect(payload).to.deep.equal(spans);
   });
 
   it('should handle transport errors', async function () {
@@ -132,12 +132,14 @@ describe('API Span Transport', function () {
   });
 
   it('should update sessionTransportOptions when reconfigured', function () {
-    const originalTransportOptions = api.sessionTransportOptions;
+    const originalTransportOptions = api.OTLPTransportOptions;
 
     api.configure({
-      endpoint: 'https://custom.rollbar.com/api/',
+      tracing: {
+        endpoint: 'https://custom.rollbar.com/api/',
+      }
     });
 
-    expect(api.sessionTransportOptions).to.not.equal(originalTransportOptions);
+    expect(api.OTLPTransportOptions).to.not.equal(originalTransportOptions);
   });
 });

--- a/test/replay/unit/api.postSpans.test.js
+++ b/test/replay/unit/api.postSpans.test.js
@@ -47,7 +47,6 @@ describe('Api', function () {
       transport,
       mockUrl,
       null, // truncation
-      null, // jsonBackup
     );
   });
 
@@ -69,17 +68,15 @@ describe('Api', function () {
     });
 
     it('should create a payload with resourceSpans', async function () {
-      const spans = [{ id: 'span1' }];
+      const spans = {resourceSpans: [{ id: 'span1' }]};
       await api.postSpans(spans);
 
       expect(transport.post.called).to.be.true;
 
       // Get the payload argument (third parameter)
       const payload = transport.post.firstCall.args[2];
-      expect(payload).to.have.property('access_token', 'test_token');
-      expect(payload).to.have.property('data');
-      expect(payload.data).to.have.property('resourceSpans');
-      expect(payload.data.resourceSpans).to.deep.equal(spans);
+      expect(payload).to.have.property('resourceSpans');
+      expect(payload).to.deep.equal(spans);
     });
 
     it('should return a promise that resolves with the response', async function () {


### PR DESCRIPTION
## Description of the change

This PR updates `postSpans` to send the expected request format, and updates the options management to allow the correct API url path to be used. (The transport options logic is such that `options.endpoint` will always override, causing the item endpoint to be used. This PR introduces a new config option at `options.tracing.endpoint` and ensures that it is used instead.)

This PR also includes related improvements.
* Remove access token from the payload for both occurrences and traces.
* Remove jsonBackup, which is no longer needed.
* Updates tests to match these changes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Maintenance

