### PR TITLE
Use Date.now() by default, make performnce api optional

### DIFF
--- a/src/tracing/hrtime.js
+++ b/src/tracing/hrtime.js
@@ -50,12 +50,15 @@ function add(a, b) {
 /**
  * Get the current high-resolution time as an OpenTelemetry hrtime tuple.
  *
- * Uses the Performance API (timeOrigin + now()).
+ * @param {boolean} usePerformance=false - If true, uses the Performance API (timeOrigin + now()).
  *
  * @returns {[number, number]} The current hrtime tuple [s, ns].
  */
-function now() {
-  return add(fromMillis(performance.timeOrigin), fromMillis(performance.now()));
+function now(usePerformance = false) {
+  if (usePerformance) {
+    return add(fromMillis(performance.timeOrigin), fromMillis(performance.now()));
+  }
+  return fromMillis(Date.now());
 }
 
 /**

--- a/src/tracing/span.js
+++ b/src/tracing/span.js
@@ -2,6 +2,7 @@ import hrtime from './hrtime.js';
 
 export class Span {
   constructor(options) {
+    this.usePerformance = options.usePerformance;
     this.initReadableSpan(options);
 
     this.spanProcessor = options.spanProcessor;
@@ -19,7 +20,7 @@ export class Span {
       kind: options.kind,
       spanContext: options.spanContext,
       parentSpanId: options.parentSpanId,
-      startTime: options.startTime || hrtime.now(),
+      startTime: options.startTime || hrtime.now(options.usePerformance),
       endTime: [0, 0],
       status: { code: 0, message: '' },
       attributes: { 'session.id': options.session.id },
@@ -81,7 +82,7 @@ export class Span {
 
   end(attributes, time) {
     if (attributes) this.setAttributes(attributes);
-    this.span.endTime = time || hrtime.now();
+    this.span.endTime = time || hrtime.now(this.usePerformance);
     this.span.ended = true;
     this.spanProcessor.onEnd(this);
   }

--- a/src/tracing/tracer.js
+++ b/src/tracing/tracer.js
@@ -41,6 +41,7 @@ export class Tracer {
       parentSpanId,
       spanProcessor: this.spanProcessor,
       startTime: options.startTime,
+      usePerformance: options.usePerformance,
     });
     return span;
   }


### PR DESCRIPTION
## Description of the change

The performance counter stops counting during sleep on many, if not most, browsers.
* https://developer.mozilla.org/en-US/docs/Web/API/Performance/now#ticking_during_sleep

This PR uses `Date.now()` by default for span start/end timestamps, and allows optionally using the performance API.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


