### PR TITLE
Send environment from options.payload.environment in sesh rep

### DIFF
--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -32,8 +32,9 @@ export default class Tracing {
     return {
       attributes: {
         ...(this.options.resource || {}),
-        'rollbar.environment': this.options.environment,
-      }
+        'rollbar.environment':
+          this.options.payload?.environment ?? this.options.environment,
+      },
     };
   }
 
@@ -73,6 +74,11 @@ export default class Tracing {
 
   withSpan(name, options, fn, thisArg) {
     const span = this.startSpan(name, options);
-    return this.with(this.setSpan(this.contextManager.active(), span), fn, thisArg, span);
+    return this.with(
+      this.setSpan(this.contextManager.active(), span),
+      fn,
+      thisArg,
+      span,
+    );
   }
 }

--- a/test/fixtures/replay/payloads.fixtures.js
+++ b/test/fixtures/replay/payloads.fixtures.js
@@ -9,7 +9,18 @@ import { EventType } from '@rrweb/types';
 export const standardPayload = {
   resourceSpans: [
     {
-      resource: { attributes: [] },
+      resource: {
+        attributes: [
+          {
+            key: 'service.name',
+            value: { stringValue: 'test_service' },
+          },
+          {
+            key: 'rollbar.environment',
+            value: { stringValue: 'testenv' },
+          },
+        ],
+      },
       scopeSpans: [
         {
           scope: { name: 'rollbar.js', version: '1.0.0', attributes: [] },

--- a/test/tracing/exporter.toPayload.test.js
+++ b/test/tracing/exporter.toPayload.test.js
@@ -326,7 +326,10 @@ describe('SpanExporter.toPayload()', function () {
         version: '1.0.0',
       },
       resource: {
-        attributes: {},
+        attributes: {
+          'service.name': 'test_service',
+          'rollbar.environment': 'testenv',
+        },
       },
     };
 


### PR DESCRIPTION
## Description of the change

This PR uses the same fallback to get the `environment` as react-native and server when setting `rollbar.environment` in for the `resource` tracing.

Not doing this was causing a 400 Bad Request to be returned when sending the payload to moxapi.

I've also added tests to check custom attributes that must be present like `rollbar.environment`, `replay.id` and `session.id`.

As per our documentation, environment should be set inside `payload` in the config:
- https://docs.rollbar.com/docs/rollbarjs-configuration-reference#notifier
- https://docs.rollbar.com/docs/browser-js#quick-start

In all instances where we attempt to get the environment, we employ this fallback:
```py
$ rg -A1 --max-columns=120 --glob '!dist' "environment ="
src/rateLimiter.js
145:  var environment =
146-    options.environment || (options.payload && options.payload.environment);

src/react-native/rollbar.js
27:  this.options.environment = this.options.environment || 'unspecified';
28-

src/react-native/transforms.js
6:  var environment =
7-    (options.payload && options.payload.environment) || options.environment;

src/server/transforms.js
9:  var environment =
10-    (options.payload && options.payload.environment) || options.environment;

src/browser/transforms.js
67:  var environment =
68-    (options.payload && options.payload.environment) || options.environment;

src/server/rollbar.js
36:  this.options.environment = this.options.environment || 'unspecified';
37-  logger.setVerbose(this.options.verbose);
```

Although we don't do it consistently, eg. in `rateLimiter` we prioritize `options.environment` over `options.payload.environment`. 

There's also some fishiness in how `this.options.environment` is set in:
```py
src/react-native/rollbar.js
27:  this.options.environment = this.options.environment || 'unspecified';
```
and
```py
src/server/rollbar.js
36:  this.options.environment = this.options.environment || 'unspecified';
```
Which may be worth looking into.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

[CAT-355/enable-tracesession-transport-to-moxapi](https://linear.app/rollbar-inc/issue/CAT-355/enable-tracesession-transport-to-moxapi)