### PR TITLE
Migrate server locals tests to mocha

### DIFF
--- a/test/server.lambda.mocha.test.mjs
+++ b/test/server.lambda.mocha.test.mjs
@@ -27,15 +27,11 @@ function promisePending(promise, callback) {
 
 function fakePostItem(_item, callback) {
   // 1000ms simulates low API response, and allows testing the state before completion.
-  setTimeout(function () {
-    callback();
-  }, 1000);
+  setTimeout(callback, 1000);
 }
 
 const stubContext = {
-  getRemainingTimeInMillis: function () {
-    return 2000;
-  },
+  getRemainingTimeInMillis: () => 2000,
 };
 
 describe('lambda', function () {

--- a/test/server.locals.constructor.mocha.test.mjs
+++ b/test/server.locals.constructor.mocha.test.mjs
@@ -1,0 +1,80 @@
+/* globals describe */
+/* globals it */
+
+import { expect } from 'chai';
+import Locals from '../src/server/locals.js';
+import logger from '../src/server/logger.js';
+
+describe('server.locals constructor', function () {
+  it('should use defaults when passing true boolean', function () {
+    const locals = new Locals(true, logger);
+    expect(locals.options.enabled).to.be.true;
+    expect(locals.options.uncaughtOnly).to.be.true;
+    expect(locals.options.depth).to.equal(1);
+    expect(locals.options.maxProperties).to.equal(30);
+    expect(locals.options.maxArray).to.equal(5);
+  });
+
+  it('should use defaults when passing false boolean', function () {
+    const locals = new Locals(false, logger);
+    expect(locals.options.enabled).to.be.true;
+    expect(locals.options.uncaughtOnly).to.be.true;
+    expect(locals.options.depth).to.equal(1);
+    expect(locals.options.maxProperties).to.equal(30);
+    expect(locals.options.maxArray).to.equal(5);
+  });
+
+  it('should use defaults when passing empty object', function () {
+    const locals = new Locals({}, logger);
+    expect(locals.options.enabled).to.be.true;
+    expect(locals.options.uncaughtOnly).to.be.true;
+    expect(locals.options.depth).to.equal(1);
+    expect(locals.options.maxProperties).to.equal(30);
+    expect(locals.options.maxArray).to.equal(5);
+  });
+
+  it('should use updated depth with remaining defaults', function () {
+    const locals = new Locals({ depth: 0 }, logger);
+    expect(locals.options.enabled).to.be.true;
+    expect(locals.options.uncaughtOnly).to.be.true;
+    expect(locals.options.depth).to.equal(0);
+    expect(locals.options.maxProperties).to.equal(30);
+    expect(locals.options.maxArray).to.equal(5);
+  });
+
+  it('should use updated enabled with remaining defaults', function () {
+    const locals = new Locals({ enabled: false }, logger);
+    expect(locals.options.enabled).to.be.false;
+    expect(locals.options.uncaughtOnly).to.be.true;
+    expect(locals.options.depth).to.equal(1);
+    expect(locals.options.maxProperties).to.equal(30);
+    expect(locals.options.maxArray).to.equal(5);
+  });
+
+  it('should use updated uncaughtOnly with remaining defaults', function () {
+    const locals = new Locals({ uncaughtOnly: false }, logger);
+    expect(locals.options.enabled).to.be.true;
+    expect(locals.options.uncaughtOnly).to.be.false;
+    expect(locals.options.depth).to.equal(1);
+    expect(locals.options.maxProperties).to.equal(30);
+    expect(locals.options.maxArray).to.equal(5);
+  });
+
+  it('should use all updated options', function () {
+    const locals = new Locals(
+      {
+        enabled: false,
+        uncaughtOnly: false,
+        depth: 2,
+        maxProperties: 15,
+        maxArray: 10,
+      },
+      logger,
+    );
+    expect(locals.options.enabled).to.be.false;
+    expect(locals.options.uncaughtOnly).to.be.false;
+    expect(locals.options.depth).to.equal(2);
+    expect(locals.options.maxProperties).to.equal(15);
+    expect(locals.options.maxArray).to.equal(10);
+  });
+});

--- a/test/server.locals.error-handling.mocha.test.mjs
+++ b/test/server.locals.error-handling.mocha.test.mjs
@@ -1,0 +1,387 @@
+/* globals describe */
+/* globals it */
+/* globals beforeEach */
+/* globals afterEach */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Rollbar from '../src/server/rollbar.js';
+import Locals from '../src/server/locals.js';
+import {
+  nodeMajorVersion,
+  nodeThrow,
+  nodeThrowNested,
+  nodeThrowAndCatch,
+  promiseReject,
+  nodeThrowWithNestedLocals,
+  nodeThrowRecursionError,
+  verifyRejectedPromise,
+} from './server.locals.test-utils.mjs';
+
+describe('server.locals error handling', function () {
+  let mochaExceptionHandlers;
+  let mochaRejectionHandlers;
+
+  beforeEach(function () {
+    // Remove Mocha's error handlers
+    mochaExceptionHandlers = process.listeners('uncaughtException');
+    mochaExceptionHandlers.forEach((handler) => {
+      process.removeListener('uncaughtException', handler);
+    });
+
+    mochaRejectionHandlers = process.listeners('unhandledRejection');
+    mochaRejectionHandlers.forEach((handler) => {
+      process.removeListener('unhandledRejection', handler);
+    });
+  });
+
+  afterEach(function () {
+    // Restore Mocha's error handlers
+    mochaExceptionHandlers.forEach((h) => process.on('uncaughtException', h));
+    mochaRejectionHandlers.forEach((h) => process.on('unhandledRejection', h));
+  });
+
+  describe('with locals enabled', function () {
+    let rollbar;
+    let addItemStub;
+
+    beforeEach(function () {
+      rollbar = new Rollbar({
+        accessToken: 'abc123',
+        captureUncaught: true,
+        captureUnhandledRejections: true,
+        locals: { module: Locals, uncaughtOnly: true, depth: 0 },
+      });
+
+      addItemStub = sinon.stub(rollbar.client.notifier.queue, 'addItem');
+    });
+
+    afterEach(function () {
+      addItemStub.restore();
+    });
+
+    it('should include locals on uncaught error', async function () {
+      await nodeThrow();
+      expect(addItemStub.called).to.be.true;
+
+      const traceChain = addItemStub.getCall(0).args[3].data.body.trace_chain;
+      expect(traceChain[0].exception.message).to.equal('node error');
+
+      let frames = traceChain[0].frames;
+      expect(frames).to.have.length.above(1);
+
+      if (nodeMajorVersion >= 18) {
+        // Node >=18; locals only in top frame
+        expect(frames.at(-1).locals.error).to.equal('<Error object>');
+        expect(frames.at(-2).locals).to.not.exist;
+      } else if (nodeMajorVersion >= 10) {
+        // Node >=10; locals enabled
+        expect(frames.at(-1).locals.error).to.equal('<Error object>');
+        expect(frames.at(-2).locals.timer).to.equal('<Timeout object>');
+      } else {
+        // Node <=8; locals disabled
+        expect(frames.at(-1).locals).to.not.exist;
+        expect(frames.at(-2).locals).to.not.exist;
+      }
+    });
+
+    describe('then disabled', function () {
+      beforeEach(function () {
+        addItemStub?.restore();
+        rollbar.configure({ locals: { enabled: false } });
+        addItemStub = sinon.stub(rollbar.client.notifier.queue, 'addItem');
+      });
+
+      it('should not include locals', async function () {
+        await nodeThrowNested();
+        expect(addItemStub.called).to.be.true;
+
+        const traceChain = addItemStub.getCall(0).args[3].data.body.trace_chain;
+        expect(traceChain[0].exception.message).to.equal('test err');
+        expect(traceChain[1].exception.message).to.equal('nested test err');
+
+        expect(traceChain[0].frames).to.have.length.above(1);
+        expect(traceChain[0].frames.at(-1).locals).to.not.exist;
+        expect(traceChain[0].frames.at(-2).locals).to.not.exist;
+      });
+
+      describe('then re-enabled', function () {
+        beforeEach(function () {
+          addItemStub?.restore();
+          rollbar.configure({ locals: { enabled: true, uncaughtOnly: false } });
+          addItemStub = sinon.stub(rollbar.client.notifier.queue, 'addItem');
+        });
+
+        it('should include locals', async function () {
+          await promiseReject();
+
+          const result = verifyRejectedPromise(addItemStub);
+          expect(result.message).to.equal('promise reject');
+          expect(result.hasLocals).to.be.true;
+          expect(result.locals.topFrame).to.exist;
+        });
+      });
+    });
+  });
+
+  describe('on caught error', function () {
+    describe('with uncaughtOnly: true', function () {
+      let rollbar;
+      let addItemStub;
+
+      beforeEach(function () {
+        rollbar = new Rollbar({
+          accessToken: 'abc123',
+          captureUncaught: true,
+          captureUnhandledRejections: true,
+          locals: { module: Locals, uncaughtOnly: true, depth: 0 },
+        });
+
+        addItemStub = sinon.stub(rollbar.client.notifier.queue, 'addItem');
+      });
+
+      afterEach(function () {
+        addItemStub.restore();
+      });
+
+      it('should not include locals', async function () {
+        await nodeThrowAndCatch(rollbar);
+        expect(addItemStub.called).to.be.true;
+
+        const traceChain = addItemStub.getCall(0).args[3].data.body.trace_chain;
+        expect(traceChain[0].exception.message).to.equal('caught error');
+        expect(traceChain[0].frames).to.have.length.above(1);
+        expect(traceChain[0].frames.at(-1).locals).to.not.exist;
+        expect(traceChain[0].frames.at(-2).locals).to.not.exist;
+      });
+
+      describe('then uncaughtOnly: false', function () {
+        beforeEach(function () {
+          addItemStub?.restore();
+          rollbar.configure({ locals: { uncaughtOnly: false } });
+          addItemStub = sinon.stub(rollbar.client.notifier.queue, 'addItem');
+        });
+
+        it('should include locals', async function () {
+          await nodeThrowAndCatch(rollbar);
+          expect(addItemStub.called).to.be.true;
+
+          const traceChain =
+            addItemStub.getCall(0).args[3].data.body.trace_chain;
+          expect(traceChain[0].exception.message).to.equal('caught error');
+
+          let frames = traceChain[0].frames;
+          expect(frames).to.have.length.above(1);
+
+          if (nodeMajorVersion >= 18) {
+            // Node >=18; locals only in top frame
+            expect(frames.at(-1).locals.error).to.equal('<Error object>');
+            expect(frames.at(-2).locals).to.not.exist;
+          } else if (nodeMajorVersion >= 10) {
+            // Node 10..<18; locals enabled
+            expect(frames.at(-1).locals.error).to.equal('<Error object>');
+            expect(frames.at(-2).locals.timer).to.equal('<Timeout object>');
+          } else {
+            expect(frames.at(-1).locals).to.not.exist;
+            expect(frames.at(-2).locals).to.not.exist;
+          }
+        });
+      });
+    });
+  });
+
+  describe('on nested exception', function () {
+    let rollbar;
+    let addItemStub;
+
+    beforeEach(function () {
+      rollbar = new Rollbar({
+        accessToken: 'abc123',
+        captureUncaught: true,
+        locals: { module: Locals, uncaughtOnly: false, depth: 0 },
+      });
+
+      addItemStub = sinon.stub(rollbar.client.notifier.queue, 'addItem');
+    });
+
+    afterEach(function () {
+      addItemStub.restore();
+    });
+
+    it('should include locals', async function () {
+      await nodeThrowNested();
+      expect(addItemStub.called).to.be.true;
+
+      const traceChain = addItemStub.getCall(0).args[3].data.body.trace_chain;
+      expect(traceChain[0].exception.message).to.equal('test err');
+      expect(traceChain[1].exception.message).to.equal('nested test err');
+
+      let frames;
+
+      if (nodeMajorVersion >= 18) {
+        // Node >=18; locals only in top frame
+        frames = traceChain[0].frames;
+        expect(frames).to.have.length.above(1);
+        expect(frames.at(-1).locals.message).to.equal('test err');
+        expect(frames.at(-1).locals.password).to.equal('********');
+        expect(frames.at(-1).locals.err).to.equal('<Error object>');
+        expect(frames.at(-1).locals.newMessage).to.equal('nested test err');
+        expect(frames.at(-2).locals).to.not.exist;
+
+        frames = traceChain[1].frames;
+        expect(frames).to.have.length.above(1);
+        expect(frames.at(-1).locals.nestedMessage).to.equal('nested test err');
+        expect(frames.at(-1).locals._password).to.equal('123456');
+        expect(frames.at(-1).locals.nestedError).to.equal('<Error object>');
+        expect(frames.at(-2).locals).to.not.exist;
+      } else if (nodeMajorVersion >= 10) {
+        // Node >=10; locals enabled
+        frames = traceChain[0].frames;
+        expect(frames).to.have.length.above(1);
+        expect(frames.at(-1).locals.err).to.equal('<Error object>');
+        expect(frames.at(-2).locals.timer).to.equal('<Timeout object>');
+
+        frames = traceChain[1].frames;
+        expect(frames).to.have.length.above(1);
+        expect(frames.at(-1).locals.nestedMessage).to.equal('nested test err');
+        expect(frames.at(-1).locals.nestedError).to.equal('<Error object>');
+        expect(frames.at(-2).locals.message).to.equal('test err');
+        expect(frames.at(-2).locals.password).to.equal('********');
+        expect(frames.at(-2).locals.err).to.equal('<Error object>');
+        expect(frames.at(-2).locals.newMessage).to.equal('nested test err');
+      } else {
+        // Node <=8; locals disabled
+        frames = traceChain[0].frames;
+        expect(frames).to.have.length.above(1);
+        expect(frames.at(-1).locals).to.not.exist;
+        expect(frames.at(-2).locals).to.not.exist;
+      }
+    });
+  });
+
+  describe('on promise rejection', function () {
+    let rollbar;
+    let addItemStub;
+
+    beforeEach(function () {
+      rollbar = new Rollbar({
+        accessToken: 'abc123',
+        captureUnhandledRejections: true,
+        locals: { module: Locals, uncaughtOnly: false, depth: 0 },
+      });
+
+      addItemStub = sinon.stub(rollbar.client.notifier.queue, 'addItem');
+    });
+
+    afterEach(function () {
+      addItemStub.restore();
+    });
+
+    it('should include locals', async function () {
+      await promiseReject();
+      const result = verifyRejectedPromise(addItemStub);
+      expect(result.message).to.equal('promise reject');
+    });
+  });
+
+  describe('with custom options', function () {
+    let rollbar;
+    let addItemStub;
+
+    beforeEach(function () {
+      rollbar = new Rollbar({
+        accessToken: 'abc123',
+        captureUncaught: true,
+        locals: { module: Locals, depth: 2, maxProperties: 5, maxArray: 2 },
+      });
+
+      addItemStub = sinon.stub(rollbar.client.notifier.queue, 'addItem');
+    });
+
+    afterEach(function () {
+      addItemStub.restore();
+      Locals.session = undefined;
+    });
+
+    it('should include locals', async function () {
+      await nodeThrowWithNestedLocals();
+      expect(addItemStub.called).to.be.true;
+
+      const traceChain = addItemStub.getCall(0).args[3].data.body.trace_chain;
+      expect(traceChain[0].exception.message).to.equal('node error');
+
+      if (nodeMajorVersion < 10) {
+        // Node 8; locals disabled
+        expect(traceChain[0].frames).to.have.length.above(1);
+        expect(traceChain[0].frames.at(-1).locals).to.not.exist;
+      } else {
+        expect(traceChain[0].frames).to.have.length.above(1);
+
+        const locals = traceChain[0].frames.at(-1).locals;
+        expect(Object.keys(locals.obj)).to.have.lengthOf(5);
+        expect(locals.obj).to.deep.equal({
+          a: 'a',
+          b: 'b',
+          c: 'c',
+          d: 'd',
+          e: 'e',
+        });
+
+        expect(locals.arr).to.have.lengthOf(2);
+        expect(locals.arr[0]).to.deep.equal({ zero: '<Array object>' });
+        expect(locals.arr[1]).to.deep.equal({ one: 1 });
+
+        expect(locals.password).to.equal('********');
+        expect(locals.sym).to.equal('Symbol(foo)');
+      }
+    });
+  });
+
+  describe('with recursive stack', function () {
+    let rollbar;
+    let addItemStub;
+
+    beforeEach(function () {
+      rollbar = new Rollbar({
+        accessToken: 'abc123',
+        captureUncaught: true,
+        locals: Locals,
+      });
+      const notifier = rollbar.client.notifier;
+      addItemStub = sinon.stub(notifier.queue, 'addItem');
+    });
+
+    afterEach(function () {
+      addItemStub.restore();
+      Locals.session = undefined;
+    });
+
+    it('should include locals in recursive frames', async function () {
+      await nodeThrowRecursionError();
+      expect(addItemStub.called).to.be.true;
+
+      const traceChain = addItemStub.getCall(0).args[3].data.body.trace_chain;
+      expect(traceChain[0].exception.message).to.equal(
+        'deep stack error, limit=3',
+      );
+
+      let frames = traceChain[0].frames;
+      expect(frames).to.have.length.above(1);
+
+      if (nodeMajorVersion >= 18) {
+        // Node >=18; locals only in top frame
+        expect(frames.at(-1).locals).to.deep.equal({ curr: 3, limit: 3 });
+        expect(frames.at(-2).locals).to.not.exist;
+        expect(frames.at(-3).locals).to.not.exist;
+      } else if (nodeMajorVersion >= 10) {
+        // Node >=10; locals enabled
+        expect(frames.at(-1).locals).to.deep.equal({ curr: 3, limit: 3 });
+        expect(frames.at(-2).locals).to.deep.equal({ curr: 2, limit: 3 });
+        expect(frames.at(-3).locals).to.deep.equal({ curr: 1, limit: 3 });
+      } else {
+        // Node <=8; locals disabled
+        expect(frames.at(-1).locals).to.not.exist;
+      }
+    });
+  });
+});

--- a/test/server.locals.merge.mocha.test.mjs
+++ b/test/server.locals.merge.mocha.test.mjs
@@ -1,0 +1,267 @@
+/* globals describe */
+/* globals it */
+/* globals afterEach */
+
+import { expect } from 'chai';
+import sinon from 'sinon';
+import Locals from '../src/server/locals.js';
+import logger from '../src/server/logger.js';
+import localsFixtures from './fixtures/locals.fixtures.js';
+
+describe('server.locals merge', function () {
+  afterEach(function () {
+    sinon.restore();
+    Locals.session = undefined;
+    Locals.currentErrors = new Map();
+  });
+
+  describe('mergeLocals', function () {
+    // Deep clone, because stack gets modified by mergeLocals
+    // and we don't want to modify the test fixtures.
+    const cloneStack = (stack) => JSON.parse(JSON.stringify(stack));
+
+    function fakeSessionPostHandler(responses) {
+      return (command, options, callback) => {
+        let error;
+        let response;
+
+        if (command === 'Runtime.getProperties') {
+          response = { result: responses[options.objectId] };
+        } else {
+          error = new Error('Unexpected session.post command');
+        }
+
+        setTimeout(() => {
+          callback(error, response);
+        }, 1);
+      };
+    }
+
+    it('should callback with error when session.post() returns error', function (done) {
+      const locals = new Locals({}, logger);
+      const err = new Error('post error');
+      sinon.stub(Locals.session, 'post').yields(err);
+
+      const key = 'key';
+      const localsMap = new Map();
+      localsMap.set('key', localsFixtures.maps.simple);
+
+      const stack = localsFixtures.stacks.simple;
+
+      locals.mergeLocals(localsMap, stack, key, (err) => {
+        expect(err).to.be.instanceOf(Error);
+        expect(err.message).to.equal('post error');
+        expect(err.stack).to.include('Error: post error');
+        done();
+      });
+    });
+
+    it('should callback with merged locals when multiple/complex locals maps present', function (done) {
+      const getPropertiesResponses = {
+        objectId1: [
+          localsFixtures.locals.object1,
+          localsFixtures.locals.object2,
+        ],
+        objectId2: [
+          localsFixtures.locals.boolean1,
+          localsFixtures.locals.boolean2,
+        ],
+        objectId3: [
+          localsFixtures.locals.string1,
+          localsFixtures.locals.array1,
+        ],
+      };
+
+      const locals = new Locals({ depth: 0 }, logger);
+      sinon
+        .stub(Locals.session, 'post')
+        .callsFake(fakeSessionPostHandler(getPropertiesResponses));
+
+      const key1 = 'key1';
+      const key2 = 'key2';
+      const localsMap = new Map();
+
+      // Test with multiple maps present.
+      localsMap.set(key1, localsFixtures.maps.simple);
+      localsMap.set(key2, localsFixtures.maps.complex); // Stack will match the 2nd locals map added.
+
+      const stack = cloneStack(localsFixtures.stacks.complex);
+
+      locals.mergeLocals(localsMap, stack, key2, (err) => {
+        expect(err).to.not.exist;
+
+        expect(stack[0].locals.response).to.equal('success');
+        expect(stack[0].locals.args).to.equal('<Array object>');
+        expect(stack[1].locals.old).to.be.false;
+        expect(stack[1].locals.new).to.be.true;
+        expect(stack[2].locals.foo).to.equal('<FooClass object>');
+        expect(stack[2].locals.bar).to.equal('<BarClass object>');
+
+        done();
+      });
+    });
+
+    it('should callback with merged locals when simple locals maps present', function (done) {
+      const getPropertiesResponses = {
+        objectId1: [
+          localsFixtures.locals.object1,
+          localsFixtures.locals.object2,
+        ],
+      };
+
+      const locals = new Locals({ depth: 0 }, logger);
+      sinon
+        .stub(Locals.session, 'post')
+        .callsFake(fakeSessionPostHandler(getPropertiesResponses));
+
+      const key = 'key';
+      const localsMap = new Map();
+      localsMap.set(key, localsFixtures.maps.simple);
+
+      const stack = cloneStack(localsFixtures.stacks.simple);
+
+      locals.mergeLocals(localsMap, stack, key, (err) => {
+        expect(err).to.not.exist;
+        expect(stack[0].locals.foo).to.equal('<FooClass object>');
+        expect(stack[0].locals.bar).to.equal('<BarClass object>');
+
+        done();
+      });
+    });
+
+    it('should callback with merged locals when depth = 1', function (done) {
+      const getPropertiesResponses = {
+        objectId1: [
+          localsFixtures.locals.object1,
+          localsFixtures.locals.object2,
+        ],
+        nestedProps1: [
+          localsFixtures.locals.string1,
+          localsFixtures.locals.boolean1,
+          localsFixtures.locals.function1,
+        ],
+        nestedProps2: [
+          localsFixtures.locals.array1,
+          localsFixtures.locals.null1,
+          localsFixtures.locals.function2,
+        ],
+      };
+
+      const locals = new Locals({ depth: 1 }, logger);
+      sinon
+        .stub(Locals.session, 'post')
+        .callsFake(fakeSessionPostHandler(getPropertiesResponses));
+
+      const key = 'key';
+      const localsMap = new Map();
+      localsMap.set(key, localsFixtures.maps.simple);
+
+      const stack = cloneStack(localsFixtures.stacks.simple);
+
+      locals.mergeLocals(localsMap, stack, key, (err) => {
+        expect(err).to.not.exist;
+
+        expect(stack[0].locals.foo).to.deep.equal({
+          response: 'success',
+          old: false,
+          func: '<Function object>',
+        });
+        expect(stack[0].locals.bar).to.deep.equal({
+          args: '<Array object>',
+          parent: null,
+          asyncFunc: '<AsyncFunction object>',
+        });
+
+        done();
+      });
+    });
+
+    it('should succeed without merged locals when no locals maps present', function (done) {
+      const getPropertiesResponses = {
+        objectId1: [
+          localsFixtures.locals.object1,
+          localsFixtures.locals.object2,
+        ],
+        objectId2: [
+          localsFixtures.locals.boolean1,
+          localsFixtures.locals.boolean2,
+        ],
+        objectId3: [
+          localsFixtures.locals.string1,
+          localsFixtures.locals.array1,
+        ],
+      };
+
+      const locals = new Locals({}, logger);
+      sinon
+        .stub(Locals.session, 'post')
+        .callsFake(fakeSessionPostHandler(getPropertiesResponses));
+
+      // Test with no maps present. 'key' won't match anything.
+      const key = 'key';
+      const localsMap = new Map();
+
+      const stack = cloneStack(localsFixtures.stacks.complex);
+
+      locals.mergeLocals(localsMap, stack, key, (err) => {
+        expect(err).to.not.exist;
+
+        expect(stack[0].locals).to.not.exist;
+        expect(stack[1].locals).to.not.exist;
+        expect(stack[2].locals).to.not.exist;
+
+        done();
+      });
+    });
+
+    it('should succeed without merged locals when no local scopes in map', function (done) {
+      const getPropertiesResponses = {
+        objectId1: [
+          localsFixtures.locals.object1,
+          localsFixtures.locals.object2,
+        ],
+        objectId2: [
+          localsFixtures.locals.boolean1,
+          localsFixtures.locals.boolean2,
+        ],
+        objectId3: [
+          localsFixtures.locals.string1,
+          localsFixtures.locals.array1,
+        ],
+      };
+
+      const locals = new Locals({}, logger);
+      sinon
+        .stub(Locals.session, 'post')
+        .callsFake(fakeSessionPostHandler(getPropertiesResponses));
+
+      const localsMap = new Map();
+      localsMap.set('key', localsFixtures.maps.noLocalScope);
+
+      const stack = cloneStack(localsFixtures.stacks.complex);
+
+      locals.mergeLocals(localsMap, stack, 'key', (err) => {
+        expect(err).to.not.exist;
+
+        expect(stack[0].locals).to.not.exist;
+        expect(stack[1].locals).to.not.exist;
+        expect(stack[2].locals).to.not.exist;
+
+        done();
+      });
+    });
+  });
+
+  describe('currentLocalsMap', function () {
+    it('should return empty map when no local scopes in map', function () {
+      const locals = new Locals({}, logger);
+
+      // Ensure empty map, as singleton might have state from other tests
+      Locals.currentErrors = new Map();
+
+      const localsMap = locals.currentLocalsMap();
+      expect(localsMap).to.be.instanceOf(Map);
+      expect(localsMap).to.be.empty;
+    });
+  });
+});

--- a/test/server.locals.test-utils.mjs
+++ b/test/server.locals.test-utils.mjs
@@ -1,0 +1,114 @@
+/**
+ * Common test utilities for server locals tests
+ */
+
+export const nodeMajorVersion = parseInt(process.versions.node.split('.')[0]);
+
+export async function wait(ms) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}
+
+export async function promiseReject() {
+  const error = new Error('promise reject');
+  Promise.reject(error);
+  await wait(500);
+}
+
+export async function nodeThrow() {
+  setTimeout(() => {
+    const error = new Error('node error');
+    throw error;
+  }, 1);
+
+  await wait(500);
+}
+
+export async function nodeThrowAndCatch(rollbar) {
+  setTimeout(() => {
+    const error = new Error('caught error');
+    try {
+      throw error;
+    } catch (e) {
+      rollbar.error(e);
+    }
+  }, 1);
+
+  await wait(500);
+}
+
+export async function nodeThrowNested() {
+  function nestedError(nestedMessage, _password) {
+    const nestedError = new Error(nestedMessage);
+    throw nestedError;
+  }
+
+  setTimeout(() => {
+    const message = 'test err';
+    const newMessage = `nested ${message}`;
+    const password = '123456';
+    const err = new Error(message);
+
+    try {
+      nestedError(newMessage, password);
+    } catch (e) {
+      err.nested = e;
+    }
+
+    throw err;
+  }, 1);
+
+  await wait(500);
+}
+
+export async function nodeThrowWithNestedLocals() {
+  setTimeout(() => {
+    const arr = [{ zero: [0, 0] }, { one: 1 }, { two: 2 }, { three: 3 }];
+    const obj = { a: 'a', b: 'b', c: 'c', d: 'd', e: 'e', f: 'f' };
+    const password = 'password';
+    const sym = Symbol('foo');
+    const error = new Error('node error');
+    throw error;
+  }, 1);
+
+  await wait(500);
+}
+
+export async function nodeThrowRecursionError() {
+  function recurse(curr, limit) {
+    if (curr < limit) {
+      recurse(curr + 1, limit);
+    } else {
+      throw new Error('deep stack error, limit=' + limit);
+    }
+  }
+
+  setTimeout(() => recurse(0, 3), 1);
+  await wait(500);
+}
+
+export function verifyRejectedPromise(addItemStub) {
+  const traceChain = addItemStub.getCall(0).args[3].data.body.trace_chain;
+  const frames = traceChain[0].frames;
+
+  return {
+    message: traceChain[0].exception.message,
+    hasLocals: nodeMajorVersion >= 10,
+    locals:
+      nodeMajorVersion >= 18
+        ? {
+            topFrame: frames.at(-1).locals,
+            secondFrame: frames.at(-2).locals,
+          }
+        : nodeMajorVersion >= 10
+          ? {
+              topFrame: frames.at(-1).locals,
+              secondFrame: frames.at(-2).locals,
+            }
+          : {
+              topFrame: undefined,
+              secondFrame: undefined,
+            },
+  };
+}


### PR DESCRIPTION
## Description of the change

This PR migrates the server test `locals` to mocha from vows.

The `server.locals` test file was gigantic. I've broken it into multiple parts and added a small utility file with the shared stuff (just a couple dozen lines).

## Related issues

[SDK-490/migrate-vowsjs-to-mocha](https://linear.app/rollbar-inc/issue/SDK-490/migrate-vowsjs-to-mocha)
[SDK-491/complete-server-test-es-module-migration](https://linear.app/rollbar-inc/issue/SDK-491/complete-server-test-es-module-migration)