### PR TITLE
Move send replay from Queue to ReplayManager

### DIFF
--- a/test/replay/integration/replayManager.test.js
+++ b/test/replay/integration/replayManager.test.js
@@ -165,4 +165,68 @@ describe('ReplayManager API Integration', function () {
 
     expect(replayIds.size).to.equal(100);
   });
+
+  describe('sendOrDiscardReplay integration', function () {
+    it('should send replay when API response is successful', async function () {
+      const replayId = 'integration-test-replay';
+      const mockPayload = [{ id: 'test-span', name: 'recording-span' }];
+      replayManager.setSpans(replayId, mockPayload);
+
+      const postSpansSpy = sinon.spy(api, 'postSpans');
+
+      await replayManager.sendOrDiscardReplay(
+        replayId,
+        null,
+        { err: 0 },
+        {
+          'Rollbar-Replay-Enabled': 'true',
+          'Rollbar-Replay-RateLimit-Remaining': '10',
+        },
+      );
+
+      expect(postSpansSpy.calledOnce).to.be.true;
+      expect(
+        postSpansSpy.calledWith(mockPayload, {
+          'X-Rollbar-Replay-Id': replayId,
+        }),
+      ).to.be.true;
+      expect(replayManager.getSpans(replayId)).to.be.null;
+    });
+
+    it('should discard replay when API returns error', async function () {
+      const replayId = 'integration-test-discard';
+      const mockPayload = [{ id: 'test-span', name: 'recording-span' }];
+      replayManager.setSpans(replayId, mockPayload);
+
+      const postSpansSpy = sinon.spy(api, 'postSpans');
+
+      await replayManager.sendOrDiscardReplay(
+        replayId,
+        null,
+        { err: 1, message: 'API Error' },
+        { 'Rollbar-Replay-Enabled': 'true' },
+      );
+
+      expect(postSpansSpy.called).to.be.false;
+      expect(replayManager.getSpans(replayId)).to.be.null;
+    });
+
+    it('should discard replay when Rollbar-Replay-Enabled is false', async function () {
+      const replayId = 'integration-test-disabled';
+      const mockPayload = [{ id: 'test-span', name: 'recording-span' }];
+      replayManager.setSpans(replayId, mockPayload);
+
+      const postSpansSpy = sinon.spy(api, 'postSpans');
+
+      await replayManager.sendOrDiscardReplay(
+        replayId,
+        null,
+        { err: 0 },
+        { 'Rollbar-Replay-Enabled': 'false' },
+      );
+
+      expect(postSpansSpy.called).to.be.false;
+      expect(replayManager.getSpans(replayId)).to.be.null;
+    });
+  });
 });

--- a/test/replay/integration/sessionRecording.test.js
+++ b/test/replay/integration/sessionRecording.test.js
@@ -326,7 +326,7 @@ describe('Session Replay Transport Integration', function () {
     const sendSpy = sinon.spy(replayManager, 'send');
     const postSpansSpy = sinon.spy(api, 'postSpans');
 
-    const sendOrDiscardReplaySpy = sinon.spy(queue, '_sendOrDiscardReplay');
+    const sendOrDiscardReplaySpy = sinon.spy(replayManager, 'sendOrDiscardReplay');
 
     const errorItem = {
       data: {


### PR DESCRIPTION
## Description of the change

> [!NOTE]
> PR Description written by Copilot

This PR refactors the replay handling logic by moving responsibility for deciding whether to send or discard replays from the `Queue` class to the `ReplayManager` class. This centralization improves maintainability and separation of concerns.

- Added a new `sendOrDiscardReplay` method to `ReplayManager` that consolidates replay eligibility checks and error handling
- Updated `Queue` to delegate replay handling to `ReplayManager.sendOrDiscardReplay` instead of handling the logic internally
- Comprehensively updated all test suites to reflect the new integration point and method signatures

**Refactoring and Responsibility Shift:**

* Moved the replay eligibility check and send/discard logic from `Queue._sendOrDiscardReplay` and `_canSendReplay` into a new method `ReplayManager.sendOrDiscardReplay`, which now encapsulates all criteria and error handling for sending or discarding replays. (`src/browser/replay/replayManager.js` [[1]](diffhunk://#diff-c383ff937850dc70d8637d058eb205c5b5d69228d1250f4f39adb05218539a7dR247-R278) `src/queue.js` [[2]](diffhunk://#diff-4e4c267a000a68bf3427a37724d47236e2fc411213f5d69d1878f87155e9b3c3L309-L359)
* Updated `Queue` to call `ReplayManager.sendOrDiscardReplay` directly instead of handling replay logic internally, simplifying `Queue` and improving separation of concerns. (`src/queue.js` [src/queue.jsL118-R123](diffhunk://#diff-4e4c267a000a68bf3427a37724d47236e2fc411213f5d69d1878f87155e9b3c3L118-R123))

**Test Suite Updates:**

* Refactored all integration and unit tests to expect calls to `ReplayManager.sendOrDiscardReplay` instead of the previous direct calls to `send` or `discard`, ensuring tests accurately reflect the new flow. (`test/replay/integration/queue.replayManager.test.js` [[1]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8R49) [[2]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L88-R89) [[3]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L104-R115) [[4]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L132-R146) [[5]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L165-R182) [[6]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L201-R218) [[7]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L247-R267) [[8]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L293-R318) [[9]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L319-R352) [[10]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L356-R387) [[11]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L395-R423) [[12]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L434-R461) [[13]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L447-R472) [[14]](diffhunk://#diff-9f70b991ca8485fca52db125ea9c0345828a91cea8f4ee430686127a80980fa8L469-R497); `test/replay/unit/queue.replayManager.test.js` [[15]](diffhunk://#diff-d4d793da774b73a447bb15aa1489bda87ca5e99591cf63ea2cb724d5b243dbbaR8-R15)

**Integration Improvements:**

* Added new integration tests for `ReplayManager.sendOrDiscardReplay` to verify correct behavior for successful sends, API errors, and disabled replay scenarios. (`test/replay/integration/replayManager.test.js` [test/replay/integration/replayManager.test.jsR168-R231](diffhunk://#diff-948112596ea98e920d5089ae2f50cce7e853156c3560ff3f0fa54155c7572620R168-R231))
* Updated session replay transport integration tests to spy on the new method, ensuring coverage of the refactored logic. (`test/replay/integration/sessionRecording.test.js` [test/replay/integration/sessionRecording.test.jsL329-R329](diffhunk://#diff-a4b6594cad5c7fa1dae8c066c8d168b7e587578af2d05b26d781c57f82d56fc4L329-R329))

These changes centralize replay handling, making the codebase easier to maintain and extend, and ensure that tests accurately verify the new replay flow.
