### PR TITLE
Fix typo in variable reference

### DIFF
--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -132,7 +132,7 @@ export default class Recorder {
 
     this._stopFn = this._recordFn({
       emit: (event, isCheckout) => {
-        if (!this._ready && event.type === EventType.FullSnapshot) {
+        if (!this._isReady && event.type === EventType.FullSnapshot) {
           this._isReady = true;
         }
         if (this.options.debug?.logEmits) {


### PR DESCRIPTION
## Description of the change

This pull request introduces a minor fix to the `Recorder` class in `src/browser/replay/recorder.js`. The change ensures that the readiness check uses the correct property name, improving reliability in snapshot event handling. 

* Changed the condition in the `emit` callback to use `this._isReady` instead of `this._ready` for tracking readiness when a `FullSnapshot` event occurs.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release
