### PR TITLE
Rename ReplayMap to ReplayManager

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,19 +73,21 @@ As of version 3.0.0, the SDK has been updated to use modern JavaScript features 
 - **Function Documentation (JSDoc/TSDoc)**: Always include comprehensive documentation for functions, classes, and methods using JSDoc/TSDoc format (`/** ... */`). These serve as API documentation, appear in IDE tooltips, and help developers understand purpose, parameters, and return values.
 
 - **Inline Code Comments**: Avoid redundant comments that merely restate what the code is doing. Only add comments to explain:
+
   - Why the code works a certain way (decisions and reasoning)
   - Non-obvious behavior or edge cases
   - Complex algorithms or business logic
   - Workarounds for bugs or limitations
-  
+
 - **Self-documenting Code**: Write clear, readable code that explains itself through descriptive variable/function names and straightforward logic. Well-written code rarely needs explanatory comments.
 
 - **Examples**:
+
   ```javascript
   // BAD - Redundant comment
   // Add one to x
   x += 1;
-  
+
   // GOOD - Explains the non-obvious "why"
   // Increment before sending to API to account for zero-indexing
   x += 1;
@@ -166,7 +168,7 @@ The `src/tracing/` directory contains an OpenTelemetry-inspired tracing implemen
 The `src/browser/replay` directory contains the implementation of the Session Replay feature:
 
 - **Recorder**: Core class that integrates with rrweb to record DOM events
-- **ReplayMap**: Manages the mapping between error occurrences and session recordings
+- **ReplayManager**: Manages the mapping between error occurrences and session recordings
 - **Configuration**: Configurable options in `defaults.js` for replay behavior
 
 The Session Replay feature utilizes our tracing infrastructure to:
@@ -180,10 +182,10 @@ The Session Replay feature utilizes our tracing infrastructure to:
 ### Session Replay Flow
 
 1. **Recording**: The Recorder class continuously records DOM events using rrweb
-2. **Error Occurrence**: When an error occurs, Queue.addItem() calls ReplayMap.add()
-3. **Correlation**: ReplayMap generates a replayId and attaches it to the error
-4. **Coordination**: After successful error submission, Queue triggers ReplayMap.send()
-5. **Transport**: ReplayMap retrieves stored replay data and sends via api.postSpans()
+2. **Error Occurrence**: When an error occurs, Queue.addItem() calls ReplayManager.add()
+3. **Correlation**: ReplayManager generates a replayId and attaches it to the error
+4. **Coordination**: After successful error submission, Queue triggers ReplayManager.send()
+5. **Transport**: ReplayManager retrieves stored replay data and sends via api.postSpans()
 
 ### Testing Infrastructure
 

--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -14,7 +14,7 @@ import * as sharedPredicates from '../predicates.js';
 import errorParser from '../errorParser.js';
 import recorderDefaults from './replay/defaults.js';
 import tracingDefaults from '../tracing/defaults.js';
-import ReplayMap from './replay/replayMap.js';
+import ReplayManager from './replay/replayManager.js';
 
 function Rollbar(options, client) {
   this.options = _.handleOptions(defaultOptions, options, null, logger);
@@ -40,7 +40,7 @@ function Rollbar(options, client) {
   if (Recorder && _.isBrowser()) {
     const recorderOptions = this.options.recorder;
     this.recorder = new Recorder(recorderOptions);
-    this.replayMap = new ReplayMap({
+    this.replayManager = new ReplayManager({
       recorder: this.recorder,
       api: api,
       tracing: this.tracing,
@@ -60,7 +60,7 @@ function Rollbar(options, client) {
       logger,
       this.telemeter,
       this.tracing,
-      this.replayMap,
+      this.replayManager,
       'browser',
     );
   var gWindow = _gWindow();
@@ -615,7 +615,13 @@ function _gWindow() {
   );
 }
 
-import { version, logLevel, reportLevel, uncaughtErrorLevel, endpoint } from '../defaults.js';
+import {
+  version,
+  logLevel,
+  reportLevel,
+  uncaughtErrorLevel,
+  endpoint,
+} from '../defaults.js';
 import browserDefaults from './defaults.js';
 
 var defaultOptions = {

--- a/src/browser/replay/replayManager.js
+++ b/src/browser/replay/replayManager.js
@@ -2,11 +2,11 @@ import id from '../../tracing/id.js';
 import logger from '../logger.js';
 
 /**
- * ReplayMap - Manages the mapping between error occurrences and their associated
+ * ReplayManager - Manages the mapping between error occurrences and their associated
  * session recordings. This class handles the coordination between when recordings
  * are dumped and when they are eventually sent to the backend.
  */
-export default class ReplayMap {
+export default class ReplayManager {
   #map;
   #recorder;
   #api;
@@ -14,7 +14,7 @@ export default class ReplayMap {
   #telemeter;
 
   /**
-   * Creates a new ReplayMap instance
+   * Creates a new ReplayManager instance
    *
    * @param {Object} props - Configuration props
    * @param {Object} props.recorder - The recorder instance that dumps replay data into spans
@@ -53,7 +53,7 @@ export default class ReplayMap {
    */
   async _processReplay(replayId, occurrenceUuid) {
     try {
-      this.#telemeter?.exportTelemetrySpan({'rollbar.replay.id': replayId});
+      this.#telemeter?.exportTelemetrySpan({ 'rollbar.replay.id': replayId });
 
       const payload = this.#recorder.dump(
         this.#tracing,
@@ -103,12 +103,14 @@ export default class ReplayMap {
    */
   async send(replayId) {
     if (!replayId) {
-      logger.error('ReplayMap.send: No replayId provided');
+      logger.error('ReplayManager.send: No replayId provided');
       return false;
     }
 
     if (!this.#map.has(replayId)) {
-      logger.error(`ReplayMap.send: No replay found for replayId: ${replayId}`);
+      logger.error(
+        `ReplayManager.send: No replay found for replayId: ${replayId}`,
+      );
       return false;
     }
 
@@ -123,7 +125,7 @@ export default class ReplayMap {
 
     if (isEmpty) {
       logger.error(
-        `ReplayMap.send: No payload found for replayId: ${replayId}`,
+        `ReplayManager.send: No payload found for replayId: ${replayId}`,
       );
       return false;
     }
@@ -146,13 +148,13 @@ export default class ReplayMap {
    */
   discard(replayId) {
     if (!replayId) {
-      logger.error('ReplayMap.discard: No replayId provided');
+      logger.error('ReplayManager.discard: No replayId provided');
       return false;
     }
 
     if (!this.#map.has(replayId)) {
       logger.error(
-        `ReplayMap.discard: No replay found for replayId: ${replayId}`,
+        `ReplayManager.discard: No replay found for replayId: ${replayId}`,
       );
       return false;
     }

--- a/test/replay/integration/index.js
+++ b/test/replay/integration/index.js
@@ -4,6 +4,6 @@
 
 export * from './sessionRecording.test.js';
 export * from './api.spans.test.js';
-export * from './replayMap.test.js';
-export * from './queue.replayMap.test.js';
+export * from './replayManager.test.js';
+export * from './queue.replayManager.test.js';
 export * from './e2e.test.js';

--- a/test/replay/unit/index.js
+++ b/test/replay/unit/index.js
@@ -2,6 +2,6 @@
  * Session Replay Unit Tests
  */
 
-export * from './replayMap.test.js';
+export * from './replayManager.test.js';
 export * from './api.postSpans.test.js';
-export * from './queue.replayMap.test.js';
+export * from './queue.replayManager.test.js';

--- a/test/replay/unit/replayPredicates.test.js
+++ b/test/replay/unit/replayPredicates.test.js
@@ -2,11 +2,10 @@
  * Unit tests for the ReplayPredicates module
  */
 
-
 import { expect } from 'chai';
 import ReplayPredicates from '../../../src/browser/replay/replayPredicates.js';
 
-describe('ReplayMap', function () {
+describe('ReplayManager', function () {
   let replayId;
   let recorderConfig;
 
@@ -22,7 +21,7 @@ describe('ReplayMap', function () {
               samplingRatio: 0.5,
             },
           ],
-        }
+        };
       });
 
       it('should return true on matching level', function () {
@@ -30,10 +29,10 @@ describe('ReplayMap', function () {
           level: 'error',
         };
 
-        const enabled = new ReplayPredicates(
-          recorderConfig,
-          { item, replayId },
-        ).isEnabledForTriggerType('occurrence')
+        const enabled = new ReplayPredicates(recorderConfig, {
+          item,
+          replayId,
+        }).isEnabledForTriggerType('occurrence');
         expect(enabled).to.be.true;
       });
 
@@ -42,10 +41,10 @@ describe('ReplayMap', function () {
           level: 'info',
         };
 
-        const enabled = new ReplayPredicates(
-          recorderConfig,
-          { item, replayId },
-        ).isEnabledForTriggerType('occurrence')
+        const enabled = new ReplayPredicates(recorderConfig, {
+          item,
+          replayId,
+        }).isEnabledForTriggerType('occurrence');
         expect(enabled).to.be.false;
       });
 
@@ -55,10 +54,10 @@ describe('ReplayMap', function () {
         };
         recorderConfig.triggers[0].level = undefined;
 
-        const enabled = new ReplayPredicates(
-          recorderConfig,
-          { item, replayId },
-        ).isEnabledForTriggerType('occurrence')
+        const enabled = new ReplayPredicates(recorderConfig, {
+          item,
+          replayId,
+        }).isEnabledForTriggerType('occurrence');
         expect(enabled).to.be.true;
       });
 
@@ -72,10 +71,10 @@ describe('ReplayMap', function () {
           samplingRatio: 0.5,
         });
 
-        const enabled = new ReplayPredicates(
-          recorderConfig,
-          { item, replayId },
-        ).isEnabledForTriggerType('occurrence')
+        const enabled = new ReplayPredicates(recorderConfig, {
+          item,
+          replayId,
+        }).isEnabledForTriggerType('occurrence');
         expect(enabled).to.be.true;
       });
 
@@ -85,10 +84,10 @@ describe('ReplayMap', function () {
         };
         recorderConfig.triggers[0].samplingRatio = undefined;
 
-        const enabled = new ReplayPredicates(
-          recorderConfig,
-          { item, replayId },
-        ).isEnabledForTriggerType('occurrence')
+        const enabled = new ReplayPredicates(recorderConfig, {
+          item,
+          replayId,
+        }).isEnabledForTriggerType('occurrence');
         expect(enabled).to.be.true;
       });
 
@@ -98,10 +97,10 @@ describe('ReplayMap', function () {
         };
         recorderConfig.triggers[0].samplingRatio = 0.1;
 
-        const enabled = new ReplayPredicates(
-          recorderConfig,
-          { item, replayId },
-        ).isEnabledForTriggerType('occurrence')
+        const enabled = new ReplayPredicates(recorderConfig, {
+          item,
+          replayId,
+        }).isEnabledForTriggerType('occurrence');
         expect(enabled).to.be.false;
       });
 
@@ -112,10 +111,10 @@ describe('ReplayMap', function () {
         recorderConfig.baseSamplingRatio = 0.1;
         recorderConfig.triggers[0].samplingRatio = undefined;
 
-        const enabled = new ReplayPredicates(
-          recorderConfig,
-          { item, replayId },
-        ).isEnabledForTriggerType('occurrence')
+        const enabled = new ReplayPredicates(recorderConfig, {
+          item,
+          replayId,
+        }).isEnabledForTriggerType('occurrence');
         expect(enabled).to.be.false;
       });
 
@@ -125,10 +124,10 @@ describe('ReplayMap', function () {
         };
         recorderConfig.baseSamplingRatio = 0.1;
 
-        const enabled = new ReplayPredicates(
-          recorderConfig,
-          { item, replayId },
-        ).isEnabledForTriggerType('occurrence')
+        const enabled = new ReplayPredicates(recorderConfig, {
+          item,
+          replayId,
+        }).isEnabledForTriggerType('occurrence');
         expect(enabled).to.be.true;
       });
 
@@ -137,10 +136,10 @@ describe('ReplayMap', function () {
           level: 'error',
         };
 
-        const enabled = new ReplayPredicates(
-          null,
-          { item, replayId },
-        ).isEnabledForTriggerType('occurrence')
+        const enabled = new ReplayPredicates(null, {
+          item,
+          replayId,
+        }).isEnabledForTriggerType('occurrence');
         expect(enabled).to.be.false;
       });
 
@@ -150,13 +149,12 @@ describe('ReplayMap', function () {
         };
         recorderConfig.triggers = null;
 
-        const enabled = new ReplayPredicates(
-          recorderConfig,
-          { item, replayId },
-        ).isEnabledForTriggerType('occurrence')
+        const enabled = new ReplayPredicates(recorderConfig, {
+          item,
+          replayId,
+        }).isEnabledForTriggerType('occurrence');
         expect(enabled).to.be.false;
       });
-
     });
   });
 });


### PR DESCRIPTION
## Description of the change

This PR renames the `ReplayMap` to `ReplayManager` due to its nature changing from a mapping of occurrences to replays to an orchestrator between the different components that make up the Session Replay feature (Replays, Recorder, Telemetry, Tracing and API).

No code documentation hasn't been changed in this PR.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
