### PR TITLE
Add `rollbar.replay.id` attribute to telemetry span

### DIFF
--- a/src/browser/replay/replayMap.js
+++ b/src/browser/replay/replayMap.js
@@ -71,8 +71,8 @@ export default class ReplayMap {
    *
    * @returns {string} A unique identifier for this replay
    */
-  add(occurrenceUuid) {
-    const replayId = id.gen(8);
+  add(replayId, occurrenceUuid) {
+    replayId = replayId || id.gen(8);
 
     this._processReplay(replayId, occurrenceUuid).catch((error) => {
       console.error('Failed to process replay:', error);

--- a/src/queue.js
+++ b/src/queue.js
@@ -103,8 +103,8 @@ Queue.prototype.addItem = function (
   }
 
   if (this.replayMap && item.body) {
-    const replayId = this.replayMap.add(item.uuid);
-    item.replayId = replayId;
+    const replayId = _.getItemAttribute(item, 'replay_id');
+    item.replayId = this.replayMap.add(replayId, item.uuid);
   }
 
   this.pendingRequests.push(item);

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -3,6 +3,7 @@ import { Session } from './session.js';
 import { SpanExporter } from './exporter.js';
 import { SpanProcessor } from './spanProcessor.js';
 import { Tracer } from './tracer.js';
+import id from './id.js';
 
 const SPAN_KEY = createContextKey('Rollbar Context Key SPAN');
 
@@ -43,6 +44,10 @@ export default class Tracing {
       name: 'rollbar-browser-js',
       version: this.options.version,
     };
+  }
+
+  idGen(bytes = 16) {
+    return id.gen(bytes);
   }
 
   createTracer() {

--- a/src/utility.js
+++ b/src/utility.js
@@ -643,11 +643,24 @@ function createTelemetryEvent(args) {
   return event;
 }
 
-function addItemAttributes(item, attributes) {
-  item.data.attributes = item.data.attributes || [];
-  if (attributes) {
-    item.data.attributes.push(...attributes);
+function addItemAttributes(itemData, attributes) {
+  itemData.attributes = itemData.attributes || [];
+  for (const a of attributes) {
+    if (a.value === undefined) {
+      continue;
+    }
+    itemData.attributes.push(a);
   }
+}
+
+function getItemAttribute(itemData, key) {
+  const attributes = itemData.attributes || [];
+  for (let i = 0; i < attributes.length; ++i) {
+    if (attributes[i].key === key) {
+      return attributes[i].value;
+    }
+  }
+  return undefined;
 }
 
 /*
@@ -804,6 +817,7 @@ module.exports = {
   addErrorContext: addErrorContext,
   createTelemetryEvent: createTelemetryEvent,
   addItemAttributes: addItemAttributes,
+  getItemAttribute: getItemAttribute,
   filterIp: filterIp,
   formatArgsAsString: formatArgsAsString,
   formatUrl: formatUrl,

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -897,13 +897,15 @@ describe('log', function () {
 
         expect(body.data.body.trace.exception.message).to.eql('test error');
         expect(body.data.attributes).to.be.an('array');
-        expect(body.data.attributes.length).to.eql(3);
-        expect(body.data.attributes[0].key).to.eql('session_id');
-        expect(body.data.attributes[0].value).to.match(/^[a-f0-9]{32}$/);
-        expect(body.data.attributes[1].key).to.eql('span_id');
-        expect(body.data.attributes[1].value).to.match(/^[a-f0-9]{16}$/);
-        expect(body.data.attributes[2].key).to.eql('trace_id');
-        expect(body.data.attributes[2].value).to.match(/^[a-f0-9]{32}$/);
+        expect(body.data.attributes.length).to.eql(4);
+        expect(body.data.attributes[0].key).to.eql('replay_id');
+        expect(body.data.attributes[0].value).to.match(/^[a-f0-9]{16}$/);
+        expect(body.data.attributes[1].key).to.eql('session_id');
+        expect(body.data.attributes[1].value).to.match(/^[a-f0-9]{32}$/);
+        expect(body.data.attributes[2].key).to.eql('span_id');
+        expect(body.data.attributes[2].value).to.match(/^[a-f0-9]{16}$/);
+        expect(body.data.attributes[3].key).to.eql('trace_id');
+        expect(body.data.attributes[3].value).to.match(/^[a-f0-9]{32}$/);
 
         done();
       } catch (e) {

--- a/test/replay/unit/replayMap.test.js
+++ b/test/replay/unit/replayMap.test.js
@@ -139,6 +139,20 @@ describe('ReplayMap', function () {
   });
 
   describe('add', function () {
+    it('should use provided replayId and initiate async processing', function () {
+      const replayId = '1122334455667788';
+      const uuid = '12345678-1234-5678-1234-1234567890ab';
+      const processStub = sinon
+        .stub(replayMap, '_processReplay')
+        .resolves('1234567890abcdef');
+
+      const resp = replayMap.add(replayId, uuid);
+
+      expect(resp).to.equal(replayId);
+      expect(id.gen.calledWith(8)).to.be.false;
+      expect(processStub.calledWith(replayId, uuid)).to.be.true;
+    });
+
     it('should generate a replayId and initiate async processing', function () {
       const processStub = sinon
         .stub(replayMap, '_processReplay')

--- a/test/tracing/tracing.test.js
+++ b/test/tracing/tracing.test.js
@@ -91,4 +91,15 @@ describe('Tracing()', function () {
 
     done();
   });
+
+  it('should generate ids', function (done) {
+    const options = tracingOptions();
+    const t = new Tracing(window, options);
+
+    const replayId = t.idGen(8);
+
+    expect(replayId).to.match(/^[a-f0-9]{16}$/);
+
+    done();
+  });
 });

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -924,3 +924,36 @@ describe('formatArgsAsString', function () {
   });
   */
 });
+
+describe('addItemAttributes', function () {
+  it('should skip undefined values', function () {
+    const item = { data: {} };
+    const attributes = [
+      {key: 'replay_id', value: '12345'},
+      {key: 'session_id', value: undefined},
+    ];
+    _.addItemAttributes(item.data, attributes);
+    expect(item.data.attributes).to.be.an('array');
+    expect(item.data.attributes.length).to.equal(1);
+    expect(item.data.attributes[0].key).to.equal('replay_id');
+    expect(item.data.attributes[0].value).to.equal('12345');
+  });
+});
+
+describe('getItemAttribute', function () {
+  it('should skip undefined values', function () {
+    const item = {
+      data: {
+        attributes: [
+          {key: 'replay_id', value: '12345'},
+          {key: 'session_id', value: '67890'},
+        ]
+      }
+    };
+    let value = _.getItemAttribute(item.data, 'replay_id');
+    expect(value).to.equal('12345');
+    value = _.getItemAttribute(item.data, 'session_id');
+    expect(value).to.equal('67890');
+  });
+});
+


### PR DESCRIPTION
## Description of the change

Adds the replay_id to the telemetry span. This may not be a long term solution, but is what the back end currently expects.

In this PR:
* Allow the replayMap to optionally accept an existing replayId.
* Add a `genId` convenience method to Tracing.
* Add `rollbar.replay.id` to the telemetry span.

## Type of change

- [x] New feature (non-breaking change that adds functionality)


