### PR TITLE
Fix private property typo

### DIFF
--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -147,7 +147,7 @@ export default class Recorder {
         }
         return true; // swallow the error instead of throwing it to the window
       },
-      ...this.rrwebOptions,
+      ...this.#rrwebOptions,
     });
 
     return this;


### PR DESCRIPTION
## Description of the change

Missing `#`.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

