### PR TITLE
Add commonjs wrappers to components when using require

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,42 +34,42 @@
     },
     "./src/browser/core": {
       "types": "./src/browser/core.d.ts",
-      "require": "./src/browser/core.js",
+      "require": "./src/browser/core.cjs",
       "default": "./src/browser/core.js"
     },
     "./src/telemetry": {
       "types": "./src/telemetry.d.ts",
-      "require": "./src/telemetry.js",
+      "require": "./src/telemetry.cjs",
       "default": "./src/telemetry.js"
     },
     "./src/browser/telemetry": {
       "types": "./src/browser/telemetry.d.ts",
-      "require": "./src/browser/telemetry.js",
+      "require": "./src/browser/telemetry.cjs",
       "default": "./src/browser/telemetry.js"
     },
     "./src/browser/wrapGlobals": {
       "types": "./src/browser/wrapGlobals.d.ts",
-      "require": "./src/browser/wrapGlobals.js",
+      "require": "./src/browser/wrapGlobals.cjs",
       "default": "./src/browser/wrapGlobals.js"
     },
     "./src/scrub": {
       "types": "./src/scrub.d.ts",
-      "require": "./src/scrub.js",
+      "require": "./src/scrub.cjs",
       "default": "./src/scrub.js"
     },
     "./src/truncation": {
       "types": "./src/truncation.d.ts",
-      "require": "./src/truncation.js",
+      "require": "./src/truncation.cjs",
       "default": "./src/truncation.js"
     },
     "./src/tracing/tracing": {
       "types": "./src/tracing/tracing.d.ts",
-      "require": "./src/tracing/tracing.js",
+      "require": "./src/tracing/tracing.cjs",
       "default": "./src/tracing/tracing.js"
     },
     "./src/browser/replay/recorder": {
       "types": "./src/browser/replay/recorder.d.ts",
-      "require": "./src/browser/replay/recorder.js",
+      "require": "./src/browser/replay/recorder.cjs",
       "default": "./src/browser/replay/recorder.js"
     }
   },

--- a/src/browser/core.cjs
+++ b/src/browser/core.cjs
@@ -1,0 +1,7 @@
+/**
+ * CommonJS wrapper for ES module
+ *
+ * This file provides CommonJS compatibility for users who use require()
+ */
+
+module.exports = require('./core.js').default;

--- a/src/browser/replay/recorder.cjs
+++ b/src/browser/replay/recorder.cjs
@@ -1,0 +1,7 @@
+/**
+ * CommonJS wrapper for ES module
+ *
+ * This file provides CommonJS compatibility for users who use require()
+ */
+
+module.exports = require('./recorder.js').default;

--- a/src/browser/telemetry.cjs
+++ b/src/browser/telemetry.cjs
@@ -1,0 +1,7 @@
+/**
+ * CommonJS wrapper for ES module
+ *
+ * This file provides CommonJS compatibility for users who use require()
+ */
+
+module.exports = require('./telemetry.js').default;

--- a/src/browser/wrapGlobals.cjs
+++ b/src/browser/wrapGlobals.cjs
@@ -1,0 +1,7 @@
+/**
+ * CommonJS wrapper for ES module
+ *
+ * This file provides CommonJS compatibility for users who use require()
+ */
+
+module.exports = require('./wrapGlobals.js').default;

--- a/src/scrub.cjs
+++ b/src/scrub.cjs
@@ -1,0 +1,7 @@
+/**
+ * CommonJS wrapper for ES module
+ *
+ * This file provides CommonJS compatibility for users who use require()
+ */
+
+module.exports = require('./scrub.js').default;

--- a/src/telemetry.cjs
+++ b/src/telemetry.cjs
@@ -1,0 +1,7 @@
+/**
+ * CommonJS wrapper for ES module
+ *
+ * This file provides CommonJS compatibility for users who use require()
+ */
+
+module.exports = require('./telemetry.js').default;

--- a/src/tracing/tracing.cjs
+++ b/src/tracing/tracing.cjs
@@ -1,0 +1,7 @@
+/**
+ * CommonJS wrapper for ES module
+ *
+ * This file provides CommonJS compatibility for users who use require()
+ */
+
+module.exports = require('./tracing.js').default;

--- a/src/truncation.cjs
+++ b/src/truncation.cjs
@@ -1,0 +1,7 @@
+/**
+ * CommonJS wrapper for ES module
+ *
+ * This file provides CommonJS compatibility for users who use require()
+ */
+
+module.exports = require('./truncation.js').default;


### PR DESCRIPTION
## Description of the change

This PR introduces CJS wrappers for the different Rollbar components when using the browser with require.

[SDK-531/add-cjs-for-browser-components-using-require](https://linear.app/rollbar-inc/issue/SDK-531/add-cjs-for-browser-components-using-require)