### PR TITLE
Migrate cjs to esm: utility, core, general, platform and browser tests

### DIFF
--- a/test/api.test.js
+++ b/test/api.test.js
@@ -3,8 +3,8 @@
 /* globals it */
 /* globals sinon */
 
-var API = require('../src/api');
-var utility = require('../src/utility');
+import API from '../src/api.js';
+import utility from '../src/utility.js';
 utility.setupJSON();
 
 function TestTransportGenerator() {
@@ -143,7 +143,7 @@ describe('postSpans', function () {
   });
 
   it('should call post on the transport object', async function () {
-    const urllib = require('../src/browser/url');
+    const urllib = await import('../src/browser/url.js');
     const response = 'yes';
     const url = {
       parse: function (e) {

--- a/test/apiUtility.test.js
+++ b/test/apiUtility.test.js
@@ -3,8 +3,8 @@
 /* globals it */
 /* globals sinon */
 
-var u = require('../src/apiUtility');
-var utility = require('../src/utility');
+import u from '../src/apiUtility.js';
+import utility from '../src/utility.js';
 utility.setupJSON();
 
 describe('buildPayload', function () {

--- a/test/browser.core.test.js
+++ b/test/browser.core.test.js
@@ -4,7 +4,7 @@
 /* globals sinon */
 
 // Use minimal browser package, with no optional components added.
-var Rollbar = require('../src/browser/core');
+import Rollbar from '../src/browser/core.js';
 
 describe('options.captureUncaught', function () {
   beforeEach(function (done) {

--- a/test/browser.domUtility.test.js
+++ b/test/browser.domUtility.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 /* globals sinon */
 
-var d = require('../src/browser/domUtility');
+import * as d from '../src/browser/domUtility.js';
 
 function fullElement() {
   return {

--- a/test/browser.predicates.test.js
+++ b/test/browser.predicates.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 /* globals sinon */
 
-var p = require('../src/browser/predicates');
+import * as p from '../src/browser/predicates.js';
 
 describe('checkIgnore', function () {
   it('should return false if is ajax and ignoring ajax errors is on', function () {

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 /* globals sinon */
 
-var Rollbar = require('../src/browser/rollbar');
+import Rollbar from '../src/browser/rollbar.js';
 
 const DUMMY_TRACE_ID = 'some-trace-id';
 const DUMMY_SPAN_ID = 'some-span-id';

--- a/test/browser.telemetry.test.js
+++ b/test/browser.telemetry.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 /* globals sinon */
 
-var Instrumenter = require('../src/browser/telemetry');
+import Instrumenter from '../src/browser/telemetry.js';
 
 describe('instrumentNetwork', function () {
   it('should capture XHR requests with string URL', function (done) {

--- a/test/browser.transport.test.js
+++ b/test/browser.transport.test.js
@@ -3,10 +3,10 @@
 /* globals it */
 /* globals sinon */
 
-var truncation = require('../src/truncation');
-var Transport = require('../src/browser/transport');
-var t = new Transport(truncation);
-var utility = require('../src/utility');
+import truncation from '../src/truncation.js';
+import Transport from '../src/browser/transport.js';
+const t = new Transport(truncation);
+import * as utility from '../src/utility.js';
 utility.setupJSON();
 
 describe('post', function () {

--- a/test/browser.url.test.js
+++ b/test/browser.url.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 /* globals sinon */
 
-var url = require('../src/browser/url');
+import * as url from '../src/browser/url.js';
 
 describe('parse', function () {
   it('should return an object full of nulls for a blank url', function () {

--- a/test/examples/angular.test.js
+++ b/test/examples/angular.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 
 // Import Rollbar directly from the source
-var Rollbar = require('../../dist/rollbar.umd.js');
+import Rollbar from '../../dist/rollbar.umd.js';
 
 describe('Angular integration', function () {
   // Utility function to create a test-enabled Rollbar instance

--- a/test/notifier.test.js
+++ b/test/notifier.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 /* globals sinon */
 
-var Notifier = require('../src/notifier');
+import Notifier from '../src/notifier.js';
 
 var rollbarConfig = {
   accessToken: '12c99de67a444c229fca100e0967486f',

--- a/test/predicates.test.js
+++ b/test/predicates.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 /* globals sinon */
 
-var p = require('../src/predicates');
+import p from '../src/predicates.js';
 var logger = {
   log: function () {},
   error: function () {},

--- a/test/queue.test.js
+++ b/test/queue.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 /* globals sinon */
 
-var Queue = require('../src/queue');
+import Queue from '../src/queue.js';
 
 function TestRateLimiterGenerator() {
   var TestRateLimiter = function () {

--- a/test/rateLimiter.test.js
+++ b/test/rateLimiter.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 /* globals sinon */
 
-var RateLimiter = require('../src/rateLimiter');
+import RateLimiter from '../src/rateLimiter.js';
 
 describe('RateLimiter()', function () {
   it('should have all of the expected methods', function (done) {

--- a/test/react-native.rollbar.test.js
+++ b/test/react-native.rollbar.test.js
@@ -3,7 +3,7 @@
 /* globals it */
 /* globals sinon */
 
-var Rollbar = require('../src/react-native/rollbar');
+import Rollbar from '../src/react-native/rollbar.js';
 var rollbarConfig = {
   accessToken: 'POST_CLIENT_ITEM_TOKEN',
   captureUncaught: true,

--- a/test/react-native.transforms.test.js
+++ b/test/react-native.transforms.test.js
@@ -3,8 +3,8 @@
 /* globals it */
 /* globals sinon */
 
-var Rollbar = require('../src/react-native/rollbar');
-var t = require('../src/react-native/transforms');
+import Rollbar from '../src/react-native/rollbar.js';
+import t from '../src/react-native/transforms.js';
 
 function TestClientGen() {
   var TestClient = function () {

--- a/test/react-native.transport.test.js
+++ b/test/react-native.transport.test.js
@@ -3,10 +3,10 @@
 /* globals it */
 /* globals sinon */
 
-var truncation = require('../src/truncation');
-var Transport = require('../src/react-native/transport');
+import truncation from '../src/truncation.js';
+import Transport from '../src/react-native/transport.js';
 var t = new Transport(truncation);
-var utility = require('../src/utility');
+import utility from '../src/utility.js';
 utility.setupJSON();
 
 describe('post', function () {

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -3,8 +3,8 @@
 /* globals it */
 /* globals sinon */
 
-const Telemeter = require('../src/telemetry');
-const Tracing = require('../src/tracing/tracing').default;
+import Telemeter from '../src/telemetry.js';
+import Tracing from '../src/tracing/tracing.js';
 
 describe('Telemetry()', function () {
   it('should have all of the expected methods', function (done) {

--- a/test/transforms.test.js
+++ b/test/transforms.test.js
@@ -2,8 +2,8 @@
 /* globals describe */
 /* globals it */
 
-var _ = require('../src/utility');
-var t = require('../src/transforms');
+import _ from '../src/utility.js';
+import t from '../src/transforms.js';
 
 function itemFromArgs(args) {
   var item = _.createItem(args);

--- a/test/truncation.test.js
+++ b/test/truncation.test.js
@@ -2,8 +2,8 @@
 /* globals describe */
 /* globals it */
 
-var t = require('../src/truncation');
-var utility = require('../src/utility');
+import t from '../src/truncation.js';
+import utility from '../src/utility.js';
 utility.setupJSON();
 
 describe('truncate', function () {

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -3,9 +3,9 @@
 /* globals it */
 /* globals sinon */
 
-var _ = require('../src/utility');
-var utility = require('../src/utility');
-var polyfillJSON = require('../vendor/JSON-js/json3');
+import _ from '../src/utility.js';
+import utility from '../src/utility.js';
+import polyfillJSON from '../vendor/JSON-js/json3.js';
 
 utility.setupJSON();
 
@@ -448,7 +448,7 @@ describe('merge', function () {
   });
 });
 
-var traverse = require('../src/utility/traverse');
+import traverse from '../src/utility/traverse.js';
 describe('traverse', function () {
   describe('should call the func for every key,value', function () {
     it('simple object', function (done) {
@@ -618,7 +618,13 @@ describe('addParamsAndAccessTokenToPath', function () {
 });
 
 describe('json3', function () {
-  var setupCustomJSON = require('../vendor/JSON-js/json3.js');
+  let setupCustomJSON;
+
+  before(async function () {
+    const module = await import('../vendor/JSON-js/json3.js');
+    setupCustomJSON = module.default;
+  });
+
   it('should replace stringify if not there', function () {
     var j = {};
     setupCustomJSON(j);
@@ -767,7 +773,7 @@ describe('set', function () {
   });
 });
 
-var scrub = require('../src/scrub');
+import scrub from '../src/scrub.js';
 describe('scrub', function () {
   it('should not redact fields that are okay', function () {
     var data = {
@@ -929,8 +935,8 @@ describe('addItemAttributes', function () {
   it('should skip undefined values', function () {
     const item = { data: {} };
     const attributes = [
-      {key: 'replay_id', value: '12345'},
-      {key: 'session_id', value: undefined},
+      { key: 'replay_id', value: '12345' },
+      { key: 'session_id', value: undefined },
     ];
     _.addItemAttributes(item.data, attributes);
     expect(item.data.attributes).to.be.an('array');
@@ -945,10 +951,10 @@ describe('getItemAttribute', function () {
     const item = {
       data: {
         attributes: [
-          {key: 'replay_id', value: '12345'},
-          {key: 'session_id', value: '67890'},
-        ]
-      }
+          { key: 'replay_id', value: '12345' },
+          { key: 'session_id', value: '67890' },
+        ],
+      },
     };
     let value = _.getItemAttribute(item.data, 'replay_id');
     expect(value).to.equal('12345');
@@ -956,4 +962,3 @@ describe('getItemAttribute', function () {
     expect(value).to.equal('67890');
   });
 });
-


### PR DESCRIPTION
## Description of the change

This PR migrates all test files from CommonJS to ES modules—except for Vows-related server tests—by replacing require() calls with import statements, appending .js extensions, and updating async patterns where needed.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

[SDK-489/partial-test-migration-to-es-modules](https://linear.app/rollbar-inc/issue/SDK-489/partial-test-migration-to-es-modules)
