### PR TITLE
Pass options.startTime to Span in Tracer

### DIFF
--- a/src/tracing/tracer.js
+++ b/src/tracing/tracer.js
@@ -40,6 +40,7 @@ export class Tracer {
       kind,
       parentSpanId,
       spanProcessor: this.spanProcessor,
+      startTime: options.startTime,
     });
     return span;
   }


### PR DESCRIPTION
## Description of the change

Make Tracer pass `options.startTime` as is to the `Span` being created, similar to what the reference implementation does: https://github.com/open-telemetry/opentelemetry-js/blob/v2.0.1/packages/opentelemetry-sdk-trace-base/src/Tracer.ts#L68.