### PR TITLE
Exporter integration tests

### DIFF
--- a/test/fixtures/replay/payloads.fixtures.js
+++ b/test/fixtures/replay/payloads.fixtures.js
@@ -23,32 +23,41 @@ export const standardPayload = {
               startTimeUnixNano: '1600000000000000000',
               endTimeUnixNano: '1600000100000000000',
               attributes: [
-                { key: 'rollbar.replay.id', value: { stringValue: 'test-replay-id' } }
+                {
+                  key: 'rollbar.replay.id',
+                  value: { stringValue: 'test-replay-id' },
+                },
               ],
               events: [
                 {
                   name: 'rrweb-replay-events',
                   timeUnixNano: '1600000050000000000',
                   attributes: [
-                    { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
-                    { key: 'json', value: { stringValue: '{}' } }
-                  ]
+                    {
+                      key: 'eventType',
+                      value: { stringValue: String(EventType.Meta) },
+                    },
+                    { key: 'json', value: { stringValue: '{}' } },
+                  ],
                 },
                 {
                   name: 'rrweb-replay-events',
                   timeUnixNano: '1600000060000000000',
                   attributes: [
-                    { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
-                    { key: 'json', value: { stringValue: '{}' } }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
+                    {
+                      key: 'eventType',
+                      value: { stringValue: String(EventType.FullSnapshot) },
+                    },
+                    { key: 'json', value: { stringValue: '{}' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
 };
 
 /**
@@ -72,48 +81,63 @@ export const checkpointPayload = {
               startTimeUnixNano: '1600000000000000000',
               endTimeUnixNano: '1600000400000000000',
               attributes: [
-                { key: 'rollbar.replay.id', value: { stringValue: 'test-replay-id' } }
+                {
+                  key: 'rollbar.replay.id',
+                  value: { stringValue: 'test-replay-id' },
+                },
               ],
               events: [
                 {
                   name: 'rrweb-replay-events',
                   timeUnixNano: '1600000050000000000',
                   attributes: [
-                    { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
-                    { key: 'json', value: { stringValue: '{}' } }
-                  ]
+                    {
+                      key: 'eventType',
+                      value: { stringValue: String(EventType.Meta) },
+                    },
+                    { key: 'json', value: { stringValue: '{}' } },
+                  ],
                 },
                 {
                   name: 'rrweb-replay-events',
                   timeUnixNano: '1600000060000000000',
                   attributes: [
-                    { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
-                    { key: 'json', value: { stringValue: '{}' } }
-                  ]
+                    {
+                      key: 'eventType',
+                      value: { stringValue: String(EventType.FullSnapshot) },
+                    },
+                    { key: 'json', value: { stringValue: '{}' } },
+                  ],
                 },
                 {
                   name: 'rrweb-replay-events',
                   timeUnixNano: '1600000250000000000',
                   attributes: [
-                    { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
-                    { key: 'json', value: { stringValue: '{}' } }
-                  ]
+                    {
+                      key: 'eventType',
+                      value: { stringValue: String(EventType.Meta) },
+                    },
+                    { key: 'json', value: { stringValue: '{}' } },
+                  ],
                 },
                 {
                   name: 'rrweb-replay-events',
                   timeUnixNano: '1600000260000000000',
                   attributes: [
-                    { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
-                    { key: 'json', value: { stringValue: '{}' } }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
+                    {
+                      key: 'eventType',
+                      value: { stringValue: String(EventType.FullSnapshot) },
+                    },
+                    { key: 'json', value: { stringValue: '{}' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
 };
 
 /**
@@ -136,32 +160,41 @@ export const singleCheckpointPayload = {
               startTimeUnixNano: '1600000000000000000',
               endTimeUnixNano: '1600000100000000000',
               attributes: [
-                { key: 'rollbar.replay.id', value: { stringValue: 'test-replay-id' } }
+                {
+                  key: 'rollbar.replay.id',
+                  value: { stringValue: 'test-replay-id' },
+                },
               ],
               events: [
                 {
                   name: 'rrweb-replay-events',
                   timeUnixNano: '1600000050000000000',
                   attributes: [
-                    { key: 'eventType', value: { stringValue: String(EventType.Meta) } },
-                    { key: 'json', value: { stringValue: '{}' } }
-                  ]
+                    {
+                      key: 'eventType',
+                      value: { stringValue: String(EventType.Meta) },
+                    },
+                    { key: 'json', value: { stringValue: '{}' } },
+                  ],
                 },
                 {
                   name: 'rrweb-replay-events',
                   timeUnixNano: '1600000060000000000',
                   attributes: [
-                    { key: 'eventType', value: { stringValue: String(EventType.FullSnapshot) } },
-                    { key: 'json', value: { stringValue: '{}' } }
-                  ]
-                }
-              ]
-            }
-          ]
-        }
-      ]
-    }
-  ]
+                    {
+                      key: 'eventType',
+                      value: { stringValue: String(EventType.FullSnapshot) },
+                    },
+                    { key: 'json', value: { stringValue: '{}' } },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
 };
 
 /**
@@ -171,14 +204,15 @@ export const singleCheckpointPayload = {
  */
 export function createPayloadWithReplayId(replayId) {
   const payload = JSON.parse(JSON.stringify(standardPayload));
-  
-  const idAttr = payload.resourceSpans[0].scopeSpans[0].spans[0].attributes.find(
-    attr => attr.key === 'rollbar.replay.id'
-  );
-  
+
+  const idAttr =
+    payload.resourceSpans[0].scopeSpans[0].spans[0].attributes.find(
+      (attr) => attr.key === 'rollbar.replay.id',
+    );
+
   if (idAttr) {
     idAttr.value.stringValue = replayId;
   }
-  
+
   return payload;
 }

--- a/test/replay/integration/api.spans.test.js
+++ b/test/replay/integration/api.spans.test.js
@@ -11,6 +11,10 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 
 import Api from '../../../src/api.js';
+import {
+  standardPayload,
+  createPayloadWithReplayId,
+} from '../../fixtures/replay/payloads.fixtures.js';
 
 describe('API Span Transport', function () {
   let api;
@@ -44,7 +48,7 @@ describe('API Span Transport', function () {
   });
 
   it('should use the session endpoint for spans', async function () {
-    const spans = [{ id: 'test-span', name: 'recording-span' }];
+    const spans = standardPayload;
 
     await api.postSpans(spans);
 
@@ -55,20 +59,8 @@ describe('API Span Transport', function () {
   });
 
   it('should format spans payload correctly', async function () {
-    const spans = {
-      resourceSpans: [
-        {
-          id: 'span-1',
-          name: 'recording-span-1',
-          attributes: { 'attr.key': 'value' },
-        },
-        {
-          id: 'span-2',
-          name: 'recording-span-2',
-          events: [{ name: 'event-1', attributes: { type: 'click' } }],
-        },
-      ],
-    }
+    const testReplayId = 'test-replay-api-12345';
+    const spans = createPayloadWithReplayId(testReplayId);
 
     await api.postSpans(spans);
 
@@ -92,8 +84,7 @@ describe('API Span Transport', function () {
 
     try {
       await api.postSpans(spans);
-      // Should not reach here
-      expect(true).to.be.false;
+      expect.fail('Expected error not thrown');
     } catch (error) {
       expect(error).to.equal(testError);
     }
@@ -137,7 +128,7 @@ describe('API Span Transport', function () {
     api.configure({
       tracing: {
         endpoint: 'https://custom.rollbar.com/api/',
-      }
+      },
     });
 
     expect(api.OTLPTransportOptions).to.not.equal(originalTransportOptions);

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -144,9 +144,6 @@ describe('Session Replay E2E', function () {
             expect(span).to.have.property('events');
             expect(span.events).to.be.an('array');
             expect(span).to.have.property('attributes').that.is.an('array');
-
-            console.log('Test replayId:', errorItem.replayId);
-            console.log('Span attributes:', JSON.stringify(span.attributes));
           }
 
           const transportArgs = transport.post.lastCall.args;

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -75,39 +75,16 @@ describe('Session Replay E2E', function () {
       truncationMock,
     );
 
-    const mockPayload = [
-      {
-        name: 'rrweb-replay-recording',
-        events: [
-          {
-            name: 'rrweb-replay-events',
-            attributes: {
-              eventType: 4,
-              json: '{"data":{"type":"Test"}}',
-            },
-          },
-        ],
-        attributes: {},
-      },
-    ];
     recorder = new Recorder(options.recorder, mockRecordFn);
-    sinon.stub(recorder, 'dump').callsFake((tracing, replayId) => {
-      mockPayload[0].attributes['rollbar.replay.id'] = replayId;
-      mockPayload[0].events[0].attributes['rollbar.replay.id'] = replayId;
-      return mockPayload;
-    });
 
-    // Setup rateLimiter
     rateLimiter = { shouldSend: () => ({ shouldSend: true }) };
 
-    // Setup ReplayMap with real components
     replayMap = new ReplayMap({
       recorder,
       api,
       tracing,
     });
 
-    // Setup Queue with all components
     queue = new Queue(rateLimiter, api, logger, { transmit: true }, replayMap);
   });
 
@@ -122,7 +99,7 @@ describe('Session Replay E2E', function () {
     recorder.start();
 
     setTimeout(() => {
-      const recorderDumpSpy = recorder.dump;
+      const recorderDumpSpy = sinon.spy(recorder, 'dump');
       const replayMapAddSpy = sinon.spy(replayMap, 'add');
       const replayMapSendSpy = sinon.spy(replayMap, 'send');
       const apiPostItemSpy = sinon.spy(api, 'postItem');
@@ -151,23 +128,25 @@ describe('Session Replay E2E', function () {
           expect(apiPostSpansSpy.calledOnce).to.be.true;
 
           const payload = apiPostSpansSpy.firstCall.args[0];
-          expect(payload).to.be.an('array');
+          expect(payload).to.be.an('object');
+          expect(payload).to.have.property('resourceSpans');
+          expect(payload.resourceSpans).to.be.an('array');
 
-          if (payload.length > 0) {
-            const span = payload[0];
+          if (
+            payload.resourceSpans.length > 0 &&
+            payload.resourceSpans[0].scopeSpans &&
+            payload.resourceSpans[0].scopeSpans.length > 0 &&
+            payload.resourceSpans[0].scopeSpans[0].spans &&
+            payload.resourceSpans[0].scopeSpans[0].spans.length > 0
+          ) {
+            const span = payload.resourceSpans[0].scopeSpans[0].spans[0];
             expect(span).to.have.property('name', 'rrweb-replay-recording');
             expect(span).to.have.property('events');
             expect(span.events).to.be.an('array');
-            expect(span.events[0]).to.have.property(
-              'name',
-              'rrweb-replay-events',
-            );
-            expect(span.events[0].attributes).to.have.property('eventType');
-            expect(span.events[0].attributes).to.have.property('json');
-            expect(span.attributes).to.have.property(
-              'rollbar.replay.id',
-              errorItem.replayId,
-            );
+            expect(span).to.have.property('attributes').that.is.an('array');
+
+            console.log('Test replayId:', errorItem.replayId);
+            console.log('Span attributes:', JSON.stringify(span.attributes));
           }
 
           const transportArgs = transport.post.lastCall.args;

--- a/test/replay/integration/index.js
+++ b/test/replay/integration/index.js
@@ -1,10 +1,7 @@
 /**
  * Session Replay Integration Tests
- *
- * This index exports all integration tests for the session replay feature.
  */
 
-// Export all integration tests
 export * from './sessionRecording.test.js';
 export * from './api.spans.test.js';
 export * from './replayMap.test.js';

--- a/test/replay/integration/queue.replayMap.test.js
+++ b/test/replay/integration/queue.replayMap.test.js
@@ -43,7 +43,6 @@ describe('Queue ReplayMap Integration', function () {
       truncationMock,
     );
 
-    // Mock ReplayMap - use a minimal implementation with spies
     replayMap = {
       add: sinon.stub().returns('test-replay-id'),
       send: sinon.stub().resolves(true),
@@ -52,7 +51,6 @@ describe('Queue ReplayMap Integration', function () {
       setSpans: sinon.stub(),
     };
 
-    // Create Queue with mocked rateLimiter
     queue = new Queue(
       { shouldSend: () => ({ shouldSend: true }) },
       api,
@@ -96,7 +94,6 @@ describe('Queue ReplayMap Integration', function () {
     };
 
     queue.addItem(item, function () {
-      // Wait for handleReplayResponse to complete
       setTimeout(function () {
         expect(replayMap.send.calledWith('test-replay-id')).to.be.true;
         done();
@@ -105,7 +102,6 @@ describe('Queue ReplayMap Integration', function () {
   });
 
   it('should call replayMap.discard when API response has error', function (done) {
-    // Make API return an error
     transport.post.callsFake(
       (accessToken, transportOptions, payload, callback) => {
         setTimeout(() => {
@@ -125,7 +121,6 @@ describe('Queue ReplayMap Integration', function () {
     };
 
     queue.addItem(item, function () {
-      // Wait for handleReplayResponse to complete
       setTimeout(function () {
         expect(replayMap.discard.calledWith('test-replay-id')).to.be.true;
         expect(replayMap.send.called).to.be.false;
@@ -135,7 +130,6 @@ describe('Queue ReplayMap Integration', function () {
   });
 
   it('should handle retrying items with replayId', function (done) {
-    // Make the first API call fail with network error, then succeed
     let apiCallCount = 0;
     transport.post.callsFake(
       (accessToken, transportOptions, payload, callback) => {
@@ -152,7 +146,6 @@ describe('Queue ReplayMap Integration', function () {
       },
     );
 
-    // Set retry interval to be fast for testing
     queue.configure({ retryInterval: 50, maxRetries: 3 });
 
     const item = {
@@ -167,10 +160,8 @@ describe('Queue ReplayMap Integration', function () {
 
     queue.addItem(item, function (err, resp) {
       if (resp) {
-        // Item was eventually sent successfully after retry
         expect(item).to.have.property('replayId', 'test-replay-id');
 
-        // Wait for handleReplayResponse to complete
         setTimeout(function () {
           expect(replayMap.send.calledWith('test-replay-id')).to.be.true;
           done();
@@ -181,7 +172,6 @@ describe('Queue ReplayMap Integration', function () {
 
   it('should not add replayId to items without a body', function (done) {
     const item = {
-      // No body field
       level: 'error',
       message: 'Test error without body',
     };
@@ -194,7 +184,6 @@ describe('Queue ReplayMap Integration', function () {
   });
 
   it('should handle null response in _handleReplayResponse', function (done) {
-    // Make API return null response
     transport.post.callsFake(
       (accessToken, transportOptions, payload, callback) => {
         setTimeout(() => {
@@ -216,7 +205,6 @@ describe('Queue ReplayMap Integration', function () {
     };
 
     queue.addItem(item, function () {
-      // Wait for handleReplayResponse to complete
       setTimeout(function () {
         expect(replayMap.send.called).to.be.false;
         expect(replayMap.discard.calledWith('test-replay-id')).to.be.true;

--- a/test/replay/unit/api.postSpans.test.js
+++ b/test/replay/unit/api.postSpans.test.js
@@ -11,7 +11,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-// We need to use require since the API module is a CommonJS module
 const Api = require('../../../src/api');
 
 describe('Api', function () {
@@ -20,7 +19,6 @@ describe('Api', function () {
   let mockUrl;
 
   beforeEach(function () {
-    // Create mock transport
     transport = {
       post: sinon
         .stub()
@@ -30,7 +28,6 @@ describe('Api', function () {
       postJsonPayload: sinon.stub(),
     };
 
-    // Create mock URL module
     mockUrl = {
       parse: sinon.stub().returns({
         hostname: 'api.rollbar.com',
@@ -41,7 +38,6 @@ describe('Api', function () {
       }),
     };
 
-    // Create API instance
     api = new Api(
       { accessToken: 'test_token' },
       transport,
@@ -61,7 +57,6 @@ describe('Api', function () {
 
       expect(transport.post.called).to.be.true;
 
-      // Get the options argument (second parameter)
       const options = transport.post.firstCall.args[1];
       expect(options.path).to.include('/session/');
       expect(options.method).to.equal('POST');
@@ -73,7 +68,6 @@ describe('Api', function () {
 
       expect(transport.post.called).to.be.true;
 
-      // Get the payload argument (third parameter)
       const payload = transport.post.firstCall.args[2];
       expect(payload).to.have.property('resourceSpans');
       expect(payload).to.deep.equal(spans);
@@ -91,7 +85,6 @@ describe('Api', function () {
       const spans = [{ id: 'span1' }];
       const expectedError = new Error('Transport error');
 
-      // Make transport.post fail
       transport.post.callsFake((accessToken, options, payload, callback) => {
         callback(expectedError);
       });
@@ -114,20 +107,16 @@ describe('Api', function () {
     });
 
     it('should update transport options when API is reconfigured', async function () {
-      // First request with default options
       await api.postSpans([{ id: 'span1' }]);
 
-      // Reconfigure the API with a new endpoint
       api.configure({
         endpoint: 'https://custom.rollbar.com/api/1/session/',
       });
 
-      // Send another request with new configuration
       await api.postSpans([{ id: 'span2' }]);
 
       expect(transport.post.callCount).to.equal(2);
 
-      // Get the options from the second call
       const optionsAfterConfig = transport.post.secondCall.args[1];
       expect(optionsAfterConfig.hostname).to.equal('api.rollbar.com');
     });

--- a/test/replay/unit/api.postSpans.test.js
+++ b/test/replay/unit/api.postSpans.test.js
@@ -68,7 +68,7 @@ describe('Api', function () {
     });
 
     it('should create a payload with resourceSpans', async function () {
-      const spans = {resourceSpans: [{ id: 'span1' }]};
+      const spans = { resourceSpans: [{ id: 'span1' }] };
       await api.postSpans(spans);
 
       expect(transport.post.called).to.be.true;

--- a/test/replay/unit/index.js
+++ b/test/replay/unit/index.js
@@ -1,10 +1,7 @@
 /**
  * Session Replay Unit Tests
- *
- * This index exports all unit tests for the session replay feature.
  */
 
-// Export all unit tests
 export * from './replayMap.test.js';
 export * from './api.postSpans.test.js';
 export * from './queue.replayMap.test.js';

--- a/test/tracing/exporter.toPayload.test.js
+++ b/test/tracing/exporter.toPayload.test.js
@@ -14,8 +14,6 @@ import { standardPayload } from '../fixtures/replay/payloads.fixtures.js';
 
 describe('SpanExporter.toPayload()', function () {
   let exporter;
-  let hrtimeStub;
-  let idStub;
 
   beforeEach(function () {
     spanExportQueue.length = 0;
@@ -62,18 +60,23 @@ describe('SpanExporter.toPayload()', function () {
     expect(payload).to.have.property('resourceSpans').that.is.an('array');
     expect(payload.resourceSpans).to.have.lengthOf(1);
     expect(payload.resourceSpans[0]).to.have.property('resource');
-    expect(payload.resourceSpans[0]).to.have.property('scopeSpans').that.is.an('array');
+    expect(payload.resourceSpans[0])
+      .to.have.property('scopeSpans')
+      .that.is.an('array');
     expect(payload.resourceSpans[0].scopeSpans).to.have.lengthOf(1);
 
-    // Verify span data
     const transformedSpan = payload.resourceSpans[0].scopeSpans[0].spans[0];
     expect(transformedSpan).to.have.property('name', 'test-span');
-    expect(transformedSpan).to.have.property('traceId', 'abcdef1234567890abcdef1234567890');
+    expect(transformedSpan).to.have.property(
+      'traceId',
+      'abcdef1234567890abcdef1234567890',
+    );
     expect(transformedSpan).to.have.property('spanId', '1234567890abcdef');
 
-    // Verify attributes
     expect(transformedSpan).to.have.property('attributes').that.is.an('array');
-    const attribute = transformedSpan.attributes.find(attr => attr.key === 'test.attribute');
+    const attribute = transformedSpan.attributes.find(
+      (attr) => attr.key === 'test.attribute',
+    );
     expect(attribute).to.exist;
     expect(attribute.value).to.have.property('stringValue', 'test-value');
   });
@@ -104,28 +107,29 @@ describe('SpanExporter.toPayload()', function () {
 
     exporter.export([mockSpan]);
     const payload = exporter.toPayload();
-    const attributes = payload.resourceSpans[0].scopeSpans[0].spans[0].attributes;
+    const attributes =
+      payload.resourceSpans[0].scopeSpans[0].spans[0].attributes;
 
-    const stringAttr = attributes.find(a => a.key === 'stringAttr');
+    const stringAttr = attributes.find((a) => a.key === 'stringAttr');
     expect(stringAttr.value).to.have.property('stringValue', 'string-value');
 
-    const intAttr = attributes.find(a => a.key === 'intAttr');
+    const intAttr = attributes.find((a) => a.key === 'intAttr');
     expect(intAttr.value).to.have.property('intValue', '42');
 
-    const floatAttr = attributes.find(a => a.key === 'floatAttr');
+    const floatAttr = attributes.find((a) => a.key === 'floatAttr');
     expect(floatAttr.value).to.have.property('doubleValue', 3.14);
 
-    const boolAttr = attributes.find(a => a.key === 'boolAttr');
+    const boolAttr = attributes.find((a) => a.key === 'boolAttr');
     expect(boolAttr.value).to.have.property('boolValue', true);
 
-    const nullAttr = attributes.find(a => a.key === 'nullAttr');
+    const nullAttr = attributes.find((a) => a.key === 'nullAttr');
     expect(nullAttr.value).to.have.property('stringValue', '');
 
-    const arrayAttr = attributes.find(a => a.key === 'arrayAttr');
+    const arrayAttr = attributes.find((a) => a.key === 'arrayAttr');
     expect(arrayAttr.value).to.have.property('arrayValue');
     expect(arrayAttr.value.arrayValue.values).to.have.lengthOf(3);
 
-    const objectAttr = attributes.find(a => a.key === 'objectAttr');
+    const objectAttr = attributes.find((a) => a.key === 'objectAttr');
     expect(objectAttr.value).to.have.property('kvlistValue');
   });
 
@@ -172,7 +176,9 @@ describe('SpanExporter.toPayload()', function () {
 
     expect(events[0]).to.have.property('timeUnixNano').that.is.a('number');
 
-    const eventAttribute = events[0].attributes.find(a => a.key === 'event.key1');
+    const eventAttribute = events[0].attributes.find(
+      (a) => a.key === 'event.key1',
+    );
     expect(eventAttribute).to.exist;
     expect(eventAttribute.value).to.have.property('stringValue', 'value1');
   });
@@ -241,8 +247,12 @@ describe('SpanExporter.toPayload()', function () {
     expect(payload.resourceSpans).to.have.lengthOf(1);
     expect(payload.resourceSpans[0].scopeSpans).to.have.lengthOf(2);
 
-    const scope1 = payload.resourceSpans[0].scopeSpans.find(s => s.scope.name === 'scope1');
-    const scope2 = payload.resourceSpans[0].scopeSpans.find(s => s.scope.name === 'scope2');
+    const scope1 = payload.resourceSpans[0].scopeSpans.find(
+      (s) => s.scope.name === 'scope1',
+    );
+    const scope2 = payload.resourceSpans[0].scopeSpans.find(
+      (s) => s.scope.name === 'scope2',
+    );
 
     expect(scope1).to.exist;
     expect(scope2).to.exist;
@@ -310,11 +320,11 @@ describe('SpanExporter.toPayload()', function () {
     const payload = exporter.toPayload(options);
     const resourceAttrs = payload.resourceSpans[0].resource.attributes;
 
-    const optionsAttr = resourceAttrs.find(a => a.key === 'options.resource');
+    const optionsAttr = resourceAttrs.find((a) => a.key === 'options.resource');
     expect(optionsAttr).to.exist;
     expect(optionsAttr.value).to.have.property('stringValue', 'override');
 
-    const spanAttr = resourceAttrs.find(a => a.key === 'span.resource');
+    const spanAttr = resourceAttrs.find((a) => a.key === 'span.resource');
     expect(spanAttr).to.not.exist;
   });
 
@@ -335,16 +345,16 @@ describe('SpanExporter.toPayload()', function () {
           name: 'rrweb-replay-events',
           time: hrtime.now(),
           attributes: {
-            'eventType': String(EventType.Meta),
-            'json': '{}',
+            eventType: String(EventType.Meta),
+            json: '{}',
           },
         },
         {
           name: 'rrweb-replay-events',
           time: hrtime.now(),
           attributes: {
-            'eventType': String(EventType.FullSnapshot),
-            'json': '{}',
+            eventType: String(EventType.FullSnapshot),
+            json: '{}',
           },
         },
       ],
@@ -360,27 +370,19 @@ describe('SpanExporter.toPayload()', function () {
     exporter.export([span]);
     const payload = exporter.toPayload();
 
-    // Create a standardPayload-based expected object with the stubbed IDs
     const expected = JSON.parse(JSON.stringify(standardPayload));
-
-    // Verify specific fields match before deep comparison
     const actualSpan = payload.resourceSpans[0].scopeSpans[0].spans[0];
 
-    // IDs should match our mock data
     expect(actualSpan.traceId).to.equal('abcdef1234567890abcdef1234567890');
     expect(actualSpan.spanId).to.equal('1234567890abcdef');
 
-    // Timestamps should be consistent
     expect(actualSpan.startTimeUnixNano).to.equal(1000000000);
     expect(actualSpan.endTimeUnixNano).to.equal(1000000000);
 
-    // Event timestamps should be consistent
-    actualSpan.events.forEach(event => {
+    actualSpan.events.forEach((event) => {
       expect(event.timeUnixNano).to.equal(1000000000);
     });
 
-    // Create a modified copy of payload and standardPayload for structure comparison
-    // that ignores the dynamic values we've already verified separately
     function createComparablePayload(payload) {
       const clone = JSON.parse(JSON.stringify(payload));
 
@@ -393,7 +395,7 @@ describe('SpanExporter.toPayload()', function () {
       delete span.endTimeUnixNano;
       delete span.kind;
 
-      span.events.forEach(event => {
+      span.events.forEach((event) => {
         delete event.timeUnixNano;
       });
 
@@ -403,24 +405,30 @@ describe('SpanExporter.toPayload()', function () {
     const comparablePayload = createComparablePayload(payload);
     const comparableStandard = createComparablePayload(standardPayload);
 
-    // Log the actual values to debug the difference
-    console.log('Actual events:', JSON.stringify(comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].events, null, 2));
-    console.log('Expected events:', JSON.stringify(comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].events, null, 2));
+    expect(
+      comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].name,
+    ).to.deep.equal(
+      comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].name,
+      'Span names should match',
+    );
 
-    // Log the scope objects to debug differences
-    console.log('Actual scope:', JSON.stringify(comparablePayload.resourceSpans[0].scopeSpans[0].scope, null, 2));
-    console.log('Expected scope:', JSON.stringify(comparableStandard.resourceSpans[0].scopeSpans[0].scope, null, 2));
+    expect(
+      comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].attributes,
+    ).to.deep.equal(
+      comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].attributes,
+      'Span attributes should match',
+    );
 
-    expect(comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].name)
-      .to.deep.equal(comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].name, 'Span names should match');
+    expect(
+      comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].events,
+    ).to.deep.equal(
+      comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].events,
+      'Span events should match',
+    );
 
-    expect(comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].attributes)
-      .to.deep.equal(comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].attributes, 'Span attributes should match');
-
-    expect(comparablePayload.resourceSpans[0].scopeSpans[0].spans[0].events)
-      .to.deep.equal(comparableStandard.resourceSpans[0].scopeSpans[0].spans[0].events, 'Span events should match');
-
-    // Verify the structure is identical between our payload and the standard
-    expect(comparablePayload).to.deep.equal(comparableStandard, 'Complete payload structure should match');
+    expect(comparablePayload).to.deep.equal(
+      comparableStandard,
+      'Complete payload structure should match',
+    );
   });
 });

--- a/test/tracing/exporter.toPayload.test.js
+++ b/test/tracing/exporter.toPayload.test.js
@@ -14,6 +14,8 @@ import { standardPayload } from '../fixtures/replay/payloads.fixtures.js';
 
 describe('SpanExporter.toPayload()', function () {
   let exporter;
+  let hrtimeStub;
+  let idStub;
 
   beforeEach(function () {
     spanExportQueue.length = 0;

--- a/test/tracing/id.test.js
+++ b/test/tracing/id.test.js
@@ -9,18 +9,18 @@ describe('id', function () {
     const id8 = id.gen(8);
     const id16 = id.gen(16);
     const id32 = id.gen(32);
-    
+
     expect(id8).to.match(/^[a-f0-9]{16}$/);
     expect(id16).to.match(/^[a-f0-9]{32}$/);
     expect(id32).to.match(/^[a-f0-9]{64}$/);
-    
+
     // Default should be 16 bytes (32 hex chars)
     const defaultId = id.gen();
     expect(defaultId).to.match(/^[a-f0-9]{32}$/);
-    
+
     // Should generate different IDs
     expect(id.gen()).to.not.equal(id.gen());
-    
+
     done();
   });
 });

--- a/test/tracing/id.test.js
+++ b/test/tracing/id.test.js
@@ -14,11 +14,9 @@ describe('id', function () {
     expect(id16).to.match(/^[a-f0-9]{32}$/);
     expect(id32).to.match(/^[a-f0-9]{64}$/);
 
-    // Default should be 16 bytes (32 hex chars)
     const defaultId = id.gen();
     expect(defaultId).to.match(/^[a-f0-9]{32}$/);
 
-    // Should generate different IDs
     expect(id.gen()).to.not.equal(id.gen());
 
     done();


### PR DESCRIPTION
## Description of the change

Integrated `SpanExporter.toPayload` to the integration tests instead of stubbing them. I'm still not entirely happy with it because of the non-deterministic nature of the mock record function I created to emulate rrweb.

I may either create a new mock record that's deterministic, or modify the current one. Then stub whatever gives non-deterministic data like time and ids. That way, we can do a proper deep equality to make sure the complete structure that comes in and goes out is as correct as it can be.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

[CAT-355/enable-tracesession-transport-to-moxapi](https://linear.app/rollbar-inc/issue/CAT-355/enable-tracesession-transport-to-moxapi)
