### PR TITLE
Migrated type def files from commonjs to es modules

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 // Type definitions for rollbar
 // Project: Rollbar
 
-export = Rollbar;
+export default Rollbar;
 
 declare class Rollbar {
   constructor(options?: Rollbar.Configuration);

--- a/src/browser/core.d.ts
+++ b/src/browser/core.d.ts
@@ -1,3 +1,3 @@
-import Rollbar from '../../index';
+import Rollbar from '../../index.js';
 
-export = Rollbar;
+export default Rollbar;

--- a/src/browser/replay/recorder.d.ts
+++ b/src/browser/replay/recorder.d.ts
@@ -1,5 +1,5 @@
-import Rollbar from '../../../index';
+import type { Rollbar } from '../../../index.js';
 
-declare var Recorder: Rollbar.RecorderType;
+declare const Recorder: Rollbar.RecorderType;
 
-export = Recorder;
+export default Recorder;

--- a/src/browser/telemetry.d.ts
+++ b/src/browser/telemetry.d.ts
@@ -1,5 +1,5 @@
-import Rollbar from '../../index';
+import type { Rollbar } from '../../index.js';
 
-declare var Instrumenter: Rollbar.InstrumenterType;
+declare const Instrumenter: Rollbar.InstrumenterType;
 
-export = Instrumenter;
+export default Instrumenter;

--- a/src/browser/wrapGlobals.d.ts
+++ b/src/browser/wrapGlobals.d.ts
@@ -1,5 +1,5 @@
-import Rollbar from '../../index';
+import type { Rollbar } from '../../index.js';
 
-declare var wrapGlobals: Rollbar.WrapGlobalsType;
+declare const wrapGlobals: Rollbar.WrapGlobalsType;
 
-export = wrapGlobals;
+export default wrapGlobals;

--- a/src/scrub.d.ts
+++ b/src/scrub.d.ts
@@ -1,5 +1,5 @@
-import Rollbar from '../index';
+import type { Rollbar } from '../index.js';
 
-declare var scrub: Rollbar.ScrubType;
+declare const scrub: Rollbar.ScrubType;
 
-export = scrub;
+export default scrub;

--- a/src/telemetry.d.ts
+++ b/src/telemetry.d.ts
@@ -1,5 +1,5 @@
-import Rollbar from '../index';
+import type { Rollbar } from '../index.js';
 
-declare var Telemeter: Rollbar.TelemeterType;
+declare const Telemeter: Rollbar.TelemeterType;
 
-export = Telemeter;
+export default Telemeter;

--- a/src/tracing/tracing.d.ts
+++ b/src/tracing/tracing.d.ts
@@ -1,5 +1,5 @@
-import Rollbar from '../../index';
+import type { Rollbar } from '../../index.js';
 
-declare var Tracing: Rollbar.TracingType;
+declare const Tracing: Rollbar.TracingType;
 
-export = Tracing;
+export default Tracing;

--- a/src/truncation.d.ts
+++ b/src/truncation.d.ts
@@ -1,5 +1,5 @@
-import Rollbar from '../index';
+import type { Rollbar } from '../index.js';
 
-declare var Truncation: Rollbar.TruncationType;
+declare const Truncation: Rollbar.TruncationType;
 
-export = Truncation;
+export default Truncation;


### PR DESCRIPTION
## Description of the change

Our type def files hadn't been migrated to ES Modules, so they were causing trouble on typescript projects. This PR migrates all type defs to es mod.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

[SDK-492/migrate-source-code-to-es-modules](https://linear.app/rollbar-inc/issue/SDK-492/migrate-source-code-to-es-modules)
