### PR TITLE
Add baseSamplingRatio for replay triggers

### DIFF
--- a/src/browser/replay/defaults.js
+++ b/src/browser/replay/defaults.js
@@ -7,6 +7,7 @@ export default {
   autoStart: true, // Start recording automatically when Rollbar initializes
   maxSeconds: 300, // Maximum recording duration in seconds
 
+  baseSamplingRatio: 1.0, // Used by triggers that don't specify a sampling ratio
   triggers: [
     {
       type: 'occurrence',

--- a/src/browser/replay/replayPredicates.js
+++ b/src/browser/replay/replayPredicates.js
@@ -6,8 +6,15 @@
 export default class ReplayPredicates {
   maxAdjustedCount = 2 ** 56;
 
-  constructor(triggers, context) {
-    this.triggers = triggers || [];
+  /*
+   * Constructor for ReplayPredicates.
+   *
+   * @param {Object} config - Configuration object containing replay settings.
+   * @param {Object} context - Context object containing state used by predicates.
+   */
+  constructor(config, context) {
+    this.config = config || {};
+    this.triggers = config?.triggers || [];
     this.context = context || {};
 
     this.predicates = {
@@ -76,7 +83,7 @@ export default class ReplayPredicates {
    * @returns {boolean} - True if the trigger is sampled, false otherwise.
    */
   isSampled(trigger) {
-    const ratio = trigger.samplingRatio || 1;
+    const ratio = trigger.samplingRatio || this.config.baseSamplingRatio || 1;
 
     if (ratio == 1) {
       return true;

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -203,7 +203,7 @@ Rollbar.prototype._addTracingAttributes = function (item, replayId) {
 Rollbar.prototype._replayIdIfTriggered = function (item) {
   const replayId = this.tracing?.idGen(8);
   const enabled = new ReplayPredicates(
-    this.options.recorder?.triggers,
+    this.options.recorder,
     { item, replayId },
   ).isEnabledForTriggerType('occurrence')
 

--- a/test/replay/unit/replayPredicates.test.js
+++ b/test/replay/unit/replayPredicates.test.js
@@ -11,19 +11,21 @@ import ReplayPredicates from '../../../src/browser/replay/replayPredicates.js';
 
 describe('ReplayMap', function () {
   let replayId;
-  let triggers;
+  let recorderConfig;
 
   describe('isEnabledForTriggerType', function () {
     describe('occurrence', function () {
       beforeEach(function () {
         replayId = 'aaaabbbbccccdddd';
-        triggers = [
-          {
-            type: 'occurrence',
-            level: ['error', 'critical'],
-            samplingRatio: 0.5,
-          },
-        ];
+        recorderConfig = {
+          triggers: [
+            {
+              type: 'occurrence',
+              level: ['error', 'critical'],
+              samplingRatio: 0.5,
+            },
+          ],
+        }
       });
 
       it('should return true on matching level', function () {
@@ -32,7 +34,7 @@ describe('ReplayMap', function () {
         };
 
         const enabled = new ReplayPredicates(
-          triggers,
+          recorderConfig,
           { item, replayId },
         ).isEnabledForTriggerType('occurrence')
         expect(enabled).to.be.true;
@@ -44,7 +46,7 @@ describe('ReplayMap', function () {
         };
 
         const enabled = new ReplayPredicates(
-          triggers,
+          recorderConfig,
           { item, replayId },
         ).isEnabledForTriggerType('occurrence')
         expect(enabled).to.be.false;
@@ -54,10 +56,10 @@ describe('ReplayMap', function () {
         const item = {
           level: 'info',
         };
-        triggers[0].level = undefined;
+        recorderConfig.triggers[0].level = undefined;
 
         const enabled = new ReplayPredicates(
-          triggers,
+          recorderConfig,
           { item, replayId },
         ).isEnabledForTriggerType('occurrence')
         expect(enabled).to.be.true;
@@ -67,14 +69,14 @@ describe('ReplayMap', function () {
         const item = {
           level: 'info',
         };
-        triggers.push({
+        recorderConfig.triggers.push({
           type: 'occurrence',
           level: ['info'],
           samplingRatio: 0.5,
         });
 
         const enabled = new ReplayPredicates(
-          triggers,
+          recorderConfig,
           { item, replayId },
         ).isEnabledForTriggerType('occurrence')
         expect(enabled).to.be.true;
@@ -84,10 +86,10 @@ describe('ReplayMap', function () {
         const item = {
           level: 'error',
         };
-        triggers[0].samplingRatio = undefined;
+        recorderConfig.triggers[0].samplingRatio = undefined;
 
         const enabled = new ReplayPredicates(
-          triggers,
+          recorderConfig,
           { item, replayId },
         ).isEnabledForTriggerType('occurrence')
         expect(enabled).to.be.true;
@@ -97,14 +99,67 @@ describe('ReplayMap', function () {
         const item = {
           level: 'error',
         };
-        triggers[0].samplingRatio = 0.1;
+        recorderConfig.triggers[0].samplingRatio = 0.1;
 
         const enabled = new ReplayPredicates(
-          triggers,
+          recorderConfig,
           { item, replayId },
         ).isEnabledForTriggerType('occurrence')
         expect(enabled).to.be.false;
       });
+
+      it('should return false with baseSamplingRatio specified and not sampled', function () {
+        const item = {
+          level: 'error',
+        };
+        recorderConfig.baseSamplingRatio = 0.1;
+        recorderConfig.triggers[0].samplingRatio = undefined;
+
+        const enabled = new ReplayPredicates(
+          recorderConfig,
+          { item, replayId },
+        ).isEnabledForTriggerType('occurrence')
+        expect(enabled).to.be.false;
+      });
+
+      it('should return true with trigger overriding baseSamplingRatio', function () {
+        const item = {
+          level: 'error',
+        };
+        recorderConfig.baseSamplingRatio = 0.1;
+
+        const enabled = new ReplayPredicates(
+          recorderConfig,
+          { item, replayId },
+        ).isEnabledForTriggerType('occurrence')
+        expect(enabled).to.be.true;
+      });
+
+      it('should return false with no triggers', function () {
+        const item = {
+          level: 'error',
+        };
+
+        const enabled = new ReplayPredicates(
+          null,
+          { item, replayId },
+        ).isEnabledForTriggerType('occurrence')
+        expect(enabled).to.be.false;
+      });
+
+      it('should return false with no config', function () {
+        const item = {
+          level: 'error',
+        };
+        recorderConfig.triggers = null;
+
+        const enabled = new ReplayPredicates(
+          recorderConfig,
+          { item, replayId },
+        ).isEnabledForTriggerType('occurrence')
+        expect(enabled).to.be.false;
+      });
+
     });
   });
 });


### PR DESCRIPTION
## Description of the change

Adds the recorder config option `baseSamplingRatio`. This is used by any triggers that don't specify a `samplingRatio`, including the default occurrence trigger.

The minimal recorder config is:
```js
recorder: {
  enabled: true,
}
```

The minimal config with sampling is
```js
recorder: {
  enabled: true,
  baseSamplingRatio: 0.1,
}
```

## Type of change

- [x] New feature (non-breaking change that adds functionality)

