### PR TITLE
Fix bug when updating snippets after doing a dev build

### DIFF
--- a/scripts/update-example-snippets.js
+++ b/scripts/update-example-snippets.js
@@ -17,7 +17,7 @@ async function updateSnippets() {
   const snippetPath = path.join(root, 'dist/rollbar.snippet.js');
   const snippet = await readFile(snippetPath, 'utf8');
   const regex =
-    /^([ \t]*)(\/\/ Rollbar Snippet\n)(.*?)(\n[ \t]*\/\/ End Rollbar Snippet)$/m;
+    /^([ \t]*)(\/\/ Rollbar Snippet\n)(.*?)(\n[ \t]*\/\/ End Rollbar Snippet)$/ms;
 
   const files = glob.sync('examples/**/*.{html,js}', {
     cwd: root,


### PR DESCRIPTION
## Description of the change

I found a bug in the new update snippets script that would occur after doing a `build:dev`. The resulting examples would contain the multiline rollbar snippet and on trying to build again using `build`, the regex wouldn't match because `.` wasn't matching multiple lines.

This fixes this problem.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
