### PR TITLE
Fixed span not checking correct ended prop when setting attributes

### DIFF
--- a/src/tracing/span.js
+++ b/src/tracing/span.js
@@ -48,7 +48,7 @@ export class Span {
   }
 
   setAttribute(key, value) {
-    if (value == null || this.ended) return this;
+    if (value == null || this.span.ended) return this;
     if (key.length === 0) return this;
 
     this.span.attributes[key] = value;


### PR DESCRIPTION
## Description of the change

`Span.setAttribute` doesn't seem to be checking the correct `ended` attribute.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release
