### PR TITLE
New replay config options (maxSeconds, triggerOptions)

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -12,8 +12,8 @@ var sharedTransforms = require('../transforms');
 var predicates = require('./predicates');
 var sharedPredicates = require('../predicates');
 var errorParser = require('../errorParser');
-const recorderDefaults = require('./replay/defaults');
-const tracingDefaults = require('../tracing/defaults');
+const recorderDefaults = require('./replay/defaults').default;
+const tracingDefaults = require('../tracing/defaults').default;
 const ReplayMap = require('./replay/replayMap').default;
 
 function Rollbar(options, client) {

--- a/src/browser/replay/defaults.js
+++ b/src/browser/replay/defaults.js
@@ -5,6 +5,16 @@
 export default {
   enabled: false, // Whether recording is enabled
   autoStart: true, // Start recording automatically when Rollbar initializes
+  maxSeconds: 10, // Maximum recording duration in seconds
+
+  // trigger options
+  triggerOptions: {
+    // Trigger replay on specific items (occurrences)
+    item: {
+      levels: ['error', 'critical'], // Trigger on item level
+    }
+  },
+
   debug: {
     logErrors: true, // Whether to log errors emitted by rrweb.
     logEmits: false, // Whether to log emitted events

--- a/src/queue.js
+++ b/src/queue.js
@@ -104,7 +104,9 @@ Queue.prototype.addItem = function (
 
   if (this.replayMap && item.body) {
     const replayId = _.getItemAttribute(item, 'replay_id');
-    item.replayId = this.replayMap.add(replayId, item.uuid);
+    if (replayId) {
+      item.replayId = this.replayMap.add(replayId, item.uuid);
+    }
   }
 
   this.pendingRequests.push(item);

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -154,13 +154,13 @@ Rollbar.prototype._log = function (defaultLevel, item) {
     return;
   }
   try {
-    const replayId = this.tracing?.idGen(8);
+    item.level = item.level || defaultLevel;
+
+    const replayId = this._replayIdIfTriggered(item);
     this._addTracingAttributes(item, replayId);
 
     // Legacy OpenTracing support
     this._addTracingInfo(item);
-
-    item.level = item.level || defaultLevel;
 
     const telemeter = this.telemeter;
     if (telemeter) {
@@ -198,6 +198,13 @@ Rollbar.prototype._addTracingAttributes = function (item, replayId) {
     [{key: 'rollbar.occurrence.uuid', value: item.uuid}],
   );
 };
+
+Rollbar.prototype._replayIdIfTriggered = function (item) {
+  const levels = this.options.recorder?.triggerOptions?.item?.levels || [];
+  if (levels.includes(item.level)) {
+    return this.tracing?.idGen(8);
+  }
+}
 
 Rollbar.prototype._defaultLogLevel = function () {
   return this.options.logLevel || 'debug';

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -115,11 +115,21 @@ describe('Rollbar()', function () {
     var client = new (TestClientGen())();
     var options = {
       scrubFields: ['foobar'],
+      recorder: {
+        enabled: true,
+        },
+      tracing: {
+        endpoint: 'api.rollbar.com/api/1/tracing/',
+      },
     };
     var rollbar = (window.rollbar = new Rollbar(options, client));
 
     expect(rollbar.options.scrubFields).to.contain('foobar');
     expect(rollbar.options.scrubFields).to.contain('password');
+    expect(rollbar.options.recorder.enabled).to.eql(true);
+    expect(rollbar.options.recorder.triggerOptions.item.levels).to.eql(['error', 'critical']);
+    expect(rollbar.options.tracing.endpoint).to.eql('api.rollbar.com/api/1/tracing/');
+    expect(rollbar.options.tracing.enabled).to.eql(false);
     done();
   });
 
@@ -880,6 +890,9 @@ describe('log', function () {
 
     const options = {
       accessToken: 'POST_CLIENT_ITEM_TOKEN',
+      recorder: {
+        enabled: true,
+      },
     };
     const rollbar = (window.rollbar = new Rollbar(options));
 

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -116,6 +116,9 @@ describe('Session Replay E2E', function () {
             },
           },
         },
+        attributes: [
+          { key: 'replay_id', value: '1234567812345678' },
+        ],
       };
 
       queue.addItem(errorItem, function (err, resp) {
@@ -203,6 +206,9 @@ describe('Session Replay E2E', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queue.addItem(errorItem, function (err, resp) {

--- a/test/replay/integration/queue.replayMap.test.js
+++ b/test/replay/integration/queue.replayMap.test.js
@@ -48,7 +48,7 @@ describe('Queue ReplayMap Integration', function () {
     );
 
     replayMap = {
-      add: sinon.stub().returns('test-replay-id'),
+      add: sinon.stub().returnsArg(0),
       send: sinon.stub().resolves(true),
       discard: sinon.stub().returns(true),
       getSpans: sinon.stub().returns([{ id: 'test-span' }]),
@@ -77,10 +77,13 @@ describe('Queue ReplayMap Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queue.addItem(item, function () {
-      expect(item).to.have.property('replayId', 'test-replay-id');
+      expect(item).to.have.property('replayId', '1234567812345678');
       expect(replayMap.add.calledOnce).to.be.true;
       done();
     });
@@ -95,11 +98,14 @@ describe('Queue ReplayMap Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queue.addItem(item, function () {
       setTimeout(function () {
-        expect(replayMap.send.calledWith('test-replay-id')).to.be.true;
+        expect(replayMap.send.calledWith('1234567812345678')).to.be.true;
         done();
       }, 50);
     });
@@ -122,11 +128,14 @@ describe('Queue ReplayMap Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queue.addItem(item, function () {
       setTimeout(function () {
-        expect(replayMap.discard.calledWith('test-replay-id')).to.be.true;
+        expect(replayMap.discard.calledWith('1234567812345678')).to.be.true;
         expect(replayMap.send.called).to.be.false;
         done();
       }, 50);
@@ -154,11 +163,14 @@ describe('Queue ReplayMap Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queue.addItem(item, function () {
       setTimeout(function () {
-        expect(replayMap.discard.calledWith('test-replay-id')).to.be.true;
+        expect(replayMap.discard.calledWith('1234567812345678')).to.be.true;
         expect(replayMap.send.called).to.be.false;
         done();
       }, 50);
@@ -187,11 +199,14 @@ describe('Queue ReplayMap Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queue.addItem(item, function () {
       setTimeout(function () {
-        expect(replayMap.discard.calledWith('test-replay-id')).to.be.true;
+        expect(replayMap.discard.calledWith('1234567812345678')).to.be.true;
         expect(replayMap.send.called).to.be.false;
         done();
       }, 50);
@@ -229,14 +244,17 @@ describe('Queue ReplayMap Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queue.addItem(item, function (err, resp) {
       if (resp) {
-        expect(item).to.have.property('replayId', 'test-replay-id');
+        expect(item).to.have.property('replayId', '1234567812345678');
 
         setTimeout(function () {
-          expect(replayMap.send.calledWith('test-replay-id')).to.be.true;
+          expect(replayMap.send.calledWith('1234567812345678')).to.be.true;
           done();
         }, 50);
       }
@@ -247,6 +265,29 @@ describe('Queue ReplayMap Integration', function () {
     const item = {
       level: 'error',
       message: 'Test error without body',
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
+    };
+
+    queue.addItem(item, function () {
+      expect(item).to.not.have.property('replayId');
+      expect(replayMap.add.called).to.be.false;
+      done();
+    });
+  });
+
+  it('should not add replayId to items without a replay_id attribute', function (done) {
+    const item = {
+      level: 'error',
+      message: 'Test error without body',
+      body: {
+        trace: {
+          exception: {
+            message: 'Test error with retry',
+          },
+        },
+      },
     };
 
     queue.addItem(item, function () {
@@ -275,12 +316,15 @@ describe('Queue ReplayMap Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queue.addItem(item, function () {
       setTimeout(function () {
         expect(replayMap.send.called).to.be.false;
-        expect(replayMap.discard.calledWith('test-replay-id')).to.be.false;
+        expect(replayMap.discard.calledWith('1234567812345678')).to.be.false;
         done();
       }, 50);
     });

--- a/test/replay/integration/sessionRecording.test.js
+++ b/test/replay/integration/sessionRecording.test.js
@@ -255,6 +255,9 @@ describe('Session Replay Transport Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queue.addItem(errorItem, function (err, resp) {
@@ -294,6 +297,9 @@ describe('Session Replay Transport Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queue.addItem(errorItem, function (err, resp) {
@@ -324,6 +330,9 @@ describe('Session Replay Transport Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     const addItemPromise = new Promise((resolve, reject) => {
@@ -368,6 +377,9 @@ describe('Session Replay Transport Integration', function () {
           },
         },
       },
+      attributes: [
+        { key: 'replay_id', value: '1234567812345678' },
+      ],
     };
 
     queueWithoutReplayMap.addItem(errorItem, function (err, resp) {

--- a/test/replay/unit/queue.replayMap.test.js
+++ b/test/replay/unit/queue.replayMap.test.js
@@ -16,7 +16,7 @@ const Queue = require('../../../src/queue');
 
 class MockReplayMap {
   constructor() {
-    this.add = sinon.stub().returns('test-replay-id');
+    this.add = sinon.stub().returnsArg(0);
     this.send = sinon.stub().resolves(true);
     this.discard = sinon.stub().returns(true);
   }
@@ -58,17 +58,27 @@ describe('Queue with ReplayMap', function () {
 
   describe('addItem', function () {
     it('should add replayId to the item when replayMap is available', function () {
-      const item = { body: { message: 'test error' } };
+      const item = {
+        body: { message: 'test error' },
+        attributes: [
+          { key: 'replay_id', value: '1234567812345678' },
+        ],
+      };
       const callback = sinon.stub();
 
       queue.addItem(item, callback);
 
       expect(replayMap.add.called).to.be.true;
-      expect(item.replayId).to.equal('test-replay-id');
+      expect(item.replayId).to.equal('1234567812345678');
     });
 
     it('should not add replayId when item has no body', function () {
-      const item = { noBody: true };
+      const item = {
+        noBody: true,
+        attributes: [
+          { key: 'replay_id', value: '1234567812345678' },
+        ],
+      };
       const callback = sinon.stub();
 
       queue.addItem(item, callback);
@@ -80,7 +90,12 @@ describe('Queue with ReplayMap', function () {
     it('should not add replayId when replayMap is not available', function () {
       queue = new Queue(rateLimiter, api, logger, { transmit: true });
 
-      const item = { body: { message: 'test error' } };
+      const item = {
+        body: { message: 'test error' },
+        attributes: [
+          { key: 'replay_id', value: '1234567812345678' },
+        ],
+      };
       const callback = sinon.stub();
 
       queue.addItem(item, callback);
@@ -154,13 +169,18 @@ describe('Queue with ReplayMap', function () {
     it('should call _handleReplayResponse with replayId and response on success', function () {
       const handleStub = sinon.stub(queue, '_handleReplayResponse');
 
-      const item = { body: { message: 'test error' } };
+      const item = {
+        body: { message: 'test error' },
+        attributes: [
+          { key: 'replay_id', value: '1234567812345678' },
+        ],
+      };
       const callback = sinon.stub();
 
       queue.addItem(item, callback);
 
       expect(handleStub.called).to.be.true;
-      expect(handleStub.firstCall.args[0]).to.equal('test-replay-id');
+      expect(handleStub.firstCall.args[0]).to.equal('1234567812345678');
       expect(handleStub.firstCall.args[1]).to.deep.equal({ err: 0 });
     });
 
@@ -171,7 +191,12 @@ describe('Queue with ReplayMap', function () {
 
       const handleStub = sinon.stub(queue, '_handleReplayResponse');
 
-      const item = { body: { message: 'test error' } };
+      const item = {
+        body: { message: 'test error' },
+        attributes: [
+          { key: 'replay_id', value: '1234567812345678' },
+        ],
+      };
       const callback = sinon.stub();
 
       queue.addItem(item, callback);
@@ -184,7 +209,12 @@ describe('Queue with ReplayMap', function () {
 
       queue = new Queue(rateLimiter, api, logger, { transmit: true });
 
-      const item = { body: { message: 'test error' } };
+      const item = {
+        body: { message: 'test error' },
+        attributes: [
+          { key: 'replay_id', value: '1234567812345678' },
+        ],
+      };
       const callback = sinon.stub();
 
       queue.addItem(item, callback);


### PR DESCRIPTION
## Description of the change

This PR adds two new config options.

**recorder.maxSeconds**
Specifies the maximum recording length in seconds, allowing the SDK to internally manage the number and length of rrweb checkouts, and simplifying the user-facing options.
`Default: 10`

**recorder.triggerOptions.item.levels**
Specifies the error level required to trigger a replay to be captured and sent.
`Default: ['error', 'critical']`

**Notes:**
* This PR also separates Rollbar recorder options from rrweb options, and removes disallowed rrweb options that are specific to the operation of the recorder and intended to be set internally.
* Fixes an issue, related to requiring a default es6 import, that affected merging default options for tracing and recorder.
* As part of the work to support `recorder.triggerOptions`, the `replay_id` attribute is now required for items that trigger a replay. Tests related to replay have been updated to include this payload attribute where needed.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
