### PR TITLE
Add tracing to Rollbar.configure and allow span options to update resource

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -128,9 +128,10 @@ class Rollbar {
       payload,
     );
 
+    this.tracing?.configure(this.options);
     this.recorder?.configure(this.options);
     this.client.configure(this.options, payloadData);
-    this.instrumenter && this.instrumenter.configure(this.options);
+    this.instrumenter?.configure(this.options);
     this.setupUnhandledCapture();
     return this;
   };

--- a/src/tracing/tracer.js
+++ b/src/tracing/tracer.js
@@ -29,9 +29,15 @@ export class Tracer {
 
     const kind = 0;
     const spanContext = { traceId, spanId, traceFlags, traceState };
+    const resource = {
+      attributes: {
+        ...(this.tracing.resource?.attributes || {}),
+        ...(options.resource?.attributes || {}),
+      },
+    };
 
     const span = new Span({
-      resource: this.tracing.resource,
+      resource: resource,
       scope: this.tracing.scope,
       session: this.tracing.session.session,
       context,

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -18,6 +18,11 @@ export default class Tracing {
     this.createTracer();
   }
 
+  configure(options) {
+    // Options merge happens before configure is called, so we can just replace.
+    this.options = options;
+  }
+
   initSession() {
     if (this.session) {
       this.session.init();

--- a/test/tracing/tracing.test.js
+++ b/test/tracing/tracing.test.js
@@ -51,6 +51,27 @@ describe('Tracing()', function () {
     done();
   });
 
+  it('should configure', function () {
+    const options = tracingOptions();
+    const t = new Tracing(window, options);
+    t.initSession();
+
+    expect(t.options.resource).to.deep.equal(options.resource);
+    expect(t.options.version).to.equal(options.version);
+
+    t.configure({
+      resource: {
+        'service.name': 'changed_service',
+      },
+      version: '0.2.0',
+    });
+
+    expect(t.options.resource).to.deep.equal({
+      'service.name': 'changed_service',
+    });
+    expect(t.options.version).to.equal('0.2.0');
+  });
+
   it('should create and export spans', function (done) {
     const options = tracingOptions();
     const t = new Tracing(window, options);

--- a/test/tracing/tracing.test.js
+++ b/test/tracing/tracing.test.js
@@ -118,6 +118,29 @@ describe('Tracing()', function () {
     done();
   });
 
+  it('should create spans with span option overrides', function () {
+    const options = tracingOptions();
+    const t = new Tracing(window, options);
+    t.initSession();
+
+    expect(t.sessionId).to.match(/^[a-f0-9]{32}$/);
+
+    const span = t.startSpan(
+    'test.span',
+    { resource: { attributes: { 'rollbar.environment': 'new-env' }}},
+    );
+
+    expect(span.span.name).to.equal('test.span');
+    expect(span.span.spanContext.traceId).to.match(/^[a-f0-9]{32}$/);
+    expect(span.span.spanContext.spanId).to.match(/^[a-f0-9]{16}$/);
+    expect(span.span.resource.attributes['service.name']).to.equal(
+      'unknown_service',
+    );
+    expect(span.span.resource.attributes['rollbar.environment']).to.equal(
+      'new-env',
+    );
+  });
+
   it('should get and set session attributes', function () {
     const options = tracingOptions();
     const t = new Tracing(window, options);


### PR DESCRIPTION
## Description of the change

Adds tracing to `Rollbar.configure` (269145b5e8022c6541d34b0c62675ff56618594c), and uses updated resource when passed in span options (842db75d62173cc9601d58bd9d15b7c8042f8ce4).

## Type of change


- [x] New feature (non-breaking change that adds functionality)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

