### PR TITLE
Remove console log leftover from tracing exporter

### DIFF
--- a/src/tracing/exporter.js
+++ b/src/tracing/exporter.js
@@ -12,7 +12,6 @@ export class SpanExporter {
    * @param {Function} _resultCallback - Optional callback (not used)
    */
   export(spans, _resultCallback) {
-    console.log(spans); // console exporter, TODO: make optional
     spanExportQueue.push(...spans);
   }
 


### PR DESCRIPTION
## Description of the change

This pull request makes a small change to the `SpanExporter` class by removing a debugging `console.log` statement from the `export` method. This helps clean up console output and prepares the exporter for production use.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release

## Related issues

[CAT-476/session-replay-has-introduced-console-spam](https://linear.app/rollbar-inc/issue/CAT-476/session-replay-has-introduced-console-spam)

Fixes https://github.com/rollbar/rollbar.js/issues/1314.
