### PR TITLE
Clean up replay recording logging and handle rrweb errors

### DIFF
--- a/src/browser/replay/defaults.js
+++ b/src/browser/replay/defaults.js
@@ -6,6 +6,7 @@ export default {
   enabled: false, // Whether recording is enabled
   autoStart: true, // Start recording automatically when Rollbar initializes
   debug: {
+    logErrors: true, // Whether to log errors emitted by rrweb.
     logEmits: false, // Whether to log emitted events
   },
 


### PR DESCRIPTION
## Description of the change

This PR cleans up leftover debugging console logs for both the session replay recorder and replayMap.

This PR also adds an error handler for rrweb to swallow rrweb's errors and optionally log them.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

[PRO-698/internal-errors-for-rrweb](https://linear.app/rollbar-inc/issue/PRO-698/internal-errors-for-rrweb)
