### PR TITLE
Enable level config for console logger

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -17,6 +17,7 @@ import tracingDefaults from '../tracing/defaults.js';
 import ReplayManager from './replay/replayManager.js';
 
 function Rollbar(options, client) {
+  logger.init({ logLevel: options.logLevel || 'error' });
   this.options = _.handleOptions(defaultOptions, options, null, logger);
   this.options._configuredOptions = options;
   const Telemeter = this.components.telemeter;
@@ -121,6 +122,9 @@ Rollbar.global = function (options) {
 };
 
 Rollbar.prototype.configure = function (options, payloadData) {
+  if (options.logLevel) {
+    logger.init({ logLevel: options.logLevel || 'error' });
+  }
   var oldOptions = this.options;
   var payload = {};
   if (payloadData) {

--- a/src/browser/logger.js
+++ b/src/browser/logger.js
@@ -1,25 +1,29 @@
-import * as _ from '../utility.js';
+let log = () => {};
 
-function error() {
-  var args = Array.prototype.slice.call(arguments, 0);
-  args.unshift('Rollbar:');
-  console.error.apply(console, args);
-}
-
-function info() {
-  var args = Array.prototype.slice.call(arguments, 0);
-  args.unshift('Rollbar:');
-  console.info.apply(console, args);
-}
-
-function log() {
-  var args = Array.prototype.slice.call(arguments, 0);
-  args.unshift('Rollbar:');
-  console.log.apply(console, args);
-}
-
-export default {
-  error,
-  info,
-  log,
+const levels = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+  disable: 4,
 };
+
+const logger = {
+  error: (...args) => log('error', args),
+  warn: (...args) => log('warn', args),
+  info: (...args) => log('info', args),
+  debug: (...args) => log('debug', args),
+  log: (...args) => log('info', args),
+  init: ({ logLevel }) => {
+    log = function(level, args) {
+      if (levels[level] < levels[logLevel]) return;
+
+      args.unshift('Rollbar:');
+
+      /* eslint-disable no-console */
+      console[level].apply(console, args);
+    }
+  }
+};
+
+export default logger;

--- a/test/replay/unit/replayManager.test.js
+++ b/test/replay/unit/replayManager.test.js
@@ -4,6 +4,7 @@
 
 import { expect } from 'chai';
 import sinon from 'sinon';
+import logger from '../../../src/browser/logger.js';
 import ReplayManager from '../../../src/browser/replay/replayManager.js';
 import id from '../../../src/tracing/id.js';
 
@@ -36,6 +37,7 @@ describe('ReplayManager', function () {
   let mockTracing;
 
   beforeEach(function () {
+    logger.init({ logLevel: 'error' });
     sinon.stub(id, 'gen').returns('1234567890abcdef');
 
     mockRecorder = new MockRecorder();


### PR DESCRIPTION
## Description of the change

Console logger accepts a config option for logLevel. Set `logLevel: 'disable'` to mute all logging.

Notes:
* Init is handled before config options processing, because `handleOptions` uses the logger.
* This should be compatible with server and react-native targets. The next step will be to move to a shared location.

## Type of change

- [x] Maintenance


### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


