### PR TITLE
Recorder maintains a ready flag

### DIFF
--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -27,10 +27,15 @@ export default class Recorder {
 
     this.options = options;
     this._recordFn = recordFn;
+    this._isReady = false;
   }
 
   get isRecording() {
     return this._stopFn !== null;
+  }
+
+  get isReady() {
+    return this._isReady;
   }
 
   get options() {
@@ -127,6 +132,9 @@ export default class Recorder {
 
     this._stopFn = this._recordFn({
       emit: (event, isCheckout) => {
+        if (!this._ready && event.type === EventType.FullSnapshot) {
+          this._isReady = true;
+        }
         if (this.options.debug?.logEmits) {
           this._logEvent(event, isCheckout);
         }
@@ -158,6 +166,7 @@ export default class Recorder {
 
     this._stopFn();
     this._stopFn = null;
+    this._isReady = false;
 
     return this;
   }
@@ -167,6 +176,7 @@ export default class Recorder {
       previous: [],
       current: [],
     };
+    this._isReady = false;
   }
 
   _collectEvents() {

--- a/src/browser/replay/replayManager.js
+++ b/src/browser/replay/replayManager.js
@@ -79,6 +79,10 @@ export default class ReplayManager {
    * @returns {string} A unique identifier for this replay
    */
   add(replayId, occurrenceUuid) {
+    if (!this._recorder.isReady) {
+      logger.warn('ReplayManager.add: Recorder is not ready, cannot export replay');
+      return null;
+    }
     replayId = replayId || id.gen(8);
 
     // Start processing the replay in the background

--- a/test/browser.replay.recorder.test.js
+++ b/test/browser.replay.recorder.test.js
@@ -40,6 +40,7 @@ describe('Recorder', function () {
       const recorder = new Recorder({}, recordFnStub);
 
       expect(recorder.isRecording).to.be.false;
+      expect(recorder.isReady).to.be.false;
       expect(recorder.options).to.deep.equal({
         enabled: undefined,
         autoStart: undefined,
@@ -160,6 +161,21 @@ describe('Recorder', function () {
         tag: 'replay.end',
         payload: {},
       });
+    });
+
+    it('should be ready after first full snapshot', function () {
+      const recorder = new Recorder({}, recordFnStub);
+      recorder.start();
+
+      // First checkout
+      emitCallback({ timestamp: 0, type: EventType.Meta, data: {} }, false);
+      expect(recorder.isReady).to.be.false;
+
+      emitCallback(
+        { timestamp: 10, type: EventType.FullSnapshot, data: {} },
+        false,
+      );
+      expect(recorder.isReady).to.be.true;
     });
 
     it('should handle checkout events correctly', function () {

--- a/test/replay/unit/replayManager.test.js
+++ b/test/replay/unit/replayManager.test.js
@@ -11,6 +11,7 @@ import id from '../../../src/tracing/id.js';
 class MockRecorder {
   constructor() {
     this.exportRecordingSpan = sinon.stub();
+    this.isReady = true;
   }
 }
 
@@ -219,6 +220,20 @@ describe('ReplayManager', function () {
       expect(replayId).to.equal('1234567890abcdef');
       expect(id.gen.calledWith(8)).to.be.true;
       expect(processStub.calledWith('1234567890abcdef', uuid)).to.be.true;
+    });
+
+    it('should return without replayId when recorder is not ready', function () {
+      const uuid = '12345678-1234-5678-1234-1234567890ab';
+      const processStub = sinon
+        .stub(replayManager, '_exportSpansAndAddTracingPayload')
+        .resolves();
+        mockRecorder.isReady = false;
+
+      const replayId = replayManager.add(null, uuid);
+
+      expect(replayId).to.be.null;
+      expect(id.gen.called).to.be.false;
+      expect(processStub.called).to.be.false;
     });
   });
 


### PR DESCRIPTION
## Description of the change

Background:
When a replay is triggered before the first full snapshot is emitted, a "must have 3 events" error is raised.

This PR adds a recorder flag to track when the recorder is ready, allowing a warning to be logged rather than an error on this condition.

Notes:
* This has a direct benefit to customers who are experiencing this issue. With the warning, it will now be obvious when the "must have 3 events" error has a different root cause.
* This logs a warning and does not raise, since the recorder not being ready is not an error condition.
* rrweb begins building the full snapshot after the `load` event, regardless of how early the record function is called.
* The `recordAfter` option can be set by the user to `DOMContentLoaded` to allow rrweb to build the full snapshot earlier on that event. This may not be desirable, but the user has the option. https://github.com/rrweb-io/rrweb/blob/master/guide.md#options

## Type of change

- [x] New feature (non-breaking change that adds functionality)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


