### PR TITLE
Separate defaults for snippet and hardcore jquery version

### DIFF
--- a/src/browser/bundles/defaults.js
+++ b/src/browser/bundles/defaults.js
@@ -1,0 +1,4 @@
+import { version } from '../../defaults.js'
+
+export const cdnHost = 'cdn.rollbar.com';
+export const defaultRollbarJsUrl = `https://${cdnHost}/rollbarjs/refs/tags/v${version}/rollbar.min.js`;

--- a/src/browser/bundles/rollbar.snippet.js
+++ b/src/browser/bundles/rollbar.snippet.js
@@ -2,7 +2,7 @@
 
 import * as Shim from '../shim.js';
 import snippetCallback from '../snippet_callback.js';
-import { defaultRollbarJsUrl } from '../defaults.js';
+import { defaultRollbarJsUrl } from './defaults.js';
 
 _rollbarConfig = _rollbarConfig || {};
 _rollbarConfig.rollbarJsUrl = _rollbarConfig.rollbarJsUrl || defaultRollbarJsUrl;

--- a/src/browser/defaults.js
+++ b/src/browser/defaults.js
@@ -1,7 +1,7 @@
 /**
  * Default browser options
  */
-import { version, commonScrubFields } from '../defaults.js';
+import { commonScrubFields } from '../defaults.js';
 
 export const scrubFields = [
   ...commonScrubFields,
@@ -47,13 +47,5 @@ export const scrubFields = [
   'ccyear',
 ];
 
-// CDN configuration for the snippet
-export const cdnHost = 'cdn.rollbar.com';
-export const defaultRollbarJsUrl = `https://${cdnHost}/rollbarjs/refs/tags/v${version}/rollbar.min.js`;
-
-export const jqueryPluginVersion = '0.0.8';
-
 // For compatibility with existing code that expects default export with scrubFields property
-export default {
-  scrubFields,
-};
+export default { scrubFields };

--- a/src/browser/plugins/jquery.js
+++ b/src/browser/plugins/jquery.js
@@ -1,14 +1,12 @@
 /* globals jQuery */
 
-import { jqueryPluginVersion } from '../defaults.js';
-
 (function (jQuery, window, document) {
   var rb = window.Rollbar;
   if (!rb) {
     return;
   }
 
-  var JQUERY_PLUGIN_VERSION = jqueryPluginVersion;
+  var JQUERY_PLUGIN_VERSION = '0.0.8';
 
   rb.configure({
     payload: {


### PR DESCRIPTION
## Description of the change

This PR hardcoded jquery version in the script itself @ `src/browser/plugins/jquery.js` instead of importing it. Importing was causing the entire hierarchy of defaults file to get embedded in the minified file. The rationale for hardcoding the version is that 1. it was already hardcoded it (where is the version even coming from?), and it's only required at the point of use, which is the script itself.

I've also separated the defaults for the `rollbar.snippet.js`, although this does the same importing to grab the version, it seems to affect the size positively as it's not embedding anyrthing other than the version string, thus the `rollbar.snippet.js` is now smaller.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release