### PR TITLE
Enable attributes on the session, and send as span attributes on replay

### DIFF
--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -92,7 +92,10 @@ export default class Recorder {
 
     const recordingSpan = tracing.startSpan('rrweb-replay-recording', {});
 
-    recordingSpan.setAttribute('rollbar.replay.id', replayId);
+    recordingSpan.setAttributes({
+      ...(tracing.session?.attributes ?? {}),
+      'rollbar.replay.id': replayId
+    });
 
     if (occurrenceUuid) {
       recordingSpan.setAttribute('rollbar.occurrence.uuid', occurrenceUuid);

--- a/src/tracing/session.js
+++ b/src/tracing/session.js
@@ -3,11 +3,14 @@ import id from './id.js';
 const SESSION_KEY = 'RollbarSession';
 
 export class Session {
+  #attributes;
+
   constructor(tracing, options) {
     this.options = options;
     this.tracing = tracing;
     this.window = tracing.window;
     this.session = null;
+    this.#attributes = {};
   }
 
   init() {
@@ -51,5 +54,13 @@ export class Session {
     }
     return this;
   }
-}
 
+  get attributes() {
+    return this.#attributes;
+  }
+
+  setAttributes(attributes) {
+    this.#attributes = { ...this.#attributes, ...attributes };
+    return this;
+  }
+}

--- a/test/browser.replay.recorder.test.js
+++ b/test/browser.replay.recorder.test.js
@@ -15,7 +15,7 @@ describe('Recorder', function () {
   beforeEach(function () {
     mockSpan = {
       addEvent: sinon.spy(),
-      setAttribute: sinon.spy(),
+      setAttributes: sinon.spy(),
       span: { startTime: null },
       end: sinon.spy(),
     };
@@ -148,8 +148,8 @@ describe('Recorder', function () {
 
       // Event count includes the custom end event
       expect(mockSpan.addEvent.calledThrice).to.be.true;
-      expect(mockSpan.setAttribute.calledOnce).to.be.true;
-      expect(mockSpan.setAttribute.calledWith('rollbar.replay.id', testReplayId)).to.be.true;
+      expect(mockSpan.setAttributes.calledOnce).to.be.true;
+      expect(mockSpan.setAttributes.calledWith({'rollbar.replay.id': testReplayId})).to.be.true;
 
       const firstCallData = mockSpan.addEvent.firstCall.args[1];
       expect(firstCallData.eventType).to.equal('event1');

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -126,6 +126,11 @@ describe('Session Replay E2E', function () {
         },
       };
 
+      tracing.session.setAttributes({
+        'user.id': '12345',
+        'user.email': 'aaa@bb.com',
+      });
+
       queue.addItem(errorItem, function (err, resp) {
         expect(errorItem).to.have.property('replayId');
         const expectedReplayId = errorItem.replayId;
@@ -163,11 +168,19 @@ describe('Session Replay E2E', function () {
           expect(span_r).to.have.property('events');
           expect(span_r.events).to.be.an('array');
           expect(span_r).to.have.property('attributes').that.is.an('array');
-          expect(span_r.attributes).to.have.lengthOf(2);
+          expect(span_r.attributes).to.have.lengthOf(4);
 
           expect(span_r.attributes).to.deep.include({
             key: 'rollbar.replay.id',
             value: { stringValue: expectedReplayId },
+          });
+          expect(span_r.attributes).to.deep.include({
+            key: 'user.id',
+            value: { stringValue: '12345' },
+          });
+          expect(span_r.attributes).to.deep.include({
+            key: 'user.email',
+            value: { stringValue: 'aaa@bb.com' },
           });
 
           const sessionIdAttr = span_r.attributes.find(

--- a/test/tracing/tracing.test.js
+++ b/test/tracing/tracing.test.js
@@ -96,6 +96,24 @@ describe('Tracing()', function () {
     done();
   });
 
+  it('should get and set session attributes', function () {
+    const options = tracingOptions();
+    const t = new Tracing(window, options);
+    t.initSession();
+
+    t.session.setAttributes({codeVersion: 'abc123'});
+    t.session.setAttributes({
+      'user.id': '12345',
+      'user.email': 'aaa@bb.com',
+    });
+
+    expect(t.session.attributes).to.deep.equal({
+      codeVersion: 'abc123',
+      'user.id': '12345',
+      'user.email': 'aaa@bb.com',
+    });
+  });
+
   it('should generate ids', function (done) {
     const options = tracingOptions();
     const t = new Tracing(window, options);


### PR DESCRIPTION
## Description of the change

Enables attributes on the session instance, and updates the recorder to add session attributes to the replay span as span attributes.

## Type of change

- [x] New feature (non-breaking change that adds functionality)

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


