### PR TITLE
Fix resource attributes

### DIFF
--- a/src/tracing/exporter.js
+++ b/src/tracing/exporter.js
@@ -34,7 +34,7 @@ export class SpanExporter {
       return { resourceSpans: [] };
     }
 
-    const resource = options.resource || (spans[0] && spans[0].resource) || {};
+    const resource = (spans[0] && spans[0].resource) || {};
 
     const scopeMap = new Map();
 

--- a/src/tracing/exporter.js
+++ b/src/tracing/exporter.js
@@ -21,12 +21,9 @@ export class SpanExporter {
    * compatible with the Rollbar API. This follows the OpenTelemetry protocol
    * specification for traces.
    *
-   * @param {Array} spans - Array of ReadableSpan objects to transform
-   * @param {Object} options - Additional options for the transformation
-   * @param {Object} options.resource - Resource information
    * @returns {Object} OTLP format payload for API transmission
    */
-  toPayload(options = {}) {
+  toPayload() {
     const spans = spanExportQueue.slice();
     spanExportQueue.length = 0;
 

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -30,8 +30,10 @@ export default class Tracing {
 
   get resource() {
     return {
-      ...(this.options.resource || {}),
-      'rollbar.environment': this.options.environment,
+      attributes: {
+        ...(this.options.resource || {}),
+        'rollbar.environment': this.options.environment,
+      }
     };
   }
 

--- a/test/tracing/exporter.toPayload.test.js
+++ b/test/tracing/exporter.toPayload.test.js
@@ -291,45 +291,6 @@ describe('SpanExporter.toPayload()', function () {
     });
   });
 
-  it('should use resource from options if provided', function () {
-    const mockSpan = {
-      name: 'resource-test-span',
-      spanContext: {
-        traceId: 'abcdef1234567890abcdef1234567890',
-        spanId: '1234567890abcdef',
-      },
-      startTime: hrtime.now(),
-      endTime: hrtime.now(),
-      attributes: {},
-      events: [],
-      resource: {
-        attributes: {
-          'span.resource': 'value',
-        },
-      },
-    };
-
-    exporter.export([mockSpan]);
-
-    const options = {
-      resource: {
-        attributes: {
-          'options.resource': 'override',
-        },
-      },
-    };
-
-    const payload = exporter.toPayload(options);
-    const resourceAttrs = payload.resourceSpans[0].resource.attributes;
-
-    const optionsAttr = resourceAttrs.find((a) => a.key === 'options.resource');
-    expect(optionsAttr).to.exist;
-    expect(optionsAttr.value).to.have.property('stringValue', 'override');
-
-    const spanAttr = resourceAttrs.find((a) => a.key === 'span.resource');
-    expect(spanAttr).to.not.exist;
-  });
-
   it('should produce a payload compatible with standardPayload fixture', function () {
     const span = {
       name: 'rrweb-replay-recording',

--- a/test/tracing/tracing.test.js
+++ b/test/tracing/tracing.test.js
@@ -14,12 +14,10 @@ import Tracing from '../../src/tracing/tracing';
 const tracingOptions = function (options = {}) {
   return {
     resource: {
-      attributes: {
-        'service.name': 'unknown_service',
-        'telemetry.sdk.language': 'webjs',
-        'telemetry.sdk.name': 'rollbar',
-        'telemetry.sdk.version': '0.1.0',
-      },
+      'service.name': 'unknown_service',
+      'telemetry.sdk.language': 'webjs',
+      'telemetry.sdk.name': 'rollbar',
+      'telemetry.sdk.version': '0.1.0',
     },
     version: '0.1.0',
     ...options,


### PR DESCRIPTION
## Description of the change

* Wrap resource attributes, so the exporter can consume them.
* Remove the `options.resource` override in the exporter.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


