### PR TITLE
Update resource and (temporary) scope

### DIFF
--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -9,8 +9,6 @@ const SPAN_KEY = createContextKey('Rollbar Context Key SPAN');
 export default class Tracing {
   constructor(gWindow, options) {
     this.options = options;
-    this.resource = options.resource;
-    this.scope = options.notifier;
     this.window = gWindow;
 
     this.session = new Session(this, options);
@@ -30,6 +28,19 @@ export default class Tracing {
     return null;
   }
 
+  get resource() {
+    return {
+      ...(this.options.resource || {}),
+      'rollbar.environment': this.options.environment,
+    };
+  }
+
+  get scope() {
+    return {
+      name: 'rollbar-browser-js',
+      version: this.options.version,
+    };
+  }
 
   createTracer() {
     this.contextManager = new ContextManager();

--- a/test/tracing/tracing.test.js
+++ b/test/tracing/tracing.test.js
@@ -21,10 +21,7 @@ const tracingOptions = function (options = {}) {
         'telemetry.sdk.version': '0.1.0',
       },
     },
-    notifier: {
-      name: 'rollbar.js',
-      version: '0.1.0',
-    },
+    version: '0.1.0',
     ...options,
   };
 };
@@ -50,7 +47,7 @@ describe('Tracing()', function () {
     expect(t.tracer).to.be.an.instanceOf(Tracer);
 
     expect(t.options.resource).to.deep.equal(options.resource);
-    expect(t.options.notifier).to.deep.equal(options.notifier);
+    expect(t.options.version).to.equal(options.version);
     expect(t.session.session.id).to.match(/^[a-f0-9]{32}$/)
     done();
   });
@@ -68,7 +65,8 @@ describe('Tracing()', function () {
     expect(span.span.spanContext.traceId).to.match(/^[a-f0-9]{32}$/)
     expect(span.span.spanContext.spanId).to.match(/^[a-f0-9]{16}$/)
     expect(span.span.resource.attributes['service.name']).to.equal('unknown_service')
-    expect(span.span.instrumentationScope.name).to.equal('rollbar.js')
+    expect(span.span.instrumentationScope.name).to.equal('rollbar-browser-js')
+    expect(span.span.instrumentationScope.version).to.equal('0.1.0')
     expect(span.isRecording()).to.equal(true)
     expect(t.contextManager.active()).to.equal(ROOT_CONTEXT)
 


### PR DESCRIPTION
## Description of the change

Fixes the options for resource attributes and scope. The scope is temporary, and will likely be updated to use `telemetry.sdk.*` attributes, while making the scope name and version available to the app.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


