### PR TITLE
Use package entry points for conditional exports between cjs/esm

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -102,23 +102,35 @@ To test these examples with your local Rollbar.js build:
 
 ## Package Entry Points
 
-Rollbar.js provides different entry points for different environments:
+Rollbar.js uses conditional exports to provide the right module format for each environment:
 
-- **Main package**: `require('rollbar')` or `import Rollbar from 'rollbar'`
-  - Node.js: `src/server/rollbar.js`
-  - Browser (with bundler): `dist/rollbar.umd.min.js`
+### Automatic Resolution (Recommended)
 
-- **Direct imports - Source files** (ES modules):
-  - `rollbar/src/server/rollbar.js` - Server-side source
-  - `rollbar/src/browser/rollbar.js` - Browser-side source
-  - `rollbar/src/react-native/rollbar.js` - React Native source
+When you use `require('rollbar')` or `import Rollbar from 'rollbar'`, you automatically get:
 
-- **Direct imports - Distribution files** (pre-built bundles):
-  - `rollbar/dist/rollbar.umd.js` - Universal (CommonJS/AMD/global)
-  - `rollbar/dist/rollbar.umd.min.js` - Universal minified
-  - `rollbar/dist/rollbar.js` - Vanilla (script tag only)
-  - `rollbar/dist/rollbar.min.js` - Vanilla minified
-  - `rollbar/dist/rollbar.snippet.js` - Async snippet loader
-  - `rollbar/dist/rollbar.named-amd.js` - AMD/RequireJS
+- **Node.js**:
+  - `import` → ES module (`src/server/rollbar.js`)
+  - `require()` → CommonJS wrapper (`src/server/rollbar.cjs`)
+- **Browsers/Bundlers**:
+  - `import` → ES module (`src/browser/rollbar.js`)
+  - `require()` → UMD bundle (`dist/rollbar.umd.min.js`)
+- **TypeScript**: Type definitions from `index.d.ts`
 
-- **CDN**: `https://cdn.rollbar.com/rollbarjs/refs/tags/vVERSION/rollbar.min.js`
+### Direct Imports - Source Files (ES modules)
+
+- `rollbar/src/server/rollbar.js` - Server-side source
+- `rollbar/src/browser/rollbar.js` - Browser-side source
+- `rollbar/src/react-native/rollbar.js` - React Native source
+
+### Direct Imports - Distribution Files (Pre-built bundles)
+
+- `rollbar/dist/rollbar.umd.js` - Universal (CommonJS/AMD/global)
+- `rollbar/dist/rollbar.umd.min.js` - Universal minified
+- `rollbar/dist/rollbar.js` - Vanilla (script tag only)
+- `rollbar/dist/rollbar.min.js` - Vanilla minified
+- `rollbar/dist/rollbar.snippet.js` - Async snippet loader
+- `rollbar/dist/rollbar.named-amd.js` - AMD/RequireJS
+
+### CDN
+
+- `https://cdn.rollbar.com/rollbarjs/refs/tags/vVERSION/rollbar.min.js`

--- a/package.json
+++ b/package.json
@@ -15,10 +15,24 @@
     "javascript"
   ],
   "license": "MIT",
-  "main": "src/server/rollbar.js",
+  "main": "src/server/rollbar.cjs",
   "browser": "dist/rollbar.umd.min.js",
   "module": "src/browser/rollbar.js",
   "types": "./index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./index.d.ts",
+      "node": {
+        "import": "./src/server/rollbar.js",
+        "require": "./src/server/rollbar.cjs"
+      },
+      "browser": {
+        "import": "./src/browser/rollbar.js",
+        "require": "./dist/rollbar.umd.min.js"
+      },
+      "default": "./dist/rollbar.umd.min.js"
+    }
+  },
   "dependencies": {
     "@rrweb/record": "^2.0.0-alpha.18",
     "async": "~3.2.3",

--- a/src/server/rollbar.cjs
+++ b/src/server/rollbar.cjs
@@ -1,0 +1,5 @@
+// CommonJS wrapper for ES module
+// This file provides CommonJS compatibility for Node.js users
+// who require() the rollbar package
+
+module.exports = require('./rollbar.js').default;


### PR DESCRIPTION
## Description of the change

This PR fixes more issues around `import` and `require` discrepancies by introducing a modern way to define package entry points, called [Conditional Exports](https://nodejs.org/api/packages.html#conditional-exports) which [were introduced 6 years ago in Node 12.7.0](https://nodejs.org/en/blog/release/v12.7.0).

Conditional Exports replace the legacy `main`, `browser` and `module` fields providing fine-grained control over what files can be imported from our package and how.

This change was prompted by the `universal-node` example which wouldn't be able to `require('rollbar')` without suffixing `.default` to it. This is because node looked into our `package.json` and resolved to use our `main` field which points to an es module.

> [!NOTE]
>  Before Conditional Exports, packages had to expose main and rely on hacks like pkg.module (non-standard) for ESM builds. Conditional exports made dual packages clean and official.
>
> See the official [Proposal for Bare Module Specifier Resolution in node.js](https://github.com/jkrems/proposal-pkg-exports/)

The introduced changes ***override*** `main`, `browser` and `module` fields for all nodes >= 12.7.0, and any node < 12 will fallback to the older fields. I'm keeping everything to maximize compatibility.

---

> [!IMPORTANT]
> With this change I can confirm that all examples that integrate rollbar through their `package.json` file are 100% working.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

- [SDK-518/make-sure-all-sdk-examples-work-properly](https://linear.app/rollbar-inc/issue/SDK-518/make-sure-all-sdk-examples-work-properly)
- [SDK-521/use-package-entry-points-for-conditional-exports-between-cjsesm](https://linear.app/rollbar-inc/issue/SDK-521/use-package-entry-points-for-conditional-exports-between-cjsesm)
