### PR TITLE
Add type definitions for session replay related types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -107,6 +107,7 @@ declare namespace Rollbar {
     ) => void;
     overwriteScrubFields?: boolean;
     payload?: Payload;
+    recorder?: RecorderOptions;
     reportLevel?: Level;
     retryInterval?: number | null;
     rewriteFilenamePatterns?: string[];
@@ -119,6 +120,7 @@ declare namespace Rollbar {
     stackTraceLimit?: number;
     telemetryScrubber?: TelemetryScrubber;
     timeout?: number;
+    tracing?: TracingOptions;
     transform?: (data: Dictionary, item: Dictionary) => void | Promise<void>;
     transmit?: boolean;
     uncaughtErrorLevel?: Level;
@@ -201,9 +203,13 @@ declare namespace Rollbar {
 
   class Telemeter {}
   class Instrumenter {}
+  class Tracing {}
+  class Recorder {}
 
   export type TelemeterType = typeof Telemeter;
   export type InstrumenterType = typeof Instrumenter;
+  export type TracingType = typeof Tracing;
+  export type RecorderType = typeof Recorder;
   export type TruncationType = object;
   export type ScrubType = (
     data: object,
@@ -224,6 +230,66 @@ declare namespace Rollbar {
     wrapGlobals?: WrapGlobalsType;
     scrub?: ScrubType;
     truncation?: TruncationType;
+    tracing?: TracingType;
+    recorder?: RecorderType;
+  }
+
+  export interface RecorderOptions {
+    enabled?: boolean;
+    autoStart?: boolean;
+    maxSeconds?: number;
+    triggerOptions?: {
+      item?: {
+        levels?: Level[];
+      };
+    };
+    debug?: {
+      logErrors?: boolean;
+      logEmits?: boolean;
+    };
+    inlineStylesheet?: boolean;
+    inlineImages?: boolean;
+    collectFonts?: boolean;
+    maskInputOptions?: {
+      password?: boolean;
+      email?: boolean;
+      tel?: boolean;
+      text?: boolean;
+      color?: boolean;
+      date?: boolean;
+      'datetime-local'?: boolean;
+      month?: boolean;
+      number?: boolean;
+      range?: boolean;
+      search?: boolean;
+      time?: boolean;
+      url?: boolean;
+      week?: boolean;
+    };
+    blockClass?: string;
+    maskTextClass?: string;
+    ignoreClass?: string;
+    slimDOMOptions?: {
+      script?: boolean;
+      comment?: boolean;
+      headFavicon?: boolean;
+      headWhitespace?: boolean;
+      headMetaDescKeywords?: boolean;
+      headMetaSocial?: boolean;
+      headMetaRobots?: boolean;
+      headMetaHttpEquiv?: boolean;
+      headMetaAuthorship?: boolean;
+      headMetaVerification?: boolean;
+    };
+    maskInputFn?: (text: string) => string;
+    maskTextFn?: (text: string) => string;
+    errorHandler?: (error: Error) => void;
+    plugins?: any[];
+  }
+
+  export interface TracingOptions {
+    enabled?: boolean;
+    endpoint?: string;
   }
 
   /**

--- a/src/browser/replay/recorder.d.ts
+++ b/src/browser/replay/recorder.d.ts
@@ -1,0 +1,5 @@
+import Rollbar from '../../../index';
+
+declare var Recorder: Rollbar.RecorderType;
+
+export = Recorder;

--- a/src/tracing/tracing.d.ts
+++ b/src/tracing/tracing.d.ts
@@ -1,0 +1,5 @@
+import Rollbar from '../../index';
+
+declare var Tracing: Rollbar.TracingType;
+
+export = Tracing;


### PR DESCRIPTION
## Description of the change

This PR adds missing type definitions for the new Session Replay related classes, `Recorder` and `Tracing`. Following the same pattern as we currently have.

This is necessary for TS projects in order to be able to pass `recorder` and `tracing` options to `Rollbar` at the point of instantiation.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

[SDK-517](https://linear.app/rollbar-inc/issue/SDK-517/add-type-definitions-for-session-replay-types)