### PR TITLE
Telemetry: enable dom events

### DIFF
--- a/src/browser/domUtility.js
+++ b/src/browser/domUtility.js
@@ -65,6 +65,10 @@ function elementArrayToString(a) {
   return out.join(separator);
 }
 
+function elementString(elem) {
+  return elementArrayToString(treeToArray(elem));
+};
+
 function descriptionToString(desc) {
   if (!desc || !desc.tagName) {
     return '';
@@ -133,6 +137,7 @@ export {
   describeElement,
   descriptionToString,
   elementArrayToString,
+  elementString,
   treeToArray,
   getElementFromEvent,
   isDescribedElement,

--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -683,7 +683,7 @@ class Instrumenter {
 
   handleFocus(evt) {
     const type = evt.type;
-    const element = evt.target.window ? 'window' : domUtil.elementString(evt.target);
+    const element = evt.target?.window ? 'window' : domUtil.elementString(evt.target);
 
     this.telemeter.captureFocus({
       type: type,
@@ -696,7 +696,7 @@ class Instrumenter {
   handleForm(evt) {
     // TODO: implement form event handling
     const type = evt.type;
-    const elementString = evt.target.window ? 'window' : domUtil.elementString(evt.target);
+    const elementString = evt.target?.window ? 'window' : domUtil.elementString(evt.target);
     console.log('handleForm', type, elementString, evt);
   }
 
@@ -721,7 +721,6 @@ class Instrumenter {
       kinds = [];
       mediaTypes = [];
       const objs = [...evt.dataTransfer.files, ...evt.dataTransfer.items];
-      //const objs = Array.from(evt.dataTransfer.files) || Array.from(evt.dataTransfer.items);
       for (const o of objs) {
         if (o.kind && o.type) {
           kinds.push(o.kind);

--- a/src/browser/telemetry.js
+++ b/src/browser/telemetry.js
@@ -640,82 +640,142 @@ class Instrumenter {
   };
 
   instrumentDom() {
-    if (!('addEventListener' in this._window || 'attachEvent' in this._window)) {
-      return;
-    }
-    const clickHandler = this.handleClick.bind(this);
-    const blurHandler = this.handleBlur.bind(this);
-    this.addListener('dom', this._window, 'click', clickHandler, true);
+    const self = this;
+    this.addListener('dom', this._window, ['click', 'dblclick', 'contextmenu'], (e) => this.handleEvent('click', e));
     this.addListener(
       'dom',
       this._window,
-      'blur',
-      blurHandler,
-      true,
+      ['dragstart', 'dragend', 'dragenter', 'dragleave', 'drop'],
+      (e) => this.handleEvent('dragdrop', e)
     );
+    this.addListener('dom', this._window, ['blur', 'focus'], (e) => this.handleEvent('focus', e));
+    this.addListener('dom', this._window, ['submit', 'invalid'], (e) => this.handleEvent('form', e));
+    this.addListener('dom', this._window, ['input', 'change'], (e) => this.handleEvent('input', e));
+    this.addListener('dom', this._window, ['resize'], (e) => this.handleEvent('resize', e));
+  }
+
+  handleEvent(name, evt) {
+    try {
+      return {
+        click: this.handleClick,
+        dragdrop: this.handleDrag,
+        focus: this.handleFocus,
+        form: this.handleForm,
+        input: this.handleInput,
+        resize: this.handleResize,
+      }[name].call(this, evt);
+    } catch (exc) {
+      console.log(`${name} handler error`, evt, exc, exc.stack);
+    }
   }
 
   handleClick(evt) {
-    try {
-      const e = domUtil.getElementFromEvent(evt, this._document);
-      const hasTag = e && e.tagName;
-      const anchorOrButton =
-        domUtil.isDescribedElement(e, 'a') ||
-        domUtil.isDescribedElement(e, 'button');
-      if (
-        hasTag &&
-        (anchorOrButton ||
-          domUtil.isDescribedElement(e, 'input', ['button', 'submit']))
-      ) {
-        this.captureDomEvent('click', e);
-      } else if (domUtil.isDescribedElement(e, 'input', ['checkbox', 'radio'])) {
-        this.captureDomEvent('input', e, e.value, e.checked);
-      }
-    } catch (exc) {
-      // TODO: Not sure what to do here
-    }
+    const tagName = evt.target?.tagName.toLowerCase();
+    if (['input', 'select', 'textarea'].includes(tagName)) return;
+
+    this.telemeter.captureClick({
+      type: evt.type,
+      isSynthetic: !evt.isTrusted,
+      element: domUtil.elementString(evt.target),
+      timestamp: _.now(),
+    })
   }
 
-  handleBlur(evt) {
-    try {
-      const e = domUtil.getElementFromEvent(evt, this._document);
-      if (e && e.tagName) {
-        if (domUtil.isDescribedElement(e, 'textarea')) {
-          this.captureDomEvent('input', e, e.value);
-        } else if (
-          domUtil.isDescribedElement(e, 'select') &&
-          e.options &&
-          e.options.length
-        ) {
-          this.handleSelectInputChanged(e);
-        } else if (
-          domUtil.isDescribedElement(e, 'input') &&
-          !domUtil.isDescribedElement(e, 'input', [
-            'button',
-            'submit',
-            'hidden',
-            'checkbox',
-            'radio',
-          ])
-        ) {
-          this.captureDomEvent('input', e, e.value);
-        }
-      }
-    } catch (exc) {
-      // TODO: Not sure what to do here
-    }
+  handleFocus(evt) {
+    const type = evt.type;
+    const element = evt.target.window ? 'window' : domUtil.elementString(evt.target);
+
+    this.telemeter.captureFocus({
+      type: type,
+      isSynthetic: !evt.isTrusted,
+      element,
+      timestamp: _.now(),
+    })
   }
 
-  handleSelectInputChanged(elem) {
-    if (elem.multiple) {
-      for (const o of elem.options) {
-        if (o.selected) {
-          this.captureDomEvent('input', elem, o.value);
+  handleForm(evt) {
+    const type = evt.type;
+    const elementString = evt.target.window ? 'window' : domUtil.elementString(evt.target);
+    console.log('handleForm', type, elementString, evt);
+  }
+
+  handleResize(evt) {
+    const textZoomRatio = window.screen.width / window.innerWidth;
+
+    this.telemeter.captureResize({
+      type: evt.type,
+      isSynthetic: !evt.isTrusted,
+      width: window.innerWidth,
+      height: window.innerHeight,
+      textZoomRatio: textZoomRatio,
+      timestamp: _.now(),
+    })
+  }
+
+  handleDrag(evt) {
+    const type = evt.type;
+    let kinds, mediaTypes, dropEffect, effectAllowed;
+
+    if (type === 'drop') {
+      kinds = [];
+      mediaTypes = [];
+      const objs = [...evt.dataTransfer.files, ...evt.dataTransfer.items];
+      //const objs = Array.from(evt.dataTransfer.files) || Array.from(evt.dataTransfer.items);
+      for (const o of objs) {
+        if (o.kind && o.type) {
+          kinds.push(o.kind);
+          mediaTypes.push(o.type);
         }
       }
-    } else if (elem.selectedIndex >= 0 && elem.options[elem.selectedIndex]) {
-      this.captureDomEvent('input', elem, elem.options[elem.selectedIndex].value);
     }
+    if (['drop', 'dragstart'].includes(type)) {
+      dropEffect = evt.dataTransfer?.dropEffect;
+      effectAllowed = evt.dataTransfer?.effectAllowed;
+    }
+
+    this.telemeter.captureDragDrop({
+      type,
+      isSynthetic: !evt.isTrusted,
+      element: domUtil.elementString(evt.target),
+      dropEffect: dropEffect,
+      effectAllowed: effectAllowed,
+      kinds: JSON.stringify(kinds),
+      mediaTypes: JSON.stringify(mediaTypes),
+      timestamp: _.now(),
+    });
+  }
+
+  handleInput(evt) {
+    const type = evt.type;
+    const tagName = evt.target?.tagName.toLowerCase();
+    let value = evt.target?.value;
+    let inputType;
+
+    switch (tagName) {
+      case 'select':
+      case 'textarea':
+        if (type === 'change') return;
+        inputType = tagName;
+        break;
+      case 'input':
+        inputType = evt.target?.attributes?.type?.value || evt.target?.type;
+        if (inputType === 'password') value = null;
+        if (['radio', 'checkbox'].includes(inputType)) {
+          if (type === 'input') return;
+          if (inputType === 'checkbox') value = evt.target?.checked;
+          break;
+        }
+        if (type === 'change') return;
+        break;
+    }
+
+    this.telemeter.captureInput({
+      type: inputType,
+      isSynthetic: !evt.isTrusted,
+      element: domUtil.elementString(evt.target),
+      value,
+      timestamp: _.now(),
+    })
   }
 
   captureDomEvent(
@@ -831,23 +891,12 @@ class Instrumenter {
   }
 
   instrumentConnectivity() {
+    const self = this;
     this.addListener(
       'connectivity',
       this._window,
-      'online',
-      function () {
-        this.telemeter.captureConnectivityChange('online');
-      }.bind(this),
-      true,
-    );
-    this.addListener(
-      'connectivity',
-      this._window,
-      'offline',
-      function () {
-        this.telemeter.captureConnectivityChange('offline');
-      }.bind(this),
-      true,
+      ['online', 'offline'],
+      (evt) => self.telemeter.captureConnectivityChange(evt),
     );
   }
 
@@ -902,24 +951,25 @@ class Instrumenter {
     this.addListener(
       'contentsecuritypolicy',
       this._document,
-      'securitypolicyviolation',
+      ['securitypolicyviolation'],
       cspHandler,
-      false,
     );
   }
 
   addListener(
     section,
     obj,
-    type,
+    types,
     handler,
-    capture,
   ) {
     if (obj.addEventListener) {
-      obj.addEventListener(type, handler, capture);
-      this.eventRemovers[section].push(function () {
-        obj.removeEventListener(type, handler, capture);
-      });
+      for (const t of types) {
+        const options = { capture: true, passive: true };
+        obj.addEventListener(t, handler, options, true);
+        this.eventRemovers[section].push(function () {
+          obj.removeEventListener(t, handler, options);
+        });
+      }
     }
   }
 

--- a/test/browser.telemetry.test.js
+++ b/test/browser.telemetry.test.js
@@ -1,6 +1,10 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import Telemeter from '../src/telemetry.js';
+import Tracing from '../src/tracing/tracing.js';
 import Instrumenter from '../src/browser/telemetry.js';
+import Rollbar from '../src/browser/core.js';
+import { loadHtml } from './util/fixtures.js';
 
 describe('instrumentNetwork', function () {
   it('should capture XHR requests with string URL', function (done) {
@@ -60,6 +64,153 @@ describe('instrumentNetwork', function () {
     expect(callback.args[1][0].url).to.eql('http://second.call/');
 
     done();
+  });
+});
+
+describe('instrumentDom', function () {
+  let tracing, telemeter, instrumenter, rollbar, scrubFields;
+  const wait = t => new Promise(resolve => setTimeout(resolve, t));
+
+  beforeEach(async function () {
+    await loadHtml('test/fixtures/html/dom-events.html');
+    scrubFields = ['foo', 'bar'];
+    rollbar = new Rollbar({})
+    tracing = new Tracing(window, {})
+    tracing.initSession();
+    telemeter = new Telemeter({}, tracing);
+    instrumenter = new Instrumenter(
+      {scrubFields, autoInstrument: {log: false}},
+      telemeter,
+      rollbar,
+      window
+    );
+    instrumenter.instrument();
+  });
+
+  it('should handle drag drop events', async function () {
+    const draggable = document.getElementById("draggable");
+    const dropzone = document.getElementById("dropzone");
+    console.log('elements', draggable, dropzone);
+
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData('text/plain', 'some data');
+
+    const dragEvent = new DragEvent('dragstart', { dataTransfer: dataTransfer });
+    draggable.dispatchEvent(dragEvent);
+
+    const dragOverEvent = new DragEvent('dragover', {
+      dataTransfer: dataTransfer,
+      bubbles: true,
+      cancelable: true
+    });
+    dragOverEvent.preventDefault = () => {};
+    dropzone.dispatchEvent(dragOverEvent);
+
+    const dropEvent = new DragEvent('drop', {
+      dataTransfer: dataTransfer,
+      bubbles: true,
+      cancelable: true
+    });
+    dropEvent.preventDefault = () => {};
+    dropzone.dispatchEvent(dropEvent);
+
+    await wait(1000);
+
+    console.log('telemeter queue', telemeter.queue);
+    expect(telemeter.queue.length).to.eql(2);
+    const events = telemeter.queue;
+
+    expect(events[0].type).to.eql('dom');
+    expect(events[0].body.type).to.eql('rollbar-dragdrop-event');
+    expect(events[0].body.subtype).to.eql('dragstart');
+    expect(events[0].body.element).to.match(/p#draggable/);
+
+    expect(events[0].otelAttributes.type).to.eql('dragstart');
+    expect(events[0].otelAttributes.isSynthetic).to.eql(true);
+    expect(events[0].otelAttributes.element).to.match(/p#draggable/);
+
+    expect(events[1].type).to.eql('dom');
+    expect(events[1].body.type).to.eql('rollbar-dragdrop-event');
+    expect(events[1].body.subtype).to.eql('drop');
+    expect(events[1].body.element).to.match(/div#dropzone/);
+
+    expect(events[1].otelAttributes.type).to.eql('drop');
+    expect(events[1].otelAttributes.isSynthetic).to.eql(true);
+    expect(events[1].otelAttributes.element).to.match(/div#dropzone/);
+    expect(events[1].otelAttributes.kinds).to.eql('["string"]');
+    expect(events[1].otelAttributes.mediaTypes).to.eql('["text/plain"]');
+    expect(events[1].otelAttributes.dropEffect).to.eql('none');
+    expect(events[1].otelAttributes.effectAllowed).to.eql('none');
+  });
+
+  it('should combine repeated click events', async function () {
+    const elem = document.getElementById("button-1");
+
+    const pointerOptions = {
+      pointerId: 1,
+      bubbles: true,
+      cancelable: true,
+      pointerType: "touch",
+      isPrimary: true,
+    }
+    let domEvent = new PointerEvent('click', pointerOptions);
+    elem.dispatchEvent(domEvent);
+
+    domEvent = new PointerEvent('click', pointerOptions);
+    elem.dispatchEvent(domEvent);
+
+    domEvent = new PointerEvent('click', pointerOptions);
+    elem.dispatchEvent(domEvent);
+
+    await wait(1000);
+
+    expect(telemeter.queue.length).to.eql(1);
+    const event = telemeter.queue[0];
+    expect(event.type).to.eql('dom');
+    expect(event.body.type).to.eql('rollbar-click-event');
+    expect(event.body.subtype).to.eql('click');
+    expect(event.body.element).to.match(/button#button-1.myButton/);
+
+    expect(event.otelAttributes.type).to.eql('click');
+    expect(event.otelAttributes.isSynthetic).to.eql(true);
+    expect(event.otelAttributes.element).to.match(/button#button-1.myButton/);
+    expect(event.otelAttributes.endTimeUnixNano[0]).to.be.a('number');
+    expect(event.otelAttributes.endTimeUnixNano[1]).to.be.a('number');
+    expect(event.otelAttributes.count).to.eql(3);
+  });
+
+  it('should combine repeated input events', async function () {
+    const elem = document.getElementById("text-input");
+
+    let domEvent = new InputEvent('input');
+    elem.value = 'a';
+    elem.dispatchEvent(domEvent);
+
+    domEvent = new InputEvent('input');
+    elem.value = 'ab';
+    elem.dispatchEvent(domEvent);
+
+    domEvent = new InputEvent('input');
+    elem.value = 'abc';
+    elem.dispatchEvent(domEvent);
+
+    await wait(1000);
+
+    expect(telemeter.queue.length).to.eql(1);
+    const event = telemeter.queue[0];
+    expect(event.type).to.eql('dom');
+    expect(event.body.type).to.eql('rollbar-input-event');
+    expect(event.body.subtype).to.eql('text');
+    expect(event.body.element).to.match(/input#text-input\[type=\"text\"\]/);
+    expect(event.body.value).to.eql('abc');
+
+    expect(event.otelAttributes.type).to.eql('text');
+    expect(event.otelAttributes.isSynthetic).to.eql(true);
+    expect(event.otelAttributes.element).to.match(/input#text-input\[type=\"text\"\]/);
+    expect(event.otelAttributes.value).to.eql('abc');
+    expect(event.otelAttributes.endTimeUnixNano[0]).to.be.a('number');
+    expect(event.otelAttributes.endTimeUnixNano[1]).to.be.a('number');
+    expect(event.otelAttributes.count).to.eql(3);
   });
 });
 

--- a/test/fixtures/html/dom-events.html
+++ b/test/fixtures/html/dom-events.html
@@ -6,33 +6,37 @@
   </head>
   <body>
     <div class="container" id"main-container">
+      <label>
+        Some text:
+        <input id="text-input"  type="text" placeholder="text input" />
+      </label>
       <button class="myButton" id="button-1" >Button</button>
       <p id="draggable" draggable="true">This element is draggable.</p>
       <div id="dropzone">
         Drop Zone
       </div>
-      <form class="simple-form" id="form">
-        <label>
-          Some text:
-          <input id="text-input"  type="text" placeholder="text input" />
-        </label>
-        <label>
-          Password:
-          <input type="password" placeholder="password" />
-        </label>
-      </form>
+      <select id="fruit-select" name="selectedFruit">
+        <option value="">--Please choose an option--</option>
+        <option value="apple">Apple</option>
+        <option value="banana">Banana</option>
+        <option value="orange">Orange</option>
+        <option value="grape">Grape</option>
+      </select>
       <label>
-        Description:
-        <textarea placeholder="description" />
-      </label>
-      <label>
-        <input
+        <input id="remember-me-checkbox"
           type="checkbox"
-          checked={isChecked}
-          onChange={handleCheckboxChange}
         />
         Remember me
       </label>
+      <label>
+        Password:
+        <input  id="password-input" type="password" placeholder="password" />
+      </label>
+      <label>
+        Description:
+        <textarea id="textarea-1" placeholder="description" />
+      </label>
+
       <label>
         <input
           type="radio"
@@ -57,13 +61,6 @@
         />
         Option C
       </label>
-      <select id="fruit-select" name="selectedFruit">
-        <option value="">--Please choose an option--</option>
-        <option value="apple">Apple</option>
-        <option value="banana">Banana</option>
-        <option value="orange">Orange</option>
-        <option value="grape">Grape</option>
-      </select>
     </div>
   </body>
 

--- a/test/fixtures/html/dom-events.html
+++ b/test/fixtures/html/dom-events.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Elements for testing DOM event handling</title>
+  </head>
+  <body>
+    <div class="container" id"main-container">
+      <button class="myButton" id="button-1" >Button</button>
+      <p id="draggable" draggable="true">This element is draggable.</p>
+      <div id="dropzone">
+        Drop Zone
+      </div>
+      <form class="simple-form" id="form">
+        <label>
+          Some text:
+          <input id="text-input"  type="text" placeholder="text input" />
+        </label>
+        <label>
+          Password:
+          <input type="password" placeholder="password" />
+        </label>
+      </form>
+      <label>
+        Description:
+        <textarea placeholder="description" />
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          checked={isChecked}
+          onChange={handleCheckboxChange}
+        />
+        Remember me
+      </label>
+      <label>
+        <input
+          type="radio"
+          value="optionA"
+          name="myRadioGroup" // Important: Same name for all radio buttons in a group
+        />
+        Option A
+      </label>
+      <label>
+        <input
+          type="radio"
+          value="optionB"
+          name="myRadioGroup"
+        />
+        Option B
+      </label>
+      <label>
+        <input
+          type="radio"
+          value="optionC"
+          name="myRadioGroup"
+        />
+        Option C
+      </label>
+      <select id="fruit-select" name="selectedFruit">
+        <option value="">--Please choose an option--</option>
+        <option value="apple">Apple</option>
+        <option value="banana">Banana</option>
+        <option value="orange">Orange</option>
+        <option value="grape">Grape</option>
+      </select>
+    </div>
+  </body>
+
+</html>


### PR DESCRIPTION
## Description of the change

Enables telemetry events for DOM events
* Input
* Click
* Focus
* Resize

And updates the connectivity event.

## Type of change

- [x] New feature (non-breaking change that adds functionality)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


