### PR TITLE
Align `Recorder.checkoutEveryNms` default with rrweb behavior when `maxSeconds` is `0`

### DIFF
--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -97,7 +97,7 @@ export default class Recorder {
    * @returns {number} Checkout interval in milliseconds
    */
   checkoutEveryNms() {
-    return ((this.options.maxSeconds || 10) * 1000) / 2;
+    return ((this.options.maxSeconds ?? 10) * 1000) / 2;
   }
 
   /**

--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -3,6 +3,7 @@ import { EventType } from '@rrweb/types';
 
 import hrtime from '../../tracing/hrtime.js';
 import logger from '../../logger.js';
+import defaults from './defaults.js';
 
 /** @typedef {import('./recorder.js').BufferCursor} BufferCursor */
 
@@ -97,7 +98,11 @@ export default class Recorder {
    * @returns {number} Checkout interval in milliseconds
    */
   checkoutEveryNms() {
-    return ((this.options.maxSeconds ?? 10) * 1000) / 2;
+    const maxSeconds =
+      this.options.maxSeconds > 0
+        ? this.options.maxSeconds
+        : defaults.maxSeconds;
+    return (maxSeconds * 1000) / 2;
   }
 
   /**

--- a/test/replay/unit/recorder.test.js
+++ b/test/replay/unit/recorder.test.js
@@ -159,16 +159,28 @@ describe('Recorder', function () {
       expect(recorder.checkoutEveryNms()).to.equal(5000);
     });
 
-    it('uses default of 10 seconds when maxSeconds not provided', function () {
+    it('uses default of 300 seconds when maxSeconds not provided', function () {
       const recorder = new Recorder({}, mockRecordFn);
 
-      expect(recorder.checkoutEveryNms()).to.equal(5000);
+      expect(recorder.checkoutEveryNms()).to.equal(150000);
     });
 
     it('calculates correctly for different maxSeconds values', function () {
       const recorder = new Recorder({ maxSeconds: 20 }, mockRecordFn);
 
       expect(recorder.checkoutEveryNms()).to.equal(10000);
+    });
+
+    it('uses default when maxSeconds is 0', function () {
+      const recorder = new Recorder({ maxSeconds: 0 }, mockRecordFn);
+
+      expect(recorder.checkoutEveryNms()).to.equal(150000);
+    });
+
+    it('uses default when maxSeconds is negative', function () {
+      const recorder = new Recorder({ maxSeconds: -5 }, mockRecordFn);
+
+      expect(recorder.checkoutEveryNms()).to.equal(150000);
     });
   });
 


### PR DESCRIPTION
## Description of the change

`checkoutEveryNms` defaults to `10` when `maxSeconds` is `0`, inconsistent with rrweb’s expected behavior:
##### https://github.com/rrweb-io/rrweb/blob/76df9799ecc14930fa914e5623a73ea7726e3747/packages/rrweb/src/record/index.ts#L247-L252
```ts
    wrappedEmit = (r: eventWithoutTime, isCheckout?: boolean) => {
      ...
      const exceedTime =
        checkoutEveryNms &&
        e.timestamp - lastFullSnapshotEvent.timestamp > checkoutEveryNms;
      if (exceedCount || exceedTime) {
        takeFullSnapshot(true);
      }
    }
```

Where a `checkoutEveryNms` of `0` means a single initial full snapshot, and continuous event emission with no checkouts.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release
