### PR TITLE
Fixed update example snippets getting into .git and node_modules dirs

### DIFF
--- a/scripts/update-example-snippets.js
+++ b/scripts/update-example-snippets.js
@@ -22,6 +22,7 @@ async function updateSnippets() {
   const files = glob.sync('examples/**/*.{html,js}', {
     cwd: root,
     absolute: true,
+    ignore: ['**/.git/**', '**/node_modules/**'],
   });
 
   for (const file of files) {


### PR DESCRIPTION
## Description of the change

This pull request updates the `updateSnippets` function in `scripts/update-example-snippets.js` to improve file selection during snippet updates.

File selection improvement:

* Updated the `glob.sync` call in `updateSnippets` to ignore files in `.git` and `node_modules` directories, ensuring these are excluded from the snippet update process.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

[SDK-506/replace-grunt-with-direct-tool-usage](https://linear.app/rollbar-inc/issue/SDK-506/replace-grunt-with-direct-tool-usage)