### PR TITLE
Use concatenation to build the cdn url for the browser snippet

### DIFF
--- a/src/browser/bundles/defaults.js
+++ b/src/browser/bundles/defaults.js
@@ -1,4 +1,5 @@
 import { version } from '../../defaults.js'
 
 export const cdnHost = 'cdn.rollbar.com';
-export const defaultRollbarJsUrl = `https://${cdnHost}/rollbarjs/refs/tags/v${version}/rollbar.min.js`;
+// concatenation over interpolation makes the minified file smaller
+export const defaultRollbarJsUrl = 'https://' + cdnHost + '/rollbarjs/refs/tags/v' + version + '/rollbar.min.js';


### PR DESCRIPTION
## Description of the change

Turns out, using concatenation results in a smaller minified file as the transpiler...

Turns this interpolated strings
```js
export const defaultRollbarJsUrl = 'https://${cdnHost}/rollbarjs/refs/tags/v${version}/rollbar.min.js`;
```
into
```js
var u="https://".concat("cdn.rollbar.com","/rollbarjs/refs/tags/v").concat("3.0.0-alpha.3","/rollbar.min.js");
```

While if we use concatenation, it turns
```js
export const defaultRollbarJsUrl = 'https://' + cdnHost + '/rollbarjs/refs/tags/v' + version + '/rollbar.min.js';
```
into a static string:
```js
"https://cdn.rollbar.com/rollbarjs/refs/tags/v3.0.0-alpha.3/rollbar.min.js"
```

This takes the size of `rollbar.snippet.js` back to its usual 6581 bytes.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
