### PR TITLE
Only extract replay headers in xhr and fetch when appropriate

### DIFF
--- a/src/browser/transport/fetch.js
+++ b/src/browser/transport/fetch.js
@@ -24,17 +24,20 @@ function makeFetchRequest(accessToken, url, method, data, callback, timeout) {
     .then(function (response) {
       if (timeoutId) clearTimeout(timeoutId);
       const respHeaders = response.headers;
-      const headers = {
-        'Rollbar-Replay-Enabled': respHeaders.get(
-          'Rollbar-Replay-Enabled'
-        ),
-        'Rollbar-Replay-RateLimit-Remaining': respHeaders.get(
-          'Rollbar-Replay-RateLimit-Remaining'
-        ),
-        'Rollbar-Replay-RateLimit-Reset': respHeaders.get(
-          'Rollbar-Replay-RateLimit-Reset'
-        ),
-      };
+
+      const isItemRoute = url.endsWith('/api/1/item/');
+      const headers = isItemRoute
+        ? {
+            'Rollbar-Replay-Enabled': respHeaders.get('Rollbar-Replay-Enabled'),
+            'Rollbar-Replay-RateLimit-Remaining': respHeaders.get(
+              'Rollbar-Replay-RateLimit-Remaining',
+            ),
+            'Rollbar-Replay-RateLimit-Reset': respHeaders.get(
+              'Rollbar-Replay-RateLimit-Reset',
+            ),
+          }
+        : {};
+
       const json = response.json();
       callback(null, json, headers);
     })

--- a/src/browser/transport/xhr.js
+++ b/src/browser/transport/xhr.js
@@ -31,17 +31,22 @@ function makeXhrRequest(
 
             var parseResponse = _.jsonParse(request.responseText);
             if (_isSuccess(request)) {
-              const headers = {
-                'Rollbar-Replay-Enabled': request.getResponseHeader(
-                  'Rollbar-Replay-Enabled'
-                ),
-                'Rollbar-Replay-RateLimit-Remaining': request.getResponseHeader(
-                  'Rollbar-Replay-RateLimit-Remaining'
-                ),
-                'Rollbar-Replay-RateLimit-Reset': request.getResponseHeader(
-                  'Rollbar-Replay-RateLimit-Reset'
-                ),
-              }
+              const isItemRoute = url.endsWith('/api/1/item/');
+
+              const headers = isItemRoute
+                ? {
+                    'Rollbar-Replay-Enabled': request.getResponseHeader(
+                      'Rollbar-Replay-Enabled',
+                    ),
+                    'Rollbar-Replay-RateLimit-Remaining':
+                      request.getResponseHeader(
+                        'Rollbar-Replay-RateLimit-Remaining',
+                      ),
+                    'Rollbar-Replay-RateLimit-Reset': request.getResponseHeader(
+                      'Rollbar-Replay-RateLimit-Reset',
+                    ),
+                  }
+                : {};
               callback(parseResponse.error, parseResponse.value, headers);
               return;
             } else if (_isNormalFailure(request)) {


### PR DESCRIPTION
## Description of the change

Only get replay related headers when the response is to an item request.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release