### PR TITLE
Change all octothorpes # to _ since private # is only >=ES2022

### DIFF
--- a/src/telemetry.js
+++ b/src/telemetry.js
@@ -273,9 +273,9 @@ class Telemeter {
       value,
       endTimeUnixNano: fromMillis(timestamp),
     };
-    const event = this.#getRepeatedEvent(name, otelAttributes);
+    const event = this._getRepeatedEvent(name, otelAttributes);
     if (event) {
-      return this.#updateRepeatedEvent(event, otelAttributes, timestamp);
+      return this._updateRepeatedEvent(event, otelAttributes, timestamp);
     }
 
     this.telemetrySpan?.addEvent(
@@ -312,9 +312,9 @@ class Telemeter {
       element,
       endTimeUnixNano: fromMillis(timestamp),
     };
-    const event = this.#getRepeatedEvent(name, otelAttributes);
+    const event = this._getRepeatedEvent(name, otelAttributes);
     if (event) {
-      return this.#updateRepeatedEvent(event, otelAttributes, timestamp);
+      return this._updateRepeatedEvent(event, otelAttributes, timestamp);
     }
 
     this.telemetrySpan?.addEvent(
@@ -333,15 +333,15 @@ class Telemeter {
     );
   }
 
-  #getRepeatedEvent(name, attributes) {
-    const lastEvent = this.#lastEvent(this.queue);
+  _getRepeatedEvent(name, attributes) {
+    const lastEvent = this._lastEvent(this.queue);
 
     if (lastEvent && lastEvent.body.type === name && lastEvent.otelAttributes.target === attributes.target) {
       return lastEvent;
     }
   }
 
-  #updateRepeatedEvent(event, attributes, timestamp) {
+  _updateRepeatedEvent(event, attributes, timestamp) {
     const duration = Math.max(timestamp - event.timestamp_ms, 1);
     event.body.value = attributes.value;
     event.otelAttributes.value = attributes.value;
@@ -354,7 +354,7 @@ class Telemeter {
     event.otelAttributes.ratio = event.otelAttributes.count / (duration / 1000);
   }
 
-  #lastEvent(list) {
+  _lastEvent(list) {
     return list.length > 0 ? list[list.length - 1] : null;
   }
 
@@ -416,9 +416,9 @@ class Telemeter {
       textZoomRatio,
     };
 
-    const event = this.#getRepeatedEvent(name, otelAttributes);
+    const event = this._getRepeatedEvent(name, otelAttributes);
     if (event) {
-      return this.#updateRepeatedEvent(event, otelAttributes, timestamp);
+      return this._updateRepeatedEvent(event, otelAttributes, timestamp);
     }
 
     this.telemetrySpan?.addEvent(

--- a/src/tracing/session.js
+++ b/src/tracing/session.js
@@ -3,14 +3,14 @@ import id from './id.js';
 const SESSION_KEY = 'RollbarSession';
 
 export class Session {
-  #attributes;
+  _attributes;
 
   constructor(tracing, options) {
     this.options = options;
     this.tracing = tracing;
     this.window = tracing.window;
     this.session = null;
-    this.#attributes = {};
+    this._attributes = {};
   }
 
   init() {
@@ -56,11 +56,11 @@ export class Session {
   }
 
   get attributes() {
-    return this.#attributes;
+    return this._attributes;
   }
 
   setAttributes(attributes) {
-    this.#attributes = { ...this.#attributes, ...attributes };
+    this._attributes = { ...this._attributes, ...attributes };
     return this;
   }
 }


### PR DESCRIPTION
## Description of the change

Users upgrading to v3.0.0-beta.2 encountered build failures with the following error:
```
SyntaxError: Class private methods are not enabled. Please add `@babel/plugin-transform-private-methods` to your configuration.
```

This occurred when bundlers (like Next.js, Vite, or custom Webpack configs) attempted to process our source files that contained *ES2022* private class fields and methods (`#privateField`).

Since our SDK transpiles *ES2021* into *ES5* for broad compatibility, we cannot use syntax that requires additional Babel plugins that users may not have configured.

This PR replaces all private class syntax (`#`) with the underscore convention (`_`) to maintain backward compatibility while preserving the intended encapsulation pattern.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Slack thread 1: https://rollbar.slack.com/archives/C07VAUL1954/p1758315757966889
- Slack thread 2: https://rollbar.slack.com/archives/C07VAUL1954/p1758317323563399?thread_ts=1758312335.608189&cid=C07VAUL1954