### PR TITLE
Remove unused copyrelease task from gruntfile

### DIFF
--- a/Gruntfile.cjs
+++ b/Gruntfile.cjs
@@ -120,7 +120,6 @@ module.exports = function (grunt) {
     karma: buildGruntKarmaConfig(singleRun, browserTests, reporters),
   });
   grunt.registerTask('test', ['test-browser']);
-  grunt.registerTask('release', ['copyrelease']);
 
   grunt.registerTask('test-browser', function (target) {
     var karmaTask = 'karma' + (target ? ':' + target : '');
@@ -181,23 +180,6 @@ module.exports = function (grunt) {
 
     integrationTests.forEach(function (testName) {
       grunt.task.run('karma:' + testName);
-    });
-  });
-
-  grunt.registerTask('copyrelease', function createRelease() {
-    var version = pkg.version;
-    var builds = ['', '.umd'];
-
-    builds.forEach(function (buildName) {
-      var js = 'dist/rollbar' + buildName + '.js';
-      var minJs = 'dist/rollbar' + buildName + '.min.js';
-
-      var releaseJs = 'release/rollbar' + buildName + '-' + version + '.js';
-      var releaseMinJs =
-        'release/rollbar' + buildName + '-' + version + '.min.js';
-
-      grunt.file.copy(js, releaseJs);
-      grunt.file.copy(minJs, releaseMinJs);
     });
   });
 };


### PR DESCRIPTION
## Description of the change

It seems we're not using the `copyrelease` task in grunt anymore, and we're not tracking or keep old release versions in a `release` dir. So, I've removed the task from the Gruntfile.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

[SDK-506/replace-grunt-with-direct-tool-usage](https://linear.app/rollbar-inc/issue/SDK-506/replace-grunt-with-direct-tool-usage)