### PR TITLE
Fix the Node.js require link in examples/README.md

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,7 +9,7 @@ The following table shows all supported integration methods across different pla
 | Environment           | Script Tag                                                           | CommonJS                | ESM Import                             | TypeScript     | AMD                           |
 | --------------------- | -------------------------------------------------------------------- | ----------------------- | -------------------------------------- | -------------- | ----------------------------- |
 | **Browser**           | ✅ [script.html](./script.html)<br>✅ [snippet.html](./snippet.html) | —                       | ✅ via bundler                         | ✅ via bundler | ✅ [requirejs/](./requirejs/) |
-| **Node.js**           | —                                                                    | ✅ `require('rollbar')` | ✅ [`import`](#es-modules--typescript) | ✅             | —                             |
+| **Node.js**           | —                                                                    | ✅ [`require`](#nodejs--commonjs) | ✅ [`import`](#es-modules--typescript) | ✅             | —                             |
 | **React Native**      | —                                                                    | ✅                      | ✅                                     | ✅             | —                             |
 | **React**             | ✅                                                                   | ✅ [react/](./react/)   | ✅                                     | ✅             | —                             |
 | **Angular**           | —                                                                    | —                       | ✅ [angular/](./angular/)              | ✅             | —                             |


### PR DESCRIPTION
## Description of the change

Change the link for the `require` example for Node.js in the integration compatibility matrix in `examples/README.md`.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
