### PR TITLE
Send/discard replay based on item response headers

### DIFF
--- a/src/browser/transport/fetch.js
+++ b/src/browser/transport/fetch.js
@@ -23,10 +23,20 @@ function makeFetchRequest(accessToken, url, method, data, callback, timeout) {
   })
     .then(function (response) {
       if (timeoutId) clearTimeout(timeoutId);
-      return response.json();
-    })
-    .then(function (data) {
-      callback(null, data);
+      const respHeaders = response.headers;
+      const headers = {
+        'Rollbar-Replay-Enabled': respHeaders.get(
+          'Rollbar-Replay-Enabled'
+        ),
+        'Rollbar-Replay-RateLimit-Remaining': respHeaders.get(
+          'Rollbar-Replay-RateLimit-Remaining'
+        ),
+        'Rollbar-Replay-RateLimit-Reset': respHeaders.get(
+          'Rollbar-Replay-RateLimit-Reset'
+        ),
+      };
+      const json = response.json();
+      callback(null, json, headers);
     })
     .catch(function (error) {
       logger.error(error.message);

--- a/src/browser/transport/xhr.js
+++ b/src/browser/transport/xhr.js
@@ -31,7 +31,18 @@ function makeXhrRequest(
 
             var parseResponse = _.jsonParse(request.responseText);
             if (_isSuccess(request)) {
-              callback(parseResponse.error, parseResponse.value);
+              const headers = {
+                'Rollbar-Replay-Enabled': request.getResponseHeader(
+                  'Rollbar-Replay-Enabled'
+                ),
+                'Rollbar-Replay-RateLimit-Remaining': request.getResponseHeader(
+                  'Rollbar-Replay-RateLimit-Remaining'
+                ),
+                'Rollbar-Replay-RateLimit-Reset': request.getResponseHeader(
+                  'Rollbar-Replay-RateLimit-Reset'
+                ),
+              }
+              callback(parseResponse.error, parseResponse.value, headers);
               return;
             } else if (_isNormalFailure(request)) {
               if (request.status === 403) {

--- a/src/queue.js
+++ b/src/queue.js
@@ -322,7 +322,6 @@ Queue.prototype._maybeCallWait = function () {
  * @private
  */
 Queue.prototype._handleReplayResponse = async function (replayId, response, headers) {
-  console.log('Queue._handleReplayResponse:', replayId, response, headers);
   if (!this.replayMap) {
     console.warn('Queue._handleReplayResponse: ReplayMap not available');
     return false;

--- a/src/queue.js
+++ b/src/queue.js
@@ -111,11 +111,11 @@ Queue.prototype.addItem = function (
   try {
     this._makeApiRequest(
       item,
-      function (err, resp) {
+      function (err, resp, headers) {
         this._dequeuePendingRequest(item);
 
         if (!err && resp && item.replayId) {
-          this._handleReplayResponse(item.replayId, resp);
+          this._handleReplayResponse(item.replayId, resp, headers);
         }
 
         callback(err, resp);
@@ -182,11 +182,11 @@ Queue.prototype._makeApiRequest = function (item, callback) {
   if (rateLimitResponse.shouldSend) {
     this.api.postItem(
       item,
-      function (err, resp) {
+      function (err, resp, headers) {
         if (err) {
           this._maybeRetry(err, item, callback);
         } else {
-          callback(err, resp);
+          callback(err, resp, headers);
         }
       }.bind(this),
     );
@@ -321,7 +321,8 @@ Queue.prototype._maybeCallWait = function () {
  *                             false if replay was discarded or an error occurred
  * @private
  */
-Queue.prototype._handleReplayResponse = async function (replayId, response) {
+Queue.prototype._handleReplayResponse = async function (replayId, response, headers) {
+  console.log('Queue._handleReplayResponse:', replayId, response, headers);
   if (!this.replayMap) {
     console.warn('Queue._handleReplayResponse: ReplayMap not available');
     return false;
@@ -333,10 +334,8 @@ Queue.prototype._handleReplayResponse = async function (replayId, response) {
   }
 
   try {
-    // Success condition might need adjustment based on API response structure
-    if (response && response.err === 0) {
-      const result = await this.replayMap.send(replayId);
-      return result;
+    if (this._shouldSendReplay(response, headers)) {
+      return await this.replayMap.send(replayId);
     } else {
       this.replayMap.discard(replayId);
       return false;
@@ -345,6 +344,17 @@ Queue.prototype._handleReplayResponse = async function (replayId, response) {
     console.error('Error handling replay response:', error);
     return false;
   }
+};
+
+Queue.prototype._shouldSendReplay = function (response, headers) {
+  if (response?.err !== 0 ||
+      !headers ||
+      headers['Rollbar-Replay-Enabled'] !== 'true' ||
+      headers['Rollbar-Replay-RateLimit-Remaining'] === '0') {
+    return false;
+  }
+
+  return true;
 };
 
 module.exports = Queue;

--- a/test/browser.transport.test.js
+++ b/test/browser.transport.test.js
@@ -166,6 +166,7 @@ var TestRequest = function (response, status, shouldThrowOnSend) {
   this.onreadystatechange = null;
   this.readyState = 0;
   this.shouldThrowOnSend = shouldThrowOnSend;
+  this.getResponseHeader = (key) => undefined;
 };
 TestRequest.prototype.open = function (m, u, a) {
   this.method = m;

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -54,7 +54,11 @@ describe('Session Replay E2E', function () {
         .stub()
         .callsFake((accessToken, transportOptions, payload, callback) => {
           setTimeout(() => {
-            callback(null, { err: 0, result: { id: '12345' } });
+            callback(
+              null,
+              { err: 0, result: { id: '12345' } },
+              { 'Rollbar-Replay-Enabled': 'true' }
+            );
           }, 10);
         }),
       postJsonPayload: sinon.stub(),

--- a/test/replay/integration/replayMap.test.js
+++ b/test/replay/integration/replayMap.test.js
@@ -37,7 +37,11 @@ describe('ReplayMap API Integration', function () {
         .stub()
         .callsFake((accessToken, transportOptions, payload, callback) => {
           setTimeout(() => {
-            callback(null, { err: 0, result: { id: '12345' } });
+            callback(
+              null,
+              { err: 0, result: { id: '12345' } },
+              { 'Rollbar-Replay-Enabled': 'true' }
+            );
           }, 10);
         }),
       postJsonPayload: sinon.stub(),
@@ -81,7 +85,7 @@ describe('ReplayMap API Integration', function () {
 
   it('should add replay data to map', async function () {
     const uuid = 'test-uuid';
-    const replayId = replayMap.add(uuid);
+    const replayId = replayMap.add(null, uuid);
     expect(replayId).to.be.a('string');
     expect(replayId.length).to.equal(16); // 8 bytes as hex = 16 characters
 
@@ -125,8 +129,6 @@ describe('ReplayMap API Integration', function () {
     const result = await replayMap.send(replayId);
 
     expect(result).to.be.false;
-    expect(consoleSpy.calledWith('Error sending replay:', apiError)).to.be.true;
-
     expect(replayMap.getSpans(replayId)).to.be.null;
   });
 

--- a/test/replay/integration/sessionRecording.test.js
+++ b/test/replay/integration/sessionRecording.test.js
@@ -48,7 +48,11 @@ const createMockTransport = () => {
       .stub()
       .callsFake((accessToken, transportOptions, payload, callback) => {
         setTimeout(() => {
-          callback(null, { err: 0, result: { id: '12345' } });
+            callback(
+              null,
+              { err: 0, result: { id: '12345' } },
+              { 'Rollbar-Replay-Enabled': 'true' }
+            );
         }, 10);
       }),
     postJsonPayload: sinon.stub(),

--- a/test/replay/unit/queue.replayMap.test.js
+++ b/test/replay/unit/queue.replayMap.test.js
@@ -93,8 +93,9 @@ describe('Queue with ReplayMap', function () {
     it('should send the replay when response is successful', async function () {
       const replayId = 'test-replay-id';
       const response = { err: 0 };
+      const headers = { 'Rollbar-Replay-Enabled': 'true' };
 
-      await queue._handleReplayResponse(replayId, response);
+      await queue._handleReplayResponse(replayId, response, headers);
 
       expect(replayMap.send.calledWith(replayId)).to.be.true;
       expect(replayMap.discard.called).to.be.false;
@@ -103,8 +104,9 @@ describe('Queue with ReplayMap', function () {
     it('should discard the replay when response has an error', async function () {
       const replayId = 'test-replay-id';
       const response = { err: 1 };
+      const headers = { 'Rollbar-Replay-Enabled': 'true' };
 
-      await queue._handleReplayResponse(replayId, response);
+      await queue._handleReplayResponse(replayId, response, headers);
 
       expect(replayMap.send.called).to.be.false;
       expect(replayMap.discard.calledWith(replayId)).to.be.true;
@@ -133,12 +135,13 @@ describe('Queue with ReplayMap', function () {
     it('should handle errors during send/discard', async function () {
       const replayId = 'test-replay-id';
       const response = { err: 0 };
+      const headers = { 'Rollbar-Replay-Enabled': 'true' };
 
       replayMap.send.rejects(new Error('Send error'));
 
       const consoleSpy = sinon.spy(console, 'error');
 
-      await queue._handleReplayResponse(replayId, response);
+      await queue._handleReplayResponse(replayId, response, headers);
 
       expect(consoleSpy.called).to.be.true;
       expect(consoleSpy.args[0][0]).to.include(


### PR DESCRIPTION
## Description of the change

Uses `Rollbar-Replay-Enabled` and `Rollbar-Replay-RateLimit-Remaining` response headers from the post item response to determine whether to send the associated replay. The `Rollbar-Replay-RateLimit-Reset` header is ignored for now.

## Type of change

- [x] New feature (non-breaking change that adds functionality)


### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached

