### PR TITLE
Fixed tested and fixed html examples with no build system

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,6 @@
   "dependencies": {},
   "main": ["dist/rollbar.umd.js"],
   "ignore": [
-    "dist/*.nojson*",
     "dist/*.named-amd*",
     "docs",
     "src",

--- a/examples/include_custom_object.html
+++ b/examples/include_custom_object.html
@@ -19,6 +19,7 @@
         // as custom data in the payload.
 
         // ensure payload.data.custom is set
+        payload.data = payload.data || {};
         payload.data.custom = payload.data.custom || {};
 
         // add our data

--- a/examples/requirejs/README.md
+++ b/examples/requirejs/README.md
@@ -4,7 +4,7 @@
 
 ```js
 //
-// Download the latest rollbar.umd.nojson.min.js and place in current directory.
+// Download the latest rollbar.min.js and place in current directory.
 var rollbarConfig = {
   accessToken: '...',
   captureUncaught: true,
@@ -14,7 +14,7 @@ var rollbarConfig = {
 };
 
 // Require the Rollbar library
-require(['rollbar.umd.nojson.min.js'], function (Rollbar) {
+require(['rollbar.umd.min.js'], function (Rollbar) {
   var rollbar = Rollbar.init(rollbarConfig);
   rollbar.info('Hello world');
 });

--- a/examples/requirejs/test.html
+++ b/examples/requirejs/test.html
@@ -5,7 +5,7 @@
     <script>
       var _rollbarConfig = {
         accessToken: 'POST_CLIENT_ITEM_ACCESS_TOKEN',
-        rollbarJsUrl: '../../dist/rollbar.umd.js',
+        rollbarJsUrl: '../../dist/rollbar.umd.min',
         captureUncaught: true,
         payload: {
           environment: 'development',
@@ -18,7 +18,7 @@
       // NOTE: you must use the name "rollbar" here.
       require.config({
         paths: {
-          rollbar: '../../dist/rollbar.umd',
+          rollbar: '../../dist/rollbar.umd.min',
         },
       });
 

--- a/examples/snippet.html
+++ b/examples/snippet.html
@@ -8,7 +8,7 @@
         payload: {
           environment: 'test',
         },
-        rollbarJsUrl: 'http://localhost:8080/dist/rollbar.js',
+        rollbarJsUrl: '/dist/rollbar.js',
       };
     </script>
     <script>

--- a/examples/test.html
+++ b/examples/test.html
@@ -23,7 +23,7 @@
 
       var _rollbarConfig = {
         accessToken: '12c99de67a444c229fca100e0967486f',
-        rollbarJsUrl: '/dist/rollbar.umd.nojson.js',
+        rollbarJsUrl: '/dist/rollbar.umd.js',
         captureUncaught: true,
         //checkIgnore: ignoreFilesUncaught,
         payload: {


### PR DESCRIPTION
## Description of the change

This PR fixes some non-working HTML examples and streamlines others so they're easier to test by simply creating a local server (eg. `python3 -m http.server 8000`).

- Removed `nojson` dist variant which doesn't exist anymore.
- Fixed an issue where `data` wouldn't be defined for `payload` for some reason.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

[SDK-518/make-sure-all-sdk-examples-work-properly](https://linear.app/rollbar-inc/issue/SDK-518/make-sure-all-sdk-examples-work-properly)