### PR TITLE
Initial (minimal) support for replay triggers config

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -238,11 +238,10 @@ declare namespace Rollbar {
     enabled?: boolean;
     autoStart?: boolean;
     maxSeconds?: number;
-    triggerOptions?: {
-      item?: {
-        levels?: Level[];
-      };
-    };
+    triggers?: {
+      type: string;
+      level?: string[];
+    }[];
     debug?: {
       logErrors?: boolean;
       logEmits?: boolean;

--- a/index.d.ts
+++ b/index.d.ts
@@ -240,7 +240,7 @@ declare namespace Rollbar {
     maxSeconds?: number;
     triggers?: {
       type: string;
-      level?: string[];
+      level?: Level[];
     }[];
     debug?: {
       logErrors?: boolean;

--- a/src/browser/replay/defaults.js
+++ b/src/browser/replay/defaults.js
@@ -7,12 +7,12 @@ export default {
   autoStart: true, // Start recording automatically when Rollbar initializes
   maxSeconds: 300, // Maximum recording duration in seconds
 
-  triggerOptions: {
-    // Trigger replay on specific items (occurrences)
-    item: {
-      levels: ['error', 'critical'], // Trigger on item level
+  triggers: [
+    {
+      type: 'occurrence',
+      level: ['error', 'critical'],
     },
-  },
+  ],
 
   debug: {
     logErrors: true, // Whether to log errors emitted by rrweb.

--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -47,7 +47,7 @@ export default class Recorder {
       enabled,
       autoStart,
       maxSeconds,
-      triggerOptions,
+      triggers,
       debug,
 
       // disallowed rrweb options
@@ -57,7 +57,7 @@ export default class Recorder {
       // rrweb options
       ...rrwebOptions
     } = newOptions;
-    this.#options = { enabled, autoStart, maxSeconds, triggerOptions, debug };
+    this.#options = { enabled, autoStart, maxSeconds, triggers, debug };
     this.#rrwebOptions = rrwebOptions;
 
     if (this.isRecording && newOptions.enabled === false) {

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -200,8 +200,9 @@ Rollbar.prototype._addTracingAttributes = function (item, replayId) {
 };
 
 Rollbar.prototype._replayIdIfTriggered = function (item) {
-  const levels = this.options.recorder?.triggerOptions?.item?.levels || [];
-  if (levels.includes(item.level)) {
+  const triggers = _.getReplayTriggersForType(this.options.recorder?.triggers, 'occurrence');
+  const enabledTrigger = this._getEnabledTrigger(triggers, item.level);
+  if (enabledTrigger) {
     return this.tracing?.idGen(8);
   }
 }
@@ -258,6 +259,15 @@ Rollbar.prototype._addTracingInfo = function (item) {
       }
     }
   }
+};
+
+Rollbar.prototype._getEnabledTrigger = function (triggers, level) {
+  for (const t of triggers) {
+    if (t.level?.includes(level)) {
+      return t;
+    }
+  }
+  return null;
 };
 
 function generateItemHash(item) {

--- a/src/utility.js
+++ b/src/utility.js
@@ -663,6 +663,19 @@ function getItemAttribute(itemData, key) {
   return undefined;
 }
 
+function getReplayTriggersForType(triggers, triggerType) {
+  if (!triggers) return [];
+
+  const filteredTriggers = [];
+  for (const t of triggers) {
+    if (t.type === triggerType) {
+      filteredTriggers.push(t);
+    }
+  }
+
+  return filteredTriggers;
+}
+
 /*
  * get - given an obj/array and a keypath, return the value at that keypath or
  *       undefined if not possible.
@@ -818,6 +831,7 @@ export {
   createTelemetryEvent,
   addItemAttributes,
   getItemAttribute,
+  getReplayTriggersForType,
   filterIp,
   formatArgsAsString,
   formatUrl,

--- a/test/browser.replay.recorder.test.js
+++ b/test/browser.replay.recorder.test.js
@@ -49,7 +49,7 @@ describe('Recorder', function () {
         enabled: undefined,
         autoStart: undefined,
         maxSeconds: undefined,
-        triggerOptions: undefined,
+        triggers: undefined,
         debug: undefined,
       });
     });
@@ -62,7 +62,7 @@ describe('Recorder', function () {
         enabled: true,
         autoStart: undefined,
         maxSeconds: undefined,
-        triggerOptions: undefined,
+        triggers: undefined,
         debug: undefined,
       });
     });
@@ -402,7 +402,7 @@ describe('Recorder', function () {
         enabled: false,
         autoStart: undefined,
         maxSeconds: 20,
-        triggerOptions: undefined,
+        triggers: undefined,
         debug: undefined,
       });
     });
@@ -416,7 +416,7 @@ describe('Recorder', function () {
         enabled: true,
         autoStart: undefined,
         maxSeconds: 15,
-        triggerOptions: undefined,
+        triggers: undefined,
         debug: undefined,
       });
 

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -127,7 +127,7 @@ describe('Rollbar()', function () {
     expect(rollbar.options.scrubFields).to.contain('foobar');
     expect(rollbar.options.scrubFields).to.contain('password');
     expect(rollbar.options.recorder.enabled).to.eql(true);
-    expect(rollbar.options.recorder.triggerOptions.item.levels).to.eql([
+    expect(rollbar.options.recorder.triggers[0].level).to.eql([
       'error',
       'critical',
     ]);


### PR DESCRIPTION
## Description of the change

Replaces `triggerOptions` with a minimal initial implementation of the `triggers` array, which can support multiple types of triggers with different configurations.

The default if no `triggers` key is present is, as before, an occurrence trigger on `error` and `critical` level.

This initial implementation allows users of the next alpha release to use the new config to modify or disable the occurrence trigger.

## Type of change


- [x] New feature (non-breaking change that adds functionality)

