### PR TITLE
Update 3 year old error-stack-parser library with its newer esm version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@rrweb/record": "^2.0.0-alpha.18",
         "async": "~3.2.3",
         "console-polyfill": "0.3.0",
-        "error-stack-parser": "^2.0.4",
+        "error-stack-parser-es": "^1.0.5",
         "json-stringify-safe": "~5.0.0",
         "lru-cache": "~2.2.1",
         "request-ip": "~3.3.0",
@@ -4059,16 +4059,14 @@
         "string-template": "~0.2.1"
       }
     },
-    "node_modules/error-stack-parser": {
-      "version": "2.0.6",
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
       "license": "MIT",
-      "dependencies": {
-        "stackframe": "^1.1.1"
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
-    },
-    "node_modules/error-stack-parser/node_modules/stackframe": {
-      "version": "1.2.0",
-      "license": "MIT"
     },
     "node_modules/es-check": {
       "version": "9.1.4",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@rrweb/record": "^2.0.0-alpha.18",
     "async": "~3.2.3",
     "console-polyfill": "0.3.0",
-    "error-stack-parser": "^2.0.4",
+    "error-stack-parser-es": "^1.0.5",
     "json-stringify-safe": "~5.0.0",
     "lru-cache": "~2.2.1",
     "request-ip": "~3.3.0",

--- a/src/errorParser.js
+++ b/src/errorParser.js
@@ -1,4 +1,4 @@
-import ErrorStackParser from 'error-stack-parser';
+import { parse as parseErrorStack } from 'error-stack-parser';
 
 var UNKNOWN_FUNCTION = '?';
 var ERR_CLASS_REGEXP = new RegExp(
@@ -36,7 +36,7 @@ function Stack(exception, skip) {
     skip = skip || 0;
 
     try {
-      parserStack = ErrorStackParser.parse(exception);
+      parserStack = parseErrorStack(exception);
     } catch (e) {
       parserStack = [];
     }


### PR DESCRIPTION
## Description of the change

This PR replaces the 3-year old `error-stack-parser` library to its modern (and maintained) port [`error-stack-parser-es`](https://www.npmjs.com/package/error-stack-parser-es) which provides types as well as being pure esm.

The API and behavior doesn't seem to have changed.

This is needed to make browser tests work under WTR, since browsers don't support cjs thus were complaining about it:
```
$ npx web-test-runner test/browser.core.test.js --config web-test-runner.config.mjs

test/browser.core.test.js:

 🚧 Browser logs:
      SyntaxError: The requested module './../node_modules/error-stack-parser/error-stack-parser.js' does not provide an export named 'default'

 ❌ Could not import your test module. Check the browser logs or open the browser in debug mode for more information.

Chromium: |██████████████████████████████| 1/1 test files | 0 passed, 0 failed

Error while running tests.
```

I'm trying my best not to introduce rollup plugins to convert cjs until I absolutely must. I took the plugin road last time and it was very messy (also, because we hadn't migrated to esm, yet), but still.

This is simpler, gives us a maintained lib, improves security, etc.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

[SDK-493](https://linear.app/rollbar-inc/issue/SDK-493/replace-karma-with-webtest-runner-for-modern-performant-browser)