### PR TITLE
Record replay enabled by default

### DIFF
--- a/src/browser/replay/defaults.js
+++ b/src/browser/replay/defaults.js
@@ -3,7 +3,7 @@
  * See https://github.com/rrweb-io/rrweb/blob/master/guide.md#options for details
  */
 export default {
-  enabled: false, // Whether recording is enabled
+  enabled: true, // Whether recording is enabled
   autoStart: true, // Start recording automatically when Rollbar initializes
   debug: {
     logEmits: false, // Whether to log emitted events


### PR DESCRIPTION
## Description of the change

This PR enables replay recording by default as per the DoD of the related ticket.

## Related issues

[PRO-533/story-enable-session-recording-via-sdk](https://linear.app/rollbar-inc/issue/PRO-533/story-enable-session-recording-via-sdk)
