### PR TITLE
Add transformSpan callback

### DIFF
--- a/src/tracing/spanProcessor.js
+++ b/src/tracing/spanProcessor.js
@@ -1,6 +1,9 @@
+import logger from '../logger.js';
+
 export class SpanProcessor {
-  constructor(exporter) {
+  constructor(exporter, options = {}) {
     this.exporter = exporter;
+    this.options = options;
     this.pendingSpans = new Map()
   }
 
@@ -9,6 +12,13 @@ export class SpanProcessor {
   }
 
   onEnd(span) {
+    try {
+      if (this.options.transformSpan) {
+        this.options.transformSpan({span: span.span});
+      }
+    } catch (e) {
+      logger.error('Error running transformSpan callback', e);
+    }
     this.exporter.export([span.export()])
     this.pendingSpans.delete(span.span.spanContext.spanId);
   }

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -60,7 +60,7 @@ export default class Tracing {
   createTracer() {
     this.contextManager = new ContextManager();
     this.exporter = new SpanExporter();
-    this.spanProcessor = new SpanProcessor(this.exporter);
+    this.spanProcessor = new SpanProcessor(this.exporter, this.options.tracing);
     this.tracer = new Tracer(this, this.spanProcessor);
   }
 


### PR DESCRIPTION
## Description of the change

Adds a transform callback for spans similar to the existing one for occurrences. The user defined function receives a readableSpan in `{ span: span }` which can be inspected and modified. Any return value is ignored.

## Type of change


- [x] New feature (non-breaking change that adds functionality)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


