### PR TITLE
Missing debug was causing debug options to be ignored by the recorder

### DIFF
--- a/src/browser/replay/defaults.js
+++ b/src/browser/replay/defaults.js
@@ -7,12 +7,11 @@ export default {
   autoStart: true, // Start recording automatically when Rollbar initializes
   maxSeconds: 300, // Maximum recording duration in seconds
 
-  // trigger options
   triggerOptions: {
     // Trigger replay on specific items (occurrences)
     item: {
       levels: ['error', 'critical'], // Trigger on item level
-    }
+    },
   },
 
   debug: {

--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -48,6 +48,7 @@ export default class Recorder {
       autoStart,
       maxSeconds,
       triggerOptions,
+      debug,
 
       // disallowed rrweb options
       emit,
@@ -56,7 +57,7 @@ export default class Recorder {
       // rrweb options
       ...rrwebOptions
     } = newOptions;
-    this.#options = { enabled, autoStart, maxSeconds, triggerOptions };
+    this.#options = { enabled, autoStart, maxSeconds, triggerOptions, debug };
     this.#rrwebOptions = rrwebOptions;
 
     if (this.isRecording && newOptions.enabled === false) {

--- a/test/browser.replay.recorder.test.js
+++ b/test/browser.replay.recorder.test.js
@@ -45,14 +45,26 @@ describe('Recorder', function () {
       const recorder = new Recorder({}, recordFnStub);
 
       expect(recorder.isRecording).to.equal(false);
-      expect(recorder.options).to.deep.equal({ enabled: undefined, autoStart: undefined, maxSeconds: undefined, triggerOptions:undefined });
+      expect(recorder.options).to.deep.equal({
+        enabled: undefined,
+        autoStart: undefined,
+        maxSeconds: undefined,
+        triggerOptions: undefined,
+        debug: undefined,
+      });
     });
 
     it('should initialize removing disallowed options', function () {
       const options = { enabled: true, checkoutEveryNms: 1000 };
       const recorder = new Recorder(options, recordFnStub);
 
-      expect(recorder.options).to.deep.equal({ enabled: true, autoStart: undefined, maxSeconds: undefined, triggerOptions:undefined });
+      expect(recorder.options).to.deep.equal({
+        enabled: true,
+        autoStart: undefined,
+        maxSeconds: undefined,
+        triggerOptions: undefined,
+        debug: undefined,
+      });
     });
 
     it('should throw error if no record function is passed', function () {
@@ -379,7 +391,8 @@ describe('Recorder', function () {
         enabled: false,
         autoStart: undefined,
         maxSeconds: 20,
-        triggerOptions:undefined,
+        triggerOptions: undefined,
+        debug: undefined,
       });
     });
 
@@ -392,7 +405,8 @@ describe('Recorder', function () {
         enabled: true,
         autoStart: undefined,
         maxSeconds: 15,
-        triggerOptions:undefined,
+        triggerOptions: undefined,
+        debug: undefined,
       });
 
       expect(recorder.checkoutEveryNms()).to.equal(7500);


### PR DESCRIPTION
## Description of the change

This PR adds the `debug` options that were missed when implementing https://github.com/rollbar/rollbar.js/pull/1221.

This was causing the appropriate debugging logs not to show up even when these options were set to true.

A more appropriate solution may be in order in order to not having to keep track between adding/removing options from the defaults and having to remember to add/remove them from the source code as well.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release
