### PR TITLE
Run server mocha tests directly instead of using grunt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,4 +48,4 @@ jobs:
           eslint_extensions: js
 
       - name: Run tests
-        run: npm run test_ci
+        run: npm run test-ci

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -113,7 +113,6 @@ module.exports = function (grunt) {
   grunt.loadNpmTasks('grunt-webpack');
   grunt.loadNpmTasks('grunt-text-replace');
   grunt.loadNpmTasks('grunt-vows');
-  grunt.loadNpmTasks('grunt-mocha-test');
 
   var rollbarJsSnippet = fs.readFileSync('dist/rollbar.snippet.js');
   var rollbarjQuerySnippet = fs.readFileSync('dist/plugins/jquery.min.js');
@@ -127,16 +126,6 @@ module.exports = function (grunt) {
           reporter: 'spec',
         },
         src: ['test/server.*.test.js', '!test/server.*.mocha.test.js'],
-      },
-    },
-
-    mochaTest: {
-      server: {
-        options: {
-          reporter: 'spec',
-          grep: grunt.option('grep'),
-        },
-        src: ['test/server.*.mocha.test.js'],
       },
     },
 
@@ -194,18 +183,12 @@ module.exports = function (grunt) {
   grunt.registerTask('default', ['build']);
   grunt.registerTask('test', [
     'test-server',
-    'test-server-mocha',
     'test-browser',
   ]);
   grunt.registerTask('release', ['build', 'copyrelease']);
 
   grunt.registerTask('test-server', function (_target) {
-    var tasks = ['vows', 'mochaTest:server'];
-    grunt.task.run.apply(grunt.task, tasks);
-  });
-
-  grunt.registerTask('test-server-mocha', function (_target) {
-    var tasks = ['mochaTest:server'];
+    var tasks = ['vows'];
     grunt.task.run.apply(grunt.task, tasks);
   });
 

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ test-server:
 	@npm run test-server
 	@echo ""
 
-test_ci:
-	@npm run test_ci
+test-ci:
+	@npm run test-ci
 	@echo ""
 
-.PHONY: test test_ci
+.PHONY: test test-ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -41,7 +41,6 @@
         "grunt-contrib-uglify": "^4.0.0",
         "grunt-contrib-watch": "^1.1.0",
         "grunt-karma": "^4.0.2",
-        "grunt-mocha-test": "^0.13.3",
         "grunt-parallel": "^0.5.1",
         "grunt-text-replace": "^0.4.0",
         "grunt-vows": "^0.4.2",
@@ -5540,23 +5539,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/grunt-mocha-test": {
-      "version": "0.13.3",
-      "resolved": "https://registry.npmjs.org/grunt-mocha-test/-/grunt-mocha-test-0.13.3.tgz",
-      "integrity": "sha512-zQGEsi3d+ViPPi7/4jcj78afKKAKiAA5n61pknQYi25Ugik+aNOuRmiOkmb8mN2CeG8YxT+YdT1H1Q7B/eNkoQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hooker": "^0.2.3",
-        "mkdirp": "^0.5.0"
-      },
-      "engines": {
-        "node": ">= 0.10.4"
-      },
-      "peerDependencies": {
-        "mocha": ">=1.20.0"
       }
     },
     "node_modules/grunt-parallel": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "grunt-contrib-uglify": "^4.0.0",
     "grunt-contrib-watch": "^1.1.0",
     "grunt-karma": "^4.0.2",
-    "grunt-mocha-test": "^0.13.3",
     "grunt-parallel": "^0.5.1",
     "grunt-text-replace": "^0.4.0",
     "grunt-vows": "^0.4.2",
@@ -90,11 +89,11 @@
     "test": "./node_modules/.bin/grunt test",
     "test-browser": "./node_modules/.bin/grunt test-browser",
     "test-server": "./node_modules/.bin/grunt test-server",
-    "test-server-mocha": "./node_modules/.bin/grunt test-server-mocha",
+    "test-server-mocha": "mocha 'test/server.*.mocha.test.mjs' --reporter spec",
     "test-replay": "./node_modules/.bin/grunt test-replay",
     "test-replay-unit": "./node_modules/.bin/grunt test-replay-unit",
     "test-replay-integration": "./node_modules/.bin/grunt test-replay-integration",
-    "test_ci": "./node_modules/.bin/grunt test",
+    "test-ci": "./node_modules/.bin/grunt test && npm run test-server-mocha",
     "lint": "./node_modules/.bin/eslint ."
   },
   "cdn": {


### PR DESCRIPTION
## Description of the change

This PR ditches Grunt in favor of running the server tests using mocha directly. The problem is that, like Grunt itself, the plugin required to run mocha tests is also old and obsolete (2017) and doesn't support ESM.

Running the tests directly using mocha fixes the issue.

I also renamed the `test_ci` script to `test-ci` because it was driving me crazy.

## Related issues

[SDK-490/migrate-vowsjs-to-mocha](https://linear.app/rollbar-inc/issue/SDK-490/migrate-vowsjs-to-mocha)
[SDK-491/complete-server-test-es-module-migration](https://linear.app/rollbar-inc/issue/SDK-491/complete-server-test-es-module-migration)