### PR TITLE
Yse `rb` prefix for default class names

### DIFF
--- a/src/browser/replay/defaults.js
+++ b/src/browser/replay/defaults.js
@@ -44,6 +44,11 @@ export default {
     week: false,
   },
 
+  // Override default class names.
+  blockClass: 'rb-block',
+  maskTextClass: 'rb-mask',
+  ignoreClass: 'rb-ignore',
+
   // Remove unnecessary parts of the DOM
   // By default all removable elements are removed
   slimDOMOptions: {


### PR DESCRIPTION
## Description of the change

Product request. (Linear CAT-428)

Setting class names in the Rollbar config will override the defauls.


## Type of change

- [x] New feature (non-breaking change that adds functionality)

