### PR TITLE
Don't import Rollbar as a namespace in the Angular example

### DIFF
--- a/examples/angular/src/app/app.component.ts
+++ b/examples/angular/src/app/app.component.ts
@@ -1,7 +1,7 @@
 // src/app/app.component.ts
 import { Component, inject } from '@angular/core';
 import { RollbarService } from './rollbar.errorhandler';
-import * as Rollbar from 'rollbar';
+import Rollbar from 'rollbar';
 
 @Component({
   selector: 'app-root',

--- a/examples/angular/src/app/rollbar.errorhandler.ts
+++ b/examples/angular/src/app/rollbar.errorhandler.ts
@@ -1,6 +1,6 @@
 // src/app/rollbar.errorhandler.ts
 import { ErrorHandler, inject, Injectable, InjectionToken } from '@angular/core';
-import * as Rollbar from 'rollbar';
+import Rollbar from 'rollbar';
 
 // InjectionToken for providing a Rollbar instance
 export const RollbarService = new InjectionToken<Rollbar>('rollbar');


### PR DESCRIPTION
## Description of the change

The Angular example was importing Rollbar as a namespace which was causing these errors during `npm run build`:
```ts
✘ [ERROR] TS2709: Cannot use namespace 'Rollbar' as a type. [plugin angular-compiler]

    src/app/app.component.ts:17:27:
      17 │   private rollbar = inject<Rollbar>(RollbarService);
         ╵                            ~~~~~~~


✘ [ERROR] TS2709: Cannot use namespace 'Rollbar' as a type. [plugin angular-compiler]

    src/app/rollbar.errorhandler.ts:6:49:
      6 │ export const RollbarService = new InjectionToken<Rollbar>('rollbar');
        ╵                                                  ~~~~~~~
```

It's not recommended to import Rollbar as a namespace:
https://docs.rollbar.com/docs/importing-or-requiring-rollbar#namespace-import-syntax-not-recommended

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

[SDK-518/make-sure-all-sdk-examples-work-properly](https://linear.app/rollbar-inc/issue/SDK-518/make-sure-all-sdk-examples-work-properly)