### PR TITLE
Set default environment to 'unknown'

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -618,6 +618,7 @@ import { version, logLevel, reportLevel, uncaughtErrorLevel, endpoint } from '..
 import browserDefaults from './defaults.js';
 
 var defaultOptions = {
+  environment: 'unknown',
   version: version,
   scrubFields: browserDefaults.scrubFields,
   logLevel: logLevel,


### PR DESCRIPTION
## Description of the change

Sets the default environment to "unknown" to match 2.x rollbar.js.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

