### PR TITLE
Initial migration of react native tests

### DIFF
--- a/test/react-native.rollbar.test.js
+++ b/test/react-native.rollbar.test.js
@@ -1,7 +1,5 @@
-/* globals expect */
-/* globals describe */
-/* globals it */
-/* globals sinon */
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 import Rollbar from '../src/react-native/rollbar.js';
 var rollbarConfig = {
@@ -50,7 +48,7 @@ describe('sendJsonPayload', function () {
 
     rollbar.sendJsonPayload(json);
 
-    expect(window.fetchStub.called).to.be.ok();
+    expect(window.fetchStub.called).to.be.ok;
     expect(window.fetchStub.getCall(0).args[1].body).to.eql(json);
 
     done();
@@ -204,7 +202,7 @@ describe('Rollbar()', function () {
     var rollbar = new Rollbar(options, client);
 
     var result = rollbar.log('a messasge', 'another one');
-    expect(result.uuid).to.be.ok();
+    expect(result.uuid).to.be.ok;
 
     done();
   });
@@ -217,7 +215,7 @@ describe('Rollbar()', function () {
     var result = rollbar.log('a message', 'another one');
     var loggedItem = client.logCalls[0].item;
     expect(loggedItem.message).to.eql('a message');
-    expect(loggedItem.custom).to.be.ok();
+    expect(loggedItem.custom).to.be.ok;
 
     done();
   });
@@ -453,7 +451,7 @@ describe('callback options', function () {
     rollbar.log('test'); // generate a payload to inspect
 
     setTimeout(function () {
-      expect(window.fetchStub.called).to.be.ok();
+      expect(window.fetchStub.called).to.be.ok;
       var body = JSON.parse(window.fetchStub.getCall(0).args[1].body);
       expect(body.data.foo).to.eql('bar');
 
@@ -475,7 +473,7 @@ describe('callback options', function () {
     rollbar.log('test'); // generate a payload to inspect
 
     setTimeout(function () {
-      expect(window.fetchStub.called).to.be.ok();
+      expect(window.fetchStub.called).to.be.ok;
       var body = JSON.parse(window.fetchStub.getCall(0).args[1].body);
       expect(body.data.foo).to.eql('baz');
 
@@ -524,9 +522,9 @@ describe('createItem', function () {
     expect(item.err).to.eql(args[0]);
     expect(item.message).to.eql('first');
     expect(item.custom.extraArgs).to.eql(['second']);
-    expect(item.callback).to.be.ok();
+    expect(item.callback).to.be.ok;
     item.callback();
-    expect(myCallbackCalled).to.be.ok();
+    expect(myCallbackCalled).to.be.ok;
 
     done();
   });
@@ -578,7 +576,7 @@ describe('createItem', function () {
 
     var args = [new Error('Whoa'), 'first', { a: 1, b: 2 }, 'second'];
     var item = rollbar._createItem(args);
-    expect(item.uuid).to.be.ok();
+    expect(item.uuid).to.be.ok;
 
     var parts = item.uuid.split('-');
     expect(parts.length).to.eql(5);
@@ -624,7 +622,7 @@ describe('createItem', function () {
       }
       var args = [e, 'first', 42, { a: 1, b: 2 }, 'second'];
       var item = rollbar._createItem(args);
-      expect(item.err).to.be.ok();
+      expect(item.err).to.be.ok;
     }
 
     done();

--- a/test/react-native.transforms.test.js
+++ b/test/react-native.transforms.test.js
@@ -1,7 +1,5 @@
-/* globals expect */
-/* globals describe */
-/* globals it */
-/* globals sinon */
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 import Rollbar from '../src/react-native/rollbar.js';
 import * as t from '../src/react-native/transforms.js';

--- a/test/react-native.transport.test.js
+++ b/test/react-native.transport.test.js
@@ -1,7 +1,5 @@
-/* globals expect */
-/* globals describe */
-/* globals it */
-/* globals sinon */
+import { expect } from 'chai';
+import sinon from 'sinon';
 
 import truncation from '../src/truncation.js';
 import Transport from '../src/react-native/transport.js';
@@ -50,8 +48,8 @@ describe('post', function () {
     stubResponse(200, 0, 'OK');
 
     var callback = function (err, data) {
-      expect(err).to.eql(null);
-      expect(data).to.be.ok();
+      expect(err).to.be.null;
+      expect(data).to.be.ok;
       expect(data.uuid).to.eql(uuid);
       done();
     };
@@ -62,7 +60,7 @@ describe('post', function () {
     stubResponse(403, '403', 'bad request');
 
     var callback = function (err, resp) {
-      expect(resp).to.not.be.ok();
+      expect(resp).to.not.be.ok;
       expect(err.message).to.eql('Api error: bad request');
       done();
     };

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -8,9 +8,7 @@ export default {
     '!test/react-native.*.test.js',
   ],
 
-  nodeResolve: {
-    exportConditions: ['browser', 'development'],
-  },
+  nodeResolve: true,
 
   browsers: [
     playwrightLauncher({


### PR DESCRIPTION
## Description of the change

React Native tests have been disabled due to multiple issues we won't handle right now:

React native's `src/react-native/transport.js` is using a 10 year old library `Buffer` just to get the `byteLength` of some utf8 data. This library is supposed to be part of node now. Instead of:
```js
import { Buffer } from 'buffer/';
```
Should be imported as:
```js
import { Buffer } from 'node:buffer';
```
The other problem is that this dep isn't being added directly, it comes from a devDependency called node-libs-browser which is also extremely old and that I don't believe it's really in use.

Webpack does some magic and ends up shoving `buffer` in the bundle because it sees it's being used.

All in all, since the tests require a hybrid of node.js and browser environment to run, we need to solve these issues first before we can make these tests play nice with WTR.

That being said, an initial, basic migration has been done which is correct.

These tests will remain disabled for the time being.

## Related issues

[SDK-493/replace-karma-with-webtest-runner-for-modern-performant-browser](https://linear.app/rollbar-inc/issue/SDK-493/replace-karma-with-webtest-runner-for-modern-performant-browser)
