### PR TITLE
Initial timeline events (otel telemetry events)

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -30,9 +30,6 @@ function Rollbar(options, client) {
 
   const transport = new Transport(truncation);
   const api = new API(this.options, transport, urllib, truncation);
-  if (Telemeter) {
-    this.telemeter = new Telemeter(this.options);
-  }
   if (Tracing) {
     this.tracing = new Tracing(_gWindow(), this.options);
     this.tracing.initSession();
@@ -52,6 +49,9 @@ function Rollbar(options, client) {
     }
   }
 
+  if (Telemeter) {
+    this.telemeter = new Telemeter(this.options, this.tracing);
+  }
   this.client =
     client || new Client(this.options, api, logger, this.telemeter, this.tracing, this.replayMap, 'browser');
   var gWindow = _gWindow();

--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -613,7 +613,7 @@ Instrumenter.prototype.instrumentConsole = function () {
     c[method] = function () {
       var args = Array.prototype.slice.call(arguments);
       var message = _.formatArgsAsString(args);
-      self.telemeter.captureLog(message, level);
+      self.telemeter.captureLog(message, level, null, _.now());
       if (orig) {
         Function.prototype.apply.call(orig, origConsole, args);
       }
@@ -822,7 +822,7 @@ Instrumenter.prototype.handleUrlChange = function (from, to) {
   ) {
     from = parsedFrom.path + (parsedFrom.hash || '');
   }
-  this.telemeter.captureNavigation(from, to);
+  this.telemeter.captureNavigation(from, to, _.now());
 };
 
 Instrumenter.prototype.deinstrumentConnectivity = function () {
@@ -922,7 +922,7 @@ Instrumenter.prototype.handleCspEvent = function (cspEvent) {
 
   message += 'originalPolicy: ' + cspEvent.originalPolicy;
 
-  this.telemeter.captureLog(message, 'error');
+  this.telemeter.captureLog(message, 'error', null, _.now());
   this.handleCspError(message);
 };
 

--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -1,7 +1,11 @@
 var _ = require('./utility');
-const hrtime = require('./tracing/hrtime').default;
 
 const MAX_EVENTS = 100;
+
+// Temporary workaround while solving commonjs -> esm issues in Node 18 - 20.
+function fromMillis(millis) {
+  return [Math.trunc(millis / 1000), Math.round((millis % 1000) * 1e6)];
+}
 
 function Telemeter(options, tracing) {
   this.queue = [];
@@ -106,7 +110,7 @@ Telemeter.prototype.captureError = function (
       'occurrence.uuid': rollbarUUID, // deprecated
     },
 
-    hrtime.fromMillis(timestamp),
+    fromMillis(timestamp),
   );
 
   return this.capture('error', metadata, level, rollbarUUID, timestamp);
@@ -130,13 +134,13 @@ Telemeter.prototype.captureLog = function (
         'occurrence.type': 'message', // deprecated
         'occurrence.uuid': rollbarUUID, // deprecated
       },
-      hrtime.fromMillis(timestamp),
+      fromMillis(timestamp),
     );
   } else {
     this.telemetrySpan?.addEvent(
       'log-event',
       {message, level},
-      hrtime.fromMillis(timestamp),
+      fromMillis(timestamp),
     );
   }
 
@@ -198,7 +202,7 @@ Telemeter.prototype.captureNavigation = function (from, to, rollbarUUID, timesta
   this.telemetrySpan?.addEvent(
     'session-navigation-event',
     {'previous.url.full': from, 'url.full': to},
-    hrtime.fromMillis(timestamp),
+    fromMillis(timestamp),
   );
 
   return this.capture(


### PR DESCRIPTION
## Description of the change

Initial support for 'timeline events', sending telemetry events in an otel span.

The 'rollbar-telemetry' span is ended and a new one started whenever an occurrence is sent. This ensures a span is available to send when a replay is sent.

Note:
I considered adding the events in `Telemeter.prototype.capture`, but it seems there is enough differentiation in the event types that it's better to do it in the path for each event type.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

