### PR TITLE
Have react and react ts projects point to npm packed release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ coverage
 .DS_Store
 *.swp
 npm-debug.log
-
+.pack
 .local
 CLAUDE.*.*
 .aider*

--- a/examples/react-19-typescript/package.json
+++ b/examples/react-19-typescript/package.json
@@ -51,7 +51,7 @@
     "react-refresh": "^0.11.0",
     "resolve": "^1.20.0",
     "resolve-url-loader": "^4.0.0",
-    "rollbar": "file:../..",
+    "rollbar": "file:../../.pack/rollbar.tgz",
     "sass-loader": "^12.3.0",
     "semver": "^7.3.5",
     "source-map-loader": "^3.0.0",

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -16,9 +16,10 @@
     "webpack-dev-server": "^3.2.1"
   },
   "dependencies": {
+    "@rollbar/react": "^1.0.0",
     "babel-loader": "^7.1.5",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
-    "rollbar": "file:../.."
+    "rollbar": "file:../../.pack/rollbar.tgz"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,8 +44,6 @@
         "grunt-contrib-watch": "^1.1.0",
         "grunt-karma": "^4.0.2",
         "grunt-parallel": "^0.5.1",
-        "grunt-text-replace": "^0.4.0",
-        "grunt-webpack": "^5.0.0",
         "jade": "~0.27.7",
         "jasmine-core": "^2.3.4",
         "jquery-mockjax": "^2.5.0",
@@ -3739,14 +3737,6 @@
         "node": ">=0.12"
       }
     },
-    "node_modules/deep-for-each": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "lodash.isplainobject": "^4.0.6"
-      }
-    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "dev": true,
@@ -5899,28 +5889,6 @@
         "teleport": ">=0.2.0"
       }
     },
-    "node_modules/grunt-text-replace": {
-      "version": "0.4.0",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/grunt-webpack": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "deep-for-each": "^3.0.0",
-        "lodash": "^4.17.19"
-      },
-      "engines": {
-        "node": ">=12.13.0"
-      },
-      "peerDependencies": {
-        "webpack": "^4.0.0 || ^5.0.0"
-      }
-    },
     "node_modules/grunt/node_modules/glob": {
       "version": "7.1.7",
       "dev": true,
@@ -7268,11 +7236,6 @@
     },
     "node_modules/lodash.isfinite": {
       "version": "3.3.2",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/lodash.isplainobject": {
-      "version": "4.0.6",
       "dev": true,
       "license": "MIT"
     },


### PR DESCRIPTION
## Description of the change

Both react projects now point to a packed tgz file generated by `npm pack`. I'll automate this in an upcoming PR.

In order for it to work, simply:
```sh
$ npm install
$ npm run build
$ npm pack
$ mv rollbar-3.0.0-alpha.4.tgz ./.pack/rollbar.tgz
$ cd examples/react-19-typescript
$ rm -rf build node_modules/ package-lock.json # removing package-lock.json is necessary to prevent npm from using the old cached packed tarball
$ npm install
$ npm run build
```

> [!IMPORTANT]
> **Next PR:** The fix for the import issue with typescript.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

[SDK-518/make-sure-all-sdk-examples-work-properly](https://linear.app/rollbar-inc/issue/SDK-518/make-sure-all-sdk-examples-work-properly)
