### PR TITLE
Avoid dumping recordings with less than 2 events

### DIFF
--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -64,8 +64,8 @@ export default class Recorder {
   dump(tracing, replayId, occurrenceUuid) {
     const events = this.#events.previous.concat(this.#events.current);
 
-    if (events.length === 0) {
-      console.warn('Recorder.dump: No events to dump');
+    if (events.length < 2) {
+      console.warn(`Recorder.dump: Min 2 events req. Found ${events.length}`);
       return null;
     }
 

--- a/test/browser.replay.recorder.test.js
+++ b/test/browser.replay.recorder.test.js
@@ -304,6 +304,7 @@ describe('Recorder', function () {
       recorder.start();
 
       emitCallback({ timestamp: 1000, type: 'event1', data: { a: 1 } }, false);
+      emitCallback({ timestamp: 2000, type: 'event2', data: { b: 2 } }, false);
 
       recorder.dump(mockTracing, testReplayId);
 
@@ -346,6 +347,19 @@ describe('Recorder', function () {
 
       const result = recorder.dump(mockTracing, testReplayId);
 
+      expect(result).to.be.null;
+      expect(mockTracing.startSpan.called).to.be.false;
+      expect(mockTracing.exporter.toPayload.called).to.be.false;
+    });
+
+    it('should handle less than 2 events (invalid recording)', function () {
+      const recorder = new Recorder({}, recordFnStub);
+      recorder.start();
+      
+      emitCallback({ timestamp: 1000, type: 'event1', data: { a: 1 } }, false);
+      
+      const result = recorder.dump(mockTracing, testReplayId);
+      
       expect(result).to.be.null;
       expect(mockTracing.startSpan.called).to.be.false;
       expect(mockTracing.exporter.toPayload.called).to.be.false;


### PR DESCRIPTION
## Description of the change

Updated the `dump` method in `src/browser/replay/recorder.js` to require a minimum of 2 events for a valid recording. That is the minimum required by the rrweb player, otherwise it won't work.

All recordings need at the very least 2 events, which are typically the Meta and FullSnapshot events.

Added test cases to cover this.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

[CAT-355/enable-tracesession-transport-to-moxapi](https://linear.app/rollbar-inc/issue/CAT-355/enable-tracesession-transport-to-moxapi)
