### PR TITLE
Post spans from tracing exporter

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -36,7 +36,7 @@ class Rollbar {
     const transport = new Transport(truncation);
     const api = new API(this.options, transport, urllib, truncation);
     if (Tracing) {
-      this.tracing = new Tracing(_gWindow(), this.options);
+      this.tracing = new Tracing(_gWindow(), api, this.options);
       this.tracing.initSession();
     }
     if (Telemeter) {

--- a/src/tracing/exporter.js
+++ b/src/tracing/exporter.js
@@ -5,6 +5,11 @@ import hrtime from './hrtime.js';
  * and transforming them into the OTLP-compatible format.
  */
 export class SpanExporter {
+  constructor(api, options = {}) {
+    this.api = api;
+    this.options = options;
+  }
+
   /**
    * Export spans to the span export queue
    *
@@ -64,6 +69,17 @@ export class SpanExporter {
         },
       ],
     };
+  }
+
+  /**
+   * Sends the given payload to the Rollbar API.
+   *
+   * @param {String} payload - Serialized OTLP format payload
+   * @param {Object} headers - Optional request headers
+   * @returns {Promise} Promise that resolves when the request completes
+   */
+  post(payload, headers = {}) {
+    return this.api.postSpans(payload, headers);
   }
 
   /**

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -8,7 +8,8 @@ import id from './id.js';
 const SPAN_KEY = createContextKey('Rollbar Context Key SPAN');
 
 export default class Tracing {
-  constructor(gWindow, options) {
+  constructor(gWindow, api, options) {
+    this.api = api;
     this.options = options;
     this.window = gWindow;
 
@@ -59,7 +60,7 @@ export default class Tracing {
 
   createTracer() {
     this.contextManager = new ContextManager();
-    this.exporter = new SpanExporter();
+    this.exporter = new SpanExporter(this.api, this.options);
     this.spanProcessor = new SpanProcessor(this.exporter, this.options.tracing);
     this.tracer = new Tracer(this, this.spanProcessor);
   }

--- a/test/browser.telemetry.test.js
+++ b/test/browser.telemetry.test.js
@@ -76,7 +76,7 @@ describe('instrumentDom', function () {
     await loadHtml('test/fixtures/html/dom-events.html');
     scrubFields = ['foo', 'bar'];
     rollbar = new Rollbar({})
-    tracing = new Tracing(window, {})
+    tracing = new Tracing(window, null, {})
     tracing.initSession();
     telemeter = new Telemeter({}, tracing);
     instrumenter = new Instrumenter(

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -66,7 +66,7 @@ describe('Session Replay E2E', function () {
     };
     const logger = { error: sinon.spy(), log: sinon.spy() };
 
-    tracing = new Tracing(window, options);
+    tracing = new Tracing(window, null, options);
     tracing.initSession();
     api = new Api(
       { accessToken: 'test-token-12345' },

--- a/test/replay/integration/replayManager.test.js
+++ b/test/replay/integration/replayManager.test.js
@@ -47,7 +47,7 @@ describe('ReplayManager API Integration', function () {
       truncate: sinon.stub().returns({ error: null, value: '{}' }),
     };
 
-    tracing = new Tracing(window, options);
+    tracing = new Tracing(window, null, options);
     tracing.initSession();
 
     const mockPayload = [{ id: 'span1', name: 'recording-span' }];

--- a/test/replay/integration/sessionRecording.test.js
+++ b/test/replay/integration/sessionRecording.test.js
@@ -64,7 +64,7 @@ describe('Session Replay Integration', function () {
   let recorder;
 
   beforeEach(function () {
-    tracing = new Tracing(window, options);
+    tracing = new Tracing(window, null, options);
     tracing.initSession();
   });
 
@@ -207,7 +207,7 @@ describe('Session Replay Transport Integration', function () {
       truncate: sinon.stub().returns({ error: null, value: '{}' }),
     };
 
-    tracing = new Tracing(window, options);
+    tracing = new Tracing(window, null, options);
     tracing.initSession();
 
     api = new Api(

--- a/test/telemetry.test.js
+++ b/test/telemetry.test.js
@@ -49,6 +49,7 @@ describe('capture events', function () {
   beforeEach(function () {
     const tracing = new Tracing(
       window,
+      null,
       {
         resource: {
           'service.name': 'Test',


### PR DESCRIPTION
## Description of the change

Adds a `post` method to the exporter to post payloads returned from `toPayload`.

This is an incremental update moving toward 
* renaming the existing `export` method to `exportToQueue`
* adding a new `export` method that encapsulates the functionality of `export`, `toPayload` and `post`. This will allow spans to be sent immediately when ended.
* `ReplayManager` can now call `post` through tracing.exporter, participating in any additional handling there for all spans (e.g. request headers). 

## Type of change


- [x] New feature (non-breaking change that adds functionality)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


