### PR TITLE
[Feature] Post-trigger Replay Capture (aka. Leading Replay)

### DIFF
--- a/src/browser/replay/defaults.js
+++ b/src/browser/replay/defaults.js
@@ -6,6 +6,7 @@ export default {
   enabled: false, // Whether recording is enabled
   autoStart: true, // Start recording automatically when Rollbar initializes
   maxSeconds: 300, // Maximum recording duration in seconds
+  postDuration: 5, // Duration of events to include after a post is triggered, in seconds
 
   baseSamplingRatio: 1.0, // Used by triggers that don't specify a sampling ratio
   triggers: [

--- a/src/browser/replay/recorder.d.ts
+++ b/src/browser/replay/recorder.d.ts
@@ -1,5 +1,25 @@
 import type { Rollbar } from '../../../index.js';
 
-declare const Recorder: Rollbar.RecorderType;
+/** A point-in-time cursor into the active Recorder's two-slot ring buffer. */
+export type BufferCursor = {
+  /** Index (0|1) of the active buffer's slot at snapshot time. */
+  slot: 0 | 1;
+  /**
+   * Zero-based index of the last event at snapshot time; exclusive boundary.
+   * May be -1 when empty.
+   */
+  offset: number;
+};
+
+export interface Recorder extends Rollbar.RecorderType {
+  bufferCursor(): BufferCursor;
+  exportRecordingSpan(
+    tracing: any,
+    attributes?: Record<string, any>,
+    cursor?: BufferCursor,
+  ): void;
+}
+
+declare const Recorder: Recorder;
 
 export default Recorder;

--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -4,15 +4,24 @@ import { EventType } from '@rrweb/types';
 import hrtime from '../../tracing/hrtime.js';
 import logger from '../../logger.js';
 
+/** @typedef {import('./recorder.js').BufferCursor} BufferCursor */
+
 export default class Recorder {
   _options;
   _rrwebOptions;
+
+  _isReady = false;
   _stopFn = null;
   _recordFn;
-  _events = {
-    previous: [],
-    current: [],
-  };
+
+  /** A two-slot ring buffer for storing events. */
+  _buffers = [[], []];
+  /** Active slot index (0|1). Stores new events until next checkout. */
+  _currentSlot = 0;
+  /** Index of the finalized inactive slot (0|1). Frozen until next checkout. */
+  get _previousSlot() {
+    return this._currentSlot ^ 1;
+  }
 
   /**
    * Creates a new Recorder instance for capturing DOM events
@@ -27,7 +36,6 @@ export default class Recorder {
 
     this.options = options;
     this._recordFn = recordFn;
-    this._isReady = false;
   }
 
   get isRecording() {
@@ -52,6 +60,7 @@ export default class Recorder {
       enabled,
       autoStart,
       maxSeconds,
+      postDuration,
       triggers,
       debug,
 
@@ -62,7 +71,16 @@ export default class Recorder {
       // rrweb options
       ...rrwebOptions
     } = newOptions;
-    this._options = { enabled, autoStart, maxSeconds, triggers, debug };
+
+    this._options = {
+      enabled,
+      autoStart,
+      maxSeconds,
+      postDuration,
+      triggers,
+      debug,
+    };
+
     this._rrwebOptions = rrwebOptions;
 
     if (this.isRecording && newOptions.enabled === false) {
@@ -70,27 +88,49 @@ export default class Recorder {
     }
   }
 
+  /**
+   * Calculates the checkout interval in milliseconds.
+   *
+   * Recording may span up to two checkout intervals, so the interval is set
+   * to half of maxSeconds to ensure coverage.
+   *
+   * @returns {number} Checkout interval in milliseconds
+   */
   checkoutEveryNms() {
-    // Recording may be up to two checkout intervals, therefore the checkout
-    // interval is set to half of the maxSeconds.
     return ((this.options.maxSeconds || 10) * 1000) / 2;
   }
 
   /**
-   * Exports the recording span with all recorded events or events after a specific point.
+   * Returns a point-in-time cursor for the active buffer.
    *
-   * This method takes the recorder's stored events, creates a new span with the
-   * provided tracing context, attaches all events with their timestamps as span
-   * events, and exports the span to the tracing exporter. This is a side-effect
-   * function that doesn't return anything - the span is exported internally.
+   * Used to capture a stable cursor that survives a single checkout.
+   *
+   * @remarks
+   *
+   * While offset can be `-1` if the buffer is empty, this cannot occur when
+   * `_isReady` is `true`. The emit callback always pushes the triggering event
+   * after any buffer reset, ensuring the active buffer has at least one event.
+   *
+   * @returns {BufferCursor} Buffer index and event offset.
+   */
+  bufferCursor() {
+    return {
+      slot: this._currentSlot,
+      offset: this._buffers[this._currentSlot].length - 1,
+    };
+  }
+
+  /**
+   * Exports the recording span with all recorded events or events after a cursor.
    *
    * @param {Object} tracing - The tracing system instance to create spans
-   * @param {Object} attributes - Attributes to add to the span
-   *  (e.g., rollbar.replay.id, rollbar.occurrence.uuid, rollbar.replay.type)
-   * @param {number} [afterCount=0] - If provided, only export events after this count (for leading replay)
+   * @param {Object} attributes - Span attributes (rollbar.replay.id, etc.)
+   * @param {BufferCursor} [cursor] - Cursor position to start from (exclusive), or all if not provided
    */
-  exportRecordingSpan(tracing, attributes = {}, afterCount = 0) {
-    const events = this._collectEvents(afterCount);
+  exportRecordingSpan(tracing, attributes = {}, cursor) {
+    const events = cursor
+      ? this._collectEventsFromCursor(cursor)
+      : this._collectAll();
 
     if (events.length === 0) {
       throw new Error('Replay recording has no events');
@@ -135,16 +175,16 @@ export default class Recorder {
         if (!this._isReady && event.type === EventType.FullSnapshot) {
           this._isReady = true;
         }
+
         if (this.options.debug?.logEmits) {
-          this._logEvent(event, isCheckout);
+          Recorder._logEvent(event, isCheckout);
         }
 
         if (isCheckout && event.type === EventType.Meta) {
-          this._events.previous = this._events.current;
-          this._events.current = [];
+          this._buffers[(this._currentSlot = this._previousSlot)] = [];
         }
 
-        this._events.current.push(event);
+        this._buffers[this._currentSlot].push(event);
       },
       checkoutEveryNms: this.checkoutEveryNms(),
       errorHandler: (error) => {
@@ -172,42 +212,82 @@ export default class Recorder {
   }
 
   clear() {
-    this._events = {
-      previous: [],
-      current: [],
-    };
+    this._buffers = [[], []];
+    this._currentSlot = 0;
     this._isReady = false;
   }
 
-  _collectEvents(afterCount = 0) {
-    const allEvents = this._events.previous.concat(this._events.current);
+  /**
+   * Collects all events from both buffers.
+   *
+   * @returns {Array} All events with replay.end marker
+   * @private
+   */
+  _collectAll() {
+    const previousEvents = this._buffers[this._previousSlot];
+    const currentEvents = this._buffers[this._currentSlot];
+    const allEvents = previousEvents.concat(currentEvents);
 
-    const events = afterCount > 0 ? allEvents.slice(afterCount) : allEvents;
+    if (allEvents.length > 0) {
+      allEvents.push(Recorder._replayEndEvent());
+    }
+
+    return allEvents;
+  }
+
+  /**
+   * Collects events after a cursor position.
+   *
+   * @param {BufferCursor} cursor - Cursor position to collect from
+   * @returns {Array} Events after cursor with replay.end marker
+   * @private
+   */
+  _collectEventsFromCursor(cursor) {
+    const capturedBuffer = this._buffers[cursor.slot] ?? [];
+    const head = capturedBuffer.slice(Math.max(0, cursor.offset + 1));
+    const tail =
+      cursor.slot === this._currentSlot ? [] : this._buffers[this._currentSlot];
+
+    const events = head.concat(tail);
+
+    if (cursor.slot !== this._currentSlot && head.length === 0) {
+      logger.warn(
+        'Leading replay: captured buffer cleared by multiple checkouts',
+      );
+    }
 
     if (events.length > 0) {
-      // Helps the application correctly align playback by adding a noop event
-      // to the end of the recording.
-      events.push({
-        timestamp: Date.now(),
-        type: EventType.Custom,
-        data: { tag: 'replay.end', payload: {} },
-      });
+      events.push(Recorder._replayEndEvent());
     }
 
     return events;
   }
 
   /**
-   * Gets the current count of events in the buffers.
-   * This represents a marker for where trailing events end.
+   * Creates a replay.end noop marker event.
    *
-   * @returns {number} The total number of events currently stored
+   * Helps the application correctly align playback when added at the end of
+   * the recording.
+   *
+   * @returns {Object} replay.end event
+   * @private
    */
-  getCurrentEventCount() {
-    return this._events.previous.length + this._events.current.length;
+  static _replayEndEvent() {
+    return {
+      type: EventType.Custom,
+      timestamp: Date.now(),
+      data: { tag: 'replay.end', payload: {} },
+    };
   }
 
-  _logEvent(event, isCheckout) {
+  /**
+   * Logs an event for debugging purposes.
+   *
+   * @param {Object} event - The event to log
+   * @param {boolean} isCheckout - Whether this is a checkout event
+   * @private
+   */
+  static _logEvent(event, isCheckout) {
     logger.log(
       `Recorder: ${isCheckout ? 'checkout' : ''} event\n`,
       ((e) => {

--- a/src/browser/replay/replayManager.js
+++ b/src/browser/replay/replayManager.js
@@ -220,7 +220,7 @@ export default class ReplayManager {
   }
 
   /**
-   * Adds a replay to the map and returns a uniquely generated replay ID.
+   * Captures a replay and returns a uniquely generated replay ID.
    *
    * This method immediately returns the replayId and asynchronously processes
    * the replay data in the background. The processing involves converting
@@ -228,10 +228,10 @@ export default class ReplayManager {
    *
    * @returns {string} A unique identifier for this replay
    */
-  add(replayId, occurrenceUuid) {
+  capture(replayId, occurrenceUuid) {
     if (!this._recorder.isReady) {
       logger.warn(
-        'ReplayManager.add: Recorder is not ready, cannot export replay',
+        'ReplayManager.capture: Recorder is not ready, cannot export replay',
       );
       return null;
     }

--- a/src/queue.js
+++ b/src/queue.js
@@ -105,7 +105,7 @@ class Queue {
       const rid = data.attributes?.find((a) => a.key === 'replay_id')?.value;
 
       if (rid) {
-        item.replayId = this.replayManager.add(rid, data.uuid);
+        item.replayId = this.replayManager.capture(rid, data.uuid);
       }
     }
 

--- a/test/browser.replay.recorder.test.js
+++ b/test/browser.replay.recorder.test.js
@@ -45,6 +45,7 @@ describe('Recorder', function () {
         enabled: undefined,
         autoStart: undefined,
         maxSeconds: undefined,
+        postDuration: undefined,
         triggers: undefined,
         debug: undefined,
       });
@@ -58,6 +59,7 @@ describe('Recorder', function () {
         enabled: true,
         autoStart: undefined,
         maxSeconds: undefined,
+        postDuration: undefined,
         triggers: undefined,
         debug: undefined,
       });
@@ -411,22 +413,6 @@ describe('Recorder', function () {
       expect(mockTracing.startSpan.called).to.be.false;
       expect(mockTracing.exporter.toPayload.called).to.be.false;
     });
-
-    it.skip('should handle less than 2 events (invalid recording)', function () {
-      const recorder = new Recorder({}, recordFnStub);
-      recorder.start();
-
-      emitCallback({ timestamp: 1000, type: 'event1', data: { a: 1 } }, false);
-
-      expect(() => {
-        recorder.exportRecordingSpan(mockTracing, {
-          'rollbar.replay.id': testReplayId,
-        });
-      }).to.throw('Replay recording cannot have less than 3 events');
-
-      expect(mockTracing.startSpan.called).to.be.false;
-      expect(mockTracing.exporter.toPayload.called).to.be.false;
-    });
   });
 
   describe('configure', function () {
@@ -439,6 +425,7 @@ describe('Recorder', function () {
         enabled: false,
         autoStart: undefined,
         maxSeconds: 20,
+        postDuration: undefined,
         triggers: undefined,
         debug: undefined,
       });
@@ -453,6 +440,7 @@ describe('Recorder', function () {
         enabled: true,
         autoStart: undefined,
         maxSeconds: 15,
+        postDuration: undefined,
         triggers: undefined,
         debug: undefined,
       });

--- a/test/browser.replay.recorder.test.js
+++ b/test/browser.replay.recorder.test.js
@@ -406,13 +406,13 @@ describe('Recorder', function () {
         recorder.exportRecordingSpan(mockTracing, {
           'rollbar.replay.id': testReplayId,
         });
-      }).to.throw('Replay recording cannot have less than 3 events');
+      }).to.throw('Replay recording has no events');
 
       expect(mockTracing.startSpan.called).to.be.false;
       expect(mockTracing.exporter.toPayload.called).to.be.false;
     });
 
-    it('should handle less than 2 events (invalid recording)', function () {
+    it.skip('should handle less than 2 events (invalid recording)', function () {
       const recorder = new Recorder({}, recordFnStub);
       recorder.start();
 

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -108,7 +108,7 @@ describe('Session Replay E2E', function () {
 
     setTimeout(() => {
       const recorderExportSpy = sinon.spy(recorder, 'exportRecordingSpan');
-      const replayManagerAddSpy = sinon.spy(replayManager, 'add');
+      const replayManagerCaptureSpy = sinon.spy(replayManager, 'capture');
       const replayManagerSendSpy = sinon.spy(replayManager, 'send');
       const apiPostItemSpy = sinon.spy(api, 'postItem');
       const apiPostSpansSpy = sinon.spy(api, 'postSpans');
@@ -136,7 +136,7 @@ describe('Session Replay E2E', function () {
         const expectedReplayId = errorItem.replayId;
         expect(expectedReplayId).to.match(/^[0-9a-fA-F]{16}$/);
 
-        expect(replayManagerAddSpy.calledOnce).to.be.true;
+        expect(replayManagerCaptureSpy.calledOnce).to.be.true;
         expect(apiPostItemSpy.calledOnce).to.be.true;
 
         setTimeout(() => {
@@ -241,7 +241,7 @@ describe('Session Replay E2E', function () {
       }
     });
 
-    const replayManagerAddSpy = sinon.spy(replayManager, 'add');
+    const replayManagerCaptureSpy = sinon.spy(replayManager, 'capture');
     const replayManagerDiscardSpy = sinon.spy(replayManager, 'discard');
     const apiPostSpansSpy = sinon.spy(api, 'postSpans');
 
@@ -262,7 +262,7 @@ describe('Session Replay E2E', function () {
 
     queue.addItem(errorItem, (err, resp) => {
       expect(errorItem).to.have.property('replayId');
-      expect(replayManagerAddSpy.calledOnce).to.be.true;
+      expect(replayManagerCaptureSpy.calledOnce).to.be.true;
       expect(resp).to.have.property('err', 1);
 
       setTimeout(() => {

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -141,7 +141,7 @@ describe('Session Replay E2E', function () {
 
         setTimeout(() => {
           expect(recorderExportSpy.called).to.be.true;
-          // Check that the attributes include the replayId
+
           const exportArgs = recorderExportSpy.firstCall.args;
           expect(exportArgs[0]).to.equal(tracing);
           expect(exportArgs[1]).to.have.property(
@@ -223,6 +223,79 @@ describe('Session Replay E2E', function () {
           expect(transportArgs[0].options.path).to.include('/api/1/session/');
 
           done();
+        }, 200);
+      });
+    }, 50);
+  });
+
+  it('should handle trailing and leading replay flow', function (done) {
+    this.timeout(10000);
+
+    recorder.configure({ ...recorder.options, postDuration: 0.1 });
+    recorder.start();
+
+    setTimeout(() => {
+      const recorderExportSpy = sinon.spy(recorder, 'exportRecordingSpan');
+      const replayManagerCaptureSpy = sinon.spy(replayManager, 'capture');
+      const replayManagerSendSpy = sinon.spy(replayManager, 'send');
+      const apiPostItemSpy = sinon.spy(api, 'postItem');
+      const apiPostSpansSpy = sinon.spy(api, 'postSpans');
+
+      const errorItem = {
+        data: {
+          body: {
+            trace: {
+              exception: {
+                message: 'E2E test error with leading',
+              },
+            },
+          },
+          attributes: [{ key: 'replay_id', value: '1234567812345678' }],
+        },
+      };
+
+      queue.addItem(errorItem, (err, resp) => {
+        expect(err).to.be.null;
+        expect(resp).to.have.property('err', 0);
+        expect(errorItem).to.have.property('replayId');
+        const expectedReplayId = errorItem.replayId;
+
+        expect(replayManagerCaptureSpy.calledOnce).to.be.true;
+        expect(apiPostItemSpy.calledOnce).to.be.true;
+
+        setTimeout(() => {
+          expect(recorderExportSpy.called).to.be.true;
+          expect(replayManagerSendSpy.calledWith(errorItem.replayId)).to.be
+            .true;
+
+          const trailingExportCall = recorderExportSpy.firstCall;
+          expect(trailingExportCall.args[2]).to.be.undefined;
+
+          setTimeout(() => {
+            expect(apiPostSpansSpy.callCount).to.equal(2);
+
+            const trailingApiCall = apiPostSpansSpy.firstCall;
+            const leadingApiCall = apiPostSpansSpy.secondCall;
+
+            expect(trailingApiCall.args[1]).to.deep.equal({
+              'X-Rollbar-Replay-Id': expectedReplayId,
+            });
+            expect(leadingApiCall.args[1]).to.deep.equal({
+              'X-Rollbar-Replay-Id': expectedReplayId,
+            });
+
+            expect(recorderExportSpy.callCount).to.be.greaterThan(1);
+            const leadingExportCall = recorderExportSpy.lastCall;
+            const leadingCursor = leadingExportCall.args[2];
+
+            expect(leadingCursor).to.be.an('object');
+            expect(leadingCursor).to.have.property('slot');
+            expect(leadingCursor).to.have.property('offset');
+            expect(leadingCursor.slot).to.be.oneOf([0, 1]);
+            expect(leadingCursor.offset).to.be.a('number');
+
+            done();
+          }, 200);
         }, 200);
       });
     }, 50);

--- a/test/replay/integration/queue.replayManager.test.js
+++ b/test/replay/integration/queue.replayManager.test.js
@@ -43,7 +43,7 @@ describe('Queue ReplayManager Integration', function () {
     );
 
     replayManager = {
-      add: sinon.stub().returnsArg(0),
+      capture: sinon.stub().returnsArg(0),
       send: sinon.stub().resolves(true),
       discard: sinon.stub().returns(true),
       getSpans: sinon.stub().returns([{ id: 'test-span' }]),
@@ -80,7 +80,7 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       expect(item).to.have.property('replayId', '1234567812345678');
-      expect(replayManager.add.calledOnce).to.be.true;
+      expect(replayManager.capture.calledOnce).to.be.true;
       done();
     });
   });
@@ -262,7 +262,7 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       expect(item).to.not.have.property('replayId');
-      expect(replayManager.add.called).to.be.false;
+      expect(replayManager.capture.called).to.be.false;
       done();
     });
   });
@@ -284,7 +284,7 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       expect(item).to.not.have.property('replayId');
-      expect(replayManager.add.called).to.be.false;
+      expect(replayManager.capture.called).to.be.false;
       done();
     });
   });
@@ -317,7 +317,7 @@ describe('Queue ReplayManager Integration', function () {
         expect(err).to.be.instanceof(Error);
         setTimeout(() => {
           // Verify replay was added but then discarded
-          expect(replayManager.add.calledOnce).to.be.true;
+          expect(replayManager.capture.calledOnce).to.be.true;
           expect(replayManager.discard.calledWith('1234567812345678')).to.be
             .true;
           expect(replayManager.send.called).to.be.false;

--- a/test/replay/integration/replayManager.bufferIndex.checkoutResilience.test.js
+++ b/test/replay/integration/replayManager.bufferIndex.checkoutResilience.test.js
@@ -1,0 +1,390 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import ReplayManager from '../../../src/browser/replay/replayManager.js';
+import Recorder from '../../../src/browser/replay/recorder.js';
+import mockRecordFn from '../util/mockRecordFn.js';
+import logger from '../../../src/logger.js';
+
+describe('ReplayManager – Buffer Index Checkout Resilience', function () {
+  let replayManager, recorder, api, tracing, telemeter, clock;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+    api = { postSpans: sinon.stub().resolves() };
+    tracing = {
+      startSpan: sinon.stub().returns({
+        setAttributes: sinon.stub(),
+        addEvent: sinon.stub(),
+        end: sinon.stub(),
+        span: { startTime: 0 },
+      }),
+      exporter: {
+        toPayload: sinon
+          .stub()
+          .returns({ resourceSpans: [{ spanData: 'test' }] }),
+      },
+      session: { attributes: {} },
+    };
+    telemeter = { exportTelemetrySpan: sinon.stub() };
+  });
+
+  afterEach(function () {
+    if (recorder?.isRecording) recorder.stop();
+    clock.restore();
+  });
+
+  it('captures leading with no checkouts', async function () {
+    recorder = new Recorder(
+      {
+        enabled: true,
+        autoStart: false,
+        maxSeconds: 10,
+        postDuration: 5,
+        emitEveryNms: 100,
+      },
+      mockRecordFn,
+    );
+    replayManager = new ReplayManager({ recorder, api, tracing, telemeter });
+
+    sinon.spy(recorder, 'exportRecordingSpan');
+
+    recorder.start();
+    await clock.tickAsync(200);
+
+    const replayId = replayManager.capture('test-replay-id', 'test-uuid');
+    await clock.tickAsync(100);
+
+    const cursor = replayManager._pendingLeading.get(replayId).bufferCursor;
+    expect(cursor).to.be.an('object');
+    expect(cursor.slot).to.equal(0);
+
+    await clock.tickAsync(1000);
+
+    await replayManager.send(replayId);
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledTwice(recorder.exportRecordingSpan);
+    expect(recorder.exportRecordingSpan.firstCall.args).to.deep.equal([
+      tracing,
+      {
+        'rollbar.replay.id': 'test-replay-id',
+        'rollbar.occurrence.uuid': 'test-uuid',
+      },
+    ]);
+    expect(recorder.exportRecordingSpan.secondCall.args).to.deep.equal([
+      tracing,
+      {
+        'rollbar.replay.id': 'test-replay-id',
+        'rollbar.occurrence.uuid': 'test-uuid',
+      },
+      { slot: 0, offset: 5 },
+    ]);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+    expect(replayManager._pendingLeading.size).to.equal(0);
+
+    recorder.exportRecordingSpan.restore();
+  });
+
+  it('captures leading across a single checkout', async function () {
+    recorder = new Recorder(
+      {
+        enabled: true,
+        autoStart: false,
+        maxSeconds: 4,
+        postDuration: 5,
+        emitEveryNms: 100,
+      },
+      mockRecordFn,
+    );
+    replayManager = new ReplayManager({ recorder, api, tracing, telemeter });
+
+    sinon.spy(recorder, 'exportRecordingSpan');
+
+    recorder.start();
+    await clock.tickAsync(200);
+
+    const replayId = replayManager.capture('test-replay-id', 'test-uuid');
+
+    await clock.tickAsync(1000);
+
+    await replayManager.send(replayId);
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledTwice(recorder.exportRecordingSpan);
+    expect(recorder.exportRecordingSpan.firstCall.args).to.deep.equal([
+      tracing,
+      {
+        'rollbar.replay.id': 'test-replay-id',
+        'rollbar.occurrence.uuid': 'test-uuid',
+      },
+    ]);
+    expect(recorder.exportRecordingSpan.secondCall.args).to.deep.equal([
+      tracing,
+      {
+        'rollbar.replay.id': 'test-replay-id',
+        'rollbar.occurrence.uuid': 'test-uuid',
+      },
+      { slot: 0, offset: 5 },
+    ]);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+    expect(replayManager._pendingLeading.size).to.equal(0);
+
+    recorder.exportRecordingSpan.restore();
+  });
+
+  it('uses the exact captured cursor after one rotation', async function () {
+    recorder = new Recorder(
+      {
+        enabled: true,
+        autoStart: false,
+        maxSeconds: 4,
+        postDuration: 5,
+        emitEveryNms: 100,
+      },
+      mockRecordFn,
+    );
+    replayManager = new ReplayManager({ recorder, api, tracing, telemeter });
+
+    sinon.spy(recorder, 'exportRecordingSpan');
+
+    recorder.start();
+    await clock.tickAsync(200);
+
+    const replayId = replayManager.capture('test-replay-id', 'test-uuid');
+    await clock.tickAsync(100);
+
+    const cursor = replayManager._pendingLeading.get(replayId).bufferCursor;
+    expect(cursor).to.be.an('object');
+
+    await clock.tickAsync(2000);
+
+    await replayManager.send(replayId);
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledTwice(recorder.exportRecordingSpan);
+    expect(recorder.exportRecordingSpan.firstCall.args).to.deep.equal([
+      tracing,
+      {
+        'rollbar.replay.id': 'test-replay-id',
+        'rollbar.occurrence.uuid': 'test-uuid',
+      },
+    ]);
+    expect(recorder.exportRecordingSpan.secondCall.args).to.deep.equal([
+      tracing,
+      {
+        'rollbar.replay.id': 'test-replay-id',
+        'rollbar.occurrence.uuid': 'test-uuid',
+      },
+      cursor,
+    ]);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+    expect(replayManager._pendingLeading.size).to.equal(0);
+
+    recorder.exportRecordingSpan.restore();
+  });
+
+  it('resilience with multiple checkouts (best-effort still sends)', async function () {
+    recorder = new Recorder(
+      {
+        enabled: true,
+        autoStart: false,
+        maxSeconds: 2,
+        postDuration: 5,
+        emitEveryNms: 100,
+      },
+      mockRecordFn,
+    );
+    replayManager = new ReplayManager({ recorder, api, tracing, telemeter });
+
+    recorder.start();
+    await clock.tickAsync(200);
+
+    const replayId = replayManager.capture('test-replay-id', 'test-uuid');
+    await clock.tickAsync(100);
+
+    await clock.tickAsync(2000);
+
+    await replayManager.send(replayId);
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+    expect(replayManager._pendingLeading.size).to.equal(0);
+  });
+
+  it('collects events strictly after the cursor', async function () {
+    recorder = new Recorder(
+      {
+        enabled: true,
+        autoStart: false,
+        maxSeconds: 4,
+        postDuration: 5,
+        emitEveryNms: 100,
+      },
+      mockRecordFn,
+    );
+    replayManager = new ReplayManager({ recorder, api, tracing, telemeter });
+
+    recorder.start();
+    await clock.tickAsync(200);
+
+    const replayId = replayManager.capture('test-replay-id', 'test-uuid');
+    await clock.tickAsync(100);
+
+    const cursor = replayManager._pendingLeading.get(replayId).bufferCursor;
+
+    sinon.spy(recorder, '_collectEventsFromCursor');
+
+    await clock.tickAsync(3500);
+
+    await replayManager.send(replayId);
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledOnce(recorder._collectEventsFromCursor);
+    expect(recorder._collectEventsFromCursor.firstCall.args).to.deep.equal([
+      cursor,
+    ]);
+
+    const returnedEvents =
+      recorder._collectEventsFromCursor.firstCall.returnValue;
+    expect(returnedEvents).to.have.lengthOf(10);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+    expect(replayManager._pendingLeading.size).to.equal(0);
+
+    recorder._collectEventsFromCursor.restore();
+  });
+
+  it('no leading scheduled when trailing export throws', async function () {
+    recorder = new Recorder(
+      { enabled: true, autoStart: false, maxSeconds: 4, postDuration: 5 },
+      () => () => {},
+    );
+    replayManager = new ReplayManager({ recorder, api, tracing, telemeter });
+
+    recorder._isReady = true;
+    recorder._stopFn = () => {};
+
+    sinon.spy(logger, 'error');
+
+    const replayId = replayManager.capture('test-replay-id', 'test-uuid');
+    await clock.tickAsync(100);
+
+    sinon.assert.calledOnce(logger.error);
+    expect(logger.error.firstCall.args[0]).to.be.a('string');
+    expect(logger.error.firstCall.args[1]).to.be.instanceOf(Error);
+    expect(logger.error.firstCall.args[1].message).to.equal(
+      'Replay recording has no events',
+    );
+
+    expect(replayManager._map.has(replayId)).to.be.false;
+    expect(replayManager._pendingLeading.has(replayId)).to.be.false;
+    sinon.assert.notCalled(api.postSpans);
+
+    logger.error.restore();
+  });
+
+  it('leading post error is handled and state is cleaned', async function () {
+    recorder = new Recorder(
+      {
+        enabled: true,
+        autoStart: false,
+        maxSeconds: 4,
+        postDuration: 5,
+        emitEveryNms: 100,
+      },
+      mockRecordFn,
+    );
+    replayManager = new ReplayManager({ recorder, api, tracing, telemeter });
+
+    api.postSpans.onFirstCall().resolves();
+    api.postSpans.onSecondCall().rejects(new Error('Network error'));
+
+    recorder.start();
+    await clock.tickAsync(200);
+
+    const replayId = replayManager.capture('test-replay-id', 'test-uuid');
+
+    await clock.tickAsync(1000);
+
+    await replayManager.send(replayId);
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.firstCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+    expect(replayManager._pendingLeading.has(replayId)).to.be.false;
+  });
+
+  it('discard cancels timer; success clears state', async function () {
+    recorder = new Recorder(
+      {
+        enabled: true,
+        autoStart: false,
+        maxSeconds: 4,
+        postDuration: 5,
+        emitEveryNms: 100,
+      },
+      mockRecordFn,
+    );
+    replayManager = new ReplayManager({ recorder, api, tracing, telemeter });
+
+    recorder.start();
+    await clock.tickAsync(200);
+
+    const replayId1 = 'test-replay-id-1';
+    replayManager.capture(replayId1, 'test-uuid-1');
+    await clock.tickAsync(100);
+
+    expect(replayManager._pendingLeading.has(replayId1)).to.be.true;
+
+    replayManager.discard(replayId1);
+    await clock.tickAsync(10000);
+
+    sinon.assert.notCalled(api.postSpans);
+
+    const replayId2 = 'test-replay-id-2';
+    replayManager.capture(replayId2, 'test-uuid-2');
+    await clock.tickAsync(100);
+
+    await replayManager.send(replayId2);
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId2 },
+    ]);
+    expect(replayManager._pendingLeading.has(replayId2)).to.be.false;
+    expect(replayManager._trailingStatus.has(replayId2)).to.be.false;
+  });
+});

--- a/test/replay/integration/replayManager.bufferIndex.test.js
+++ b/test/replay/integration/replayManager.bufferIndex.test.js
@@ -1,0 +1,353 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import { EventType } from '@rrweb/types';
+
+import Recorder from '../../../src/browser/replay/recorder.js';
+import ReplayManager from '../../../src/browser/replay/replayManager.js';
+import {
+  currentBuffer,
+  setCurrentBuffer,
+  setPreviousBuffer,
+} from '../util/recorder.js';
+
+describe('ReplayManager buffer-index integration', function () {
+  let replayManager, recorder, api, tracing, telemeter, clock;
+
+  beforeEach(function () {
+    clock = sinon.useFakeTimers();
+
+    const mockRecordFn = () => () => {};
+    recorder = new Recorder(
+      {
+        enabled: true,
+        maxSeconds: 10,
+        postDuration: 5,
+      },
+      mockRecordFn,
+    );
+
+    recorder._isReady = true;
+    recorder._stopFn = () => {};
+
+    tracing = {
+      startSpan: sinon.stub().returns({
+        setAttributes: sinon.stub(),
+        addEvent: sinon.stub(),
+        end: sinon.stub(),
+        span: { startTime: 0 },
+      }),
+      exporter: {
+        toPayload: sinon
+          .stub()
+          .returns({ resourceSpans: [{ spanData: 'test' }] }),
+      },
+      session: {
+        attributes: {},
+      },
+    };
+
+    api = {
+      postSpans: sinon.stub().resolves(),
+    };
+
+    telemeter = {
+      exportTelemetrySpan: sinon.stub(),
+    };
+
+    replayManager = new ReplayManager({
+      recorder,
+      api,
+      tracing,
+      telemeter,
+    });
+
+    sinon.spy(recorder, 'exportRecordingSpan');
+  });
+
+  afterEach(function () {
+    recorder.exportRecordingSpan.restore();
+    clock.restore();
+  });
+
+  it('calls _sendOrDiscardLeadingReplay after timeout', async function () {
+    setPreviousBuffer(recorder, [
+      { timestamp: 1000, type: EventType.Meta, data: {} },
+    ]);
+    setCurrentBuffer(recorder, [
+      { timestamp: 2000, type: EventType.Meta, data: {} },
+    ]);
+
+    sinon.spy(replayManager, '_sendOrDiscardLeadingReplay');
+
+    const replayId = 'test-replay-id';
+    const occurrenceUuid = 'test-uuid';
+
+    replayManager.capture(replayId, occurrenceUuid);
+    await clock.tickAsync(100);
+
+    sinon.assert.notCalled(replayManager._sendOrDiscardLeadingReplay);
+
+    await replayManager.send(replayId);
+    sinon.assert.calledOnce(replayManager._sendOrDiscardLeadingReplay);
+
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledTwice(replayManager._sendOrDiscardLeadingReplay);
+    expect(
+      replayManager._sendOrDiscardLeadingReplay.secondCall.args,
+    ).to.deep.equal([replayId]);
+
+    replayManager._sendOrDiscardLeadingReplay.restore();
+  });
+
+  it('captures and sends leading replay with buffer-index', async function () {
+    setPreviousBuffer(recorder, [
+      { timestamp: 1000, type: EventType.Meta, data: {} },
+    ]);
+    setCurrentBuffer(recorder, [
+      { timestamp: 2000, type: EventType.Meta, data: {} },
+    ]);
+
+    const replayId = 'test-replay-id';
+    const occurrenceUuid = 'test-uuid';
+
+    replayManager.capture(replayId, occurrenceUuid);
+    await clock.tickAsync(100);
+
+    sinon.assert.calledOnce(recorder.exportRecordingSpan);
+    expect(recorder.exportRecordingSpan.firstCall.args).to.deep.equal([
+      tracing,
+      {
+        'rollbar.replay.id': replayId,
+        'rollbar.occurrence.uuid': occurrenceUuid,
+      },
+    ]);
+
+    currentBuffer(recorder).push({
+      timestamp: 3000,
+      type: EventType.IncrementalSnapshot,
+      data: {},
+    });
+
+    await replayManager.send(replayId);
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledTwice(recorder.exportRecordingSpan);
+    expect(recorder.exportRecordingSpan.secondCall.args).to.deep.equal([
+      tracing,
+      {
+        'rollbar.replay.id': replayId,
+        'rollbar.occurrence.uuid': occurrenceUuid,
+      },
+      { slot: 0, offset: 0 },
+    ]);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+  });
+
+  it('handles buffer rotation correctly with buffer-index', async function () {
+    setPreviousBuffer(recorder, [
+      { timestamp: 1000, type: EventType.Meta, data: {} },
+    ]);
+    setCurrentBuffer(recorder, [
+      { timestamp: 2000, type: EventType.Meta, data: {} },
+    ]);
+
+    const replayId = 'test-replay-id';
+    const occurrenceUuid = 'test-uuid';
+
+    replayManager.capture(replayId, occurrenceUuid);
+    await clock.tickAsync(100);
+
+    const capturedCursor =
+      replayManager._pendingLeading.get(replayId).bufferCursor;
+    expect(capturedCursor).to.be.an('object');
+    expect(capturedCursor).to.have.property('slot', 0);
+    expect(capturedCursor).to.have.property('offset', 0);
+
+    setPreviousBuffer(recorder, currentBuffer(recorder));
+    setCurrentBuffer(recorder, [
+      { timestamp: 3000, type: EventType.Meta, data: {} },
+      { timestamp: 4000, type: EventType.Meta, data: {} },
+    ]);
+
+    await replayManager.send(replayId);
+    await clock.tickAsync(5000);
+
+    expect(recorder.exportRecordingSpan.secondCall.args).to.deep.equal([
+      tracing,
+      {
+        'rollbar.replay.id': replayId,
+        'rollbar.occurrence.uuid': occurrenceUuid,
+      },
+      capturedCursor,
+    ]);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+    expect(replayManager._pendingLeading.has(replayId)).to.be.false;
+  });
+
+  it('discards leading when trailing fails', async function () {
+    setPreviousBuffer(recorder, [
+      { timestamp: 1000, type: EventType.Meta, data: {} },
+    ]);
+    setCurrentBuffer(recorder, [
+      { timestamp: 2000, type: EventType.Meta, data: {} },
+    ]);
+
+    const replayId = 'test-replay-id';
+    const occurrenceUuid = 'test-uuid';
+
+    replayManager.capture(replayId, occurrenceUuid);
+    await clock.tickAsync(100);
+
+    replayManager.discard(replayId);
+    await clock.tickAsync(5000);
+
+    sinon.assert.notCalled(api.postSpans);
+    expect(replayManager._pendingLeading.has(replayId)).to.be.false;
+  });
+
+  it('waits while trailing is pending, then sends once trailing is SENT', async function () {
+    setPreviousBuffer(recorder, [
+      { timestamp: 1000, type: EventType.Meta, data: {} },
+    ]);
+    setCurrentBuffer(recorder, [
+      { timestamp: 2000, type: EventType.Meta, data: {} },
+    ]);
+
+    const replayId = 'test-replay-id';
+    const occurrenceUuid = 'test-uuid';
+
+    replayManager.capture(replayId, occurrenceUuid);
+    await clock.tickAsync(100);
+
+    currentBuffer(recorder).push({
+      timestamp: 3000,
+      type: EventType.IncrementalSnapshot,
+      data: {},
+    });
+
+    await clock.tickAsync(5000);
+
+    const pendingContext = replayManager._pendingLeading.get(replayId);
+    expect(pendingContext.leadingReady).to.be.true;
+    sinon.assert.notCalled(api.postSpans);
+
+    await replayManager.send(replayId);
+
+    sinon.assert.calledTwice(api.postSpans);
+  });
+
+  it('cleans up on leading post error', async function () {
+    setPreviousBuffer(recorder, [
+      { timestamp: 1000, type: EventType.Meta, data: {} },
+    ]);
+    setCurrentBuffer(recorder, [
+      { timestamp: 2000, type: EventType.Meta, data: {} },
+    ]);
+
+    api.postSpans.onFirstCall().resolves();
+    api.postSpans.onSecondCall().rejects(new Error('Network error'));
+
+    const replayId = 'test-replay-id';
+    const occurrenceUuid = 'test-uuid';
+
+    replayManager.capture(replayId, occurrenceUuid);
+    await clock.tickAsync(100);
+
+    currentBuffer(recorder).push({
+      timestamp: 3000,
+      type: EventType.IncrementalSnapshot,
+      data: {},
+    });
+
+    await replayManager.send(replayId);
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.firstCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId },
+    ]);
+    expect(replayManager._pendingLeading.has(replayId)).to.be.false;
+  });
+
+  it('does not schedule leading when trailing export throws', async function () {
+    setPreviousBuffer(recorder, []);
+    setCurrentBuffer(recorder, []);
+
+    const replayId = 'test-replay-id';
+    const occurrenceUuid = 'test-uuid';
+
+    replayManager.capture(replayId, occurrenceUuid);
+    await clock.tickAsync(100);
+
+    expect(replayManager._map.has(replayId)).to.be.false;
+    expect(replayManager._pendingLeading.has(replayId)).to.be.false;
+  });
+
+  it('cleanup: discard cancels timer; success clears state', async function () {
+    setPreviousBuffer(recorder, [
+      { timestamp: 1000, type: EventType.Meta, data: {} },
+    ]);
+    setCurrentBuffer(recorder, [
+      { timestamp: 2000, type: EventType.Meta, data: {} },
+    ]);
+
+    const replayId1 = 'test-replay-id-1';
+    const occurrenceUuid1 = 'test-uuid-1';
+
+    replayManager.capture(replayId1, occurrenceUuid1);
+    await clock.tickAsync(100);
+
+    expect(replayManager._pendingLeading.has(replayId1)).to.be.true;
+
+    replayManager.discard(replayId1);
+    await clock.tickAsync(10000);
+
+    sinon.assert.notCalled(api.postSpans);
+
+    const replayId2 = 'test-replay-id-2';
+    const occurrenceUuid2 = 'test-uuid-2';
+
+    setPreviousBuffer(recorder, [
+      { timestamp: 5000, type: EventType.Meta, data: {} },
+    ]);
+    setCurrentBuffer(recorder, [
+      { timestamp: 6000, type: EventType.Meta, data: {} },
+    ]);
+
+    replayManager.capture(replayId2, occurrenceUuid2);
+    await clock.tickAsync(100);
+
+    currentBuffer(recorder).push({
+      timestamp: 7000,
+      type: EventType.IncrementalSnapshot,
+      data: {},
+    });
+
+    await replayManager.send(replayId2);
+    await clock.tickAsync(5000);
+
+    sinon.assert.calledTwice(api.postSpans);
+    expect(api.postSpans.secondCall.args).to.deep.equal([
+      { resourceSpans: [{ spanData: 'test' }] },
+      { 'X-Rollbar-Replay-Id': replayId2 },
+    ]);
+    expect(replayManager._pendingLeading.has(replayId2)).to.be.false;
+    expect(replayManager._trailingStatus.has(replayId2)).to.be.false;
+  });
+});

--- a/test/replay/integration/replayManager.test.js
+++ b/test/replay/integration/replayManager.test.js
@@ -165,4 +165,68 @@ describe('ReplayManager API Integration', function () {
 
     expect(replayIds.size).to.equal(100);
   });
+
+  describe('sendOrDiscardReplay integration', function () {
+    it('should send replay when API response is successful', async function () {
+      const replayId = 'integration-test-replay';
+      const mockPayload = [{ id: 'test-span', name: 'recording-span' }];
+      replayManager.setSpans(replayId, mockPayload);
+
+      const postSpansSpy = sinon.spy(api, 'postSpans');
+
+      await replayManager.sendOrDiscardReplay(
+        replayId,
+        null,
+        { err: 0 },
+        {
+          'Rollbar-Replay-Enabled': 'true',
+          'Rollbar-Replay-RateLimit-Remaining': '10',
+        },
+      );
+
+      expect(postSpansSpy.calledOnce).to.be.true;
+      expect(
+        postSpansSpy.calledWith(mockPayload, {
+          'X-Rollbar-Replay-Id': replayId,
+        }),
+      ).to.be.true;
+      expect(replayManager.getSpans(replayId)).to.be.null;
+    });
+
+    it('should discard replay when API returns error', async function () {
+      const replayId = 'integration-test-discard';
+      const mockPayload = [{ id: 'test-span', name: 'recording-span' }];
+      replayManager.setSpans(replayId, mockPayload);
+
+      const postSpansSpy = sinon.spy(api, 'postSpans');
+
+      await replayManager.sendOrDiscardReplay(
+        replayId,
+        null,
+        { err: 1, message: 'API Error' },
+        { 'Rollbar-Replay-Enabled': 'true' },
+      );
+
+      expect(postSpansSpy.called).to.be.false;
+      expect(replayManager.getSpans(replayId)).to.be.null;
+    });
+
+    it('should discard replay when Rollbar-Replay-Enabled is false', async function () {
+      const replayId = 'integration-test-disabled';
+      const mockPayload = [{ id: 'test-span', name: 'recording-span' }];
+      replayManager.setSpans(replayId, mockPayload);
+
+      const postSpansSpy = sinon.spy(api, 'postSpans');
+
+      await replayManager.sendOrDiscardReplay(
+        replayId,
+        null,
+        { err: 0 },
+        { 'Rollbar-Replay-Enabled': 'false' },
+      );
+
+      expect(postSpansSpy.called).to.be.false;
+      expect(replayManager.getSpans(replayId)).to.be.null;
+    });
+  });
 });

--- a/test/replay/integration/replayManager.test.js
+++ b/test/replay/integration/replayManager.test.js
@@ -81,7 +81,7 @@ describe('ReplayManager API Integration', function () {
 
   it('should add replay data to map', function () {
     const uuid = 'test-uuid';
-    const replayId = replayManager.add(null, uuid);
+    const replayId = replayManager.capture(null, uuid);
     expect(replayId).to.be.a('string');
     expect(replayId.length).to.equal(16); // 8 bytes as hex = 16 characters
 
@@ -158,7 +158,7 @@ describe('ReplayManager API Integration', function () {
     sinon.stub(replayManager, '_exportSpansAndAddTracingPayload').resolves();
 
     for (let i = 0; i < 100; i++) {
-      const replayId = replayManager.add();
+      const replayId = replayManager.capture();
       expect(replayIds.has(replayId)).to.be.false;
       replayIds.add(replayId);
     }

--- a/test/replay/integration/sessionRecording.test.js
+++ b/test/replay/integration/sessionRecording.test.js
@@ -326,7 +326,7 @@ describe('Session Replay Transport Integration', function () {
     const sendSpy = sinon.spy(replayManager, 'send');
     const postSpansSpy = sinon.spy(api, 'postSpans');
 
-    const sendOrDiscardReplaySpy = sinon.spy(queue, '_sendOrDiscardReplay');
+    const sendOrDiscardReplaySpy = sinon.spy(replayManager, 'sendOrDiscardReplay');
 
     const errorItem = {
       data: {

--- a/test/replay/integration/sessionRecording.test.js
+++ b/test/replay/integration/sessionRecording.test.js
@@ -249,7 +249,7 @@ describe('Session Replay Transport Integration', function () {
   });
 
   it('should add replayId to error item and send replay on success', function (done) {
-    const addSpy = sinon.spy(replayManager, 'add');
+    const captureSpy = sinon.spy(replayManager, 'capture');
     const sendSpy = sinon.spy(replayManager, 'send');
     const postSpansSpy = sinon.spy(api, 'postSpans');
 
@@ -268,7 +268,7 @@ describe('Session Replay Transport Integration', function () {
 
     queue.addItem(errorItem, (err, resp) => {
       expect(errorItem).to.have.property('replayId');
-      expect(addSpy.calledOnce).to.be.true;
+      expect(captureSpy.calledOnce).to.be.true;
 
       expect(err).to.be.null;
       expect(resp).to.have.property('err', 0);
@@ -291,7 +291,7 @@ describe('Session Replay Transport Integration', function () {
         }, 10);
       });
 
-    const addSpy = sinon.spy(replayManager, 'add');
+    const captureSpy = sinon.spy(replayManager, 'capture');
     const sendSpy = sinon.spy(replayManager, 'send');
     const discardSpy = sinon.spy(replayManager, 'discard');
 
@@ -310,7 +310,7 @@ describe('Session Replay Transport Integration', function () {
 
     queue.addItem(errorItem, (err, resp) => {
       expect(errorItem).to.have.property('replayId');
-      expect(addSpy.calledOnce).to.be.true;
+      expect(captureSpy.calledOnce).to.be.true;
 
       setTimeout(function () {
         expect(discardSpy.calledWith(errorItem.replayId)).to.be.true;
@@ -322,7 +322,7 @@ describe('Session Replay Transport Integration', function () {
   });
 
   it('should handle full end-to-end flow from error to spans', async function () {
-    const addSpy = sinon.spy(replayManager, 'add');
+    const captureSpy = sinon.spy(replayManager, 'capture');
     const sendSpy = sinon.spy(replayManager, 'send');
     const postSpansSpy = sinon.spy(api, 'postSpans');
 
@@ -350,7 +350,7 @@ describe('Session Replay Transport Integration', function () {
 
     await addItemPromise;
     expect(errorItem).to.have.property('replayId');
-    expect(addSpy.calledOnce).to.be.true;
+    expect(captureSpy.calledOnce).to.be.true;
 
     const responsePromise = sendOrDiscardReplaySpy.returnValues[0];
     await responsePromise;

--- a/test/replay/unit/queue.replayManager.test.js
+++ b/test/replay/unit/queue.replayManager.test.js
@@ -8,7 +8,7 @@ import Queue from '../../../src/queue.js';
 
 class MockReplayManager {
   constructor() {
-    this.add = sinon.stub().returnsArg(0);
+    this.capture = sinon.stub().returnsArg(0);
     this.send = sinon.stub().resolves(true);
     this.discard = sinon.stub().returns(true);
   }
@@ -66,7 +66,7 @@ describe('Queue with ReplayManager', function () {
 
       queue.addItem(item, callback);
 
-      expect(replayManager.add.called).to.be.true;
+      expect(replayManager.capture.called).to.be.true;
       expect(item.replayId).to.equal('1234567812345678');
     });
 
@@ -81,7 +81,7 @@ describe('Queue with ReplayManager', function () {
 
       queue.addItem(item, callback);
 
-      expect(replayManager.add.called).to.be.false;
+      expect(replayManager.capture.called).to.be.false;
       expect(item.replayId).to.be.undefined;
     });
 

--- a/test/replay/unit/recorder.collectEvents.test.js
+++ b/test/replay/unit/recorder.collectEvents.test.js
@@ -1,0 +1,167 @@
+import { expect } from 'chai';
+import { EventType } from '@rrweb/types';
+
+import Recorder from '../../../src/browser/replay/recorder.js';
+import { setCurrentBuffer, setPreviousBuffer } from '../util/recorder.js';
+
+describe('Recorder buffer-index event collection', function () {
+  let recorder;
+  const mockRecordFn = () => () => {};
+
+  beforeEach(function () {
+    recorder = new Recorder(
+      {
+        enabled: true,
+        autoStart: false,
+        maxSeconds: 10,
+      },
+      mockRecordFn,
+    );
+  });
+
+  describe('_collectAll', function () {
+    it('returns all events from both buffers', function () {
+      setPreviousBuffer(recorder, [
+        { timestamp: 1000, type: EventType.Meta, data: {} },
+        { timestamp: 2000, type: EventType.Meta, data: {} },
+      ]);
+      setCurrentBuffer(recorder, [
+        { timestamp: 3000, type: EventType.Meta, data: {} },
+        { timestamp: 4000, type: EventType.Meta, data: {} },
+      ]);
+
+      const events = recorder._collectAll();
+
+      expect(events).to.have.lengthOf(5);
+      expect(events[0].timestamp).to.equal(1000);
+      expect(events[1].timestamp).to.equal(2000);
+      expect(events[2].timestamp).to.equal(3000);
+      expect(events[3].timestamp).to.equal(4000);
+      expect(events[4].data.tag).to.equal('replay.end');
+    });
+
+    it('returns empty array when no events exist', function () {
+      setPreviousBuffer(recorder, []);
+      setCurrentBuffer(recorder, []);
+
+      const events = recorder._collectAll();
+
+      expect(events).to.have.lengthOf(0);
+    });
+  });
+
+  describe('_collectEventsFromCursor', function () {
+    it('returns events after cursor in same buffer', function () {
+      recorder._buffers[0] = [
+        { timestamp: 1000, type: EventType.Meta, data: {} },
+        { timestamp: 2000, type: EventType.Meta, data: {} },
+        { timestamp: 3000, type: EventType.Meta, data: {} },
+        { timestamp: 4000, type: EventType.Meta, data: {} },
+      ];
+      recorder._currentSlot = 0;
+
+      const cursor = { slot: 0, offset: 1 };
+      const events = recorder._collectEventsFromCursor(cursor);
+
+      expect(events).to.have.lengthOf(3);
+      expect(events[0].timestamp).to.equal(3000);
+      expect(events[1].timestamp).to.equal(4000);
+      expect(events[2].data.tag).to.equal('replay.end');
+    });
+
+    it('returns events after cursor spanning checkout', function () {
+      recorder._buffers[0] = [
+        { timestamp: 1000, type: EventType.Meta, data: {} },
+        { timestamp: 2000, type: EventType.Meta, data: {} },
+        { timestamp: 3000, type: EventType.Meta, data: {} },
+      ];
+      recorder._buffers[1] = [
+        { timestamp: 4000, type: EventType.Meta, data: {} },
+        { timestamp: 5000, type: EventType.Meta, data: {} },
+      ];
+      recorder._currentSlot = 1;
+
+      const cursor = { slot: 0, offset: 1 };
+      const events = recorder._collectEventsFromCursor(cursor);
+
+      expect(events).to.have.lengthOf(4);
+      expect(events[0].timestamp).to.equal(3000);
+      expect(events[1].timestamp).to.equal(4000);
+      expect(events[2].timestamp).to.equal(5000);
+      expect(events[3].data.tag).to.equal('replay.end');
+    });
+
+    it('handles empty captured buffer after multiple checkouts', function () {
+      recorder._buffers[0] = [];
+      recorder._buffers[1] = [
+        { timestamp: 5000, type: EventType.Meta, data: {} },
+        { timestamp: 6000, type: EventType.Meta, data: {} },
+      ];
+      recorder._currentSlot = 1;
+
+      const cursor = { slot: 0, offset: 2 };
+      const events = recorder._collectEventsFromCursor(cursor);
+
+      expect(events).to.have.lengthOf(3);
+      expect(events[0].timestamp).to.equal(5000);
+      expect(events[1].timestamp).to.equal(6000);
+      expect(events[2].data.tag).to.equal('replay.end');
+    });
+
+    it('returns empty array when cursor is at end of current buffer', function () {
+      recorder._buffers[0] = [
+        { timestamp: 1000, type: EventType.Meta, data: {} },
+        { timestamp: 2000, type: EventType.Meta, data: {} },
+      ];
+      recorder._currentSlot = 0;
+
+      const cursor = { slot: 0, offset: 1 };
+      const events = recorder._collectEventsFromCursor(cursor);
+
+      expect(events).to.have.lengthOf(0);
+    });
+
+    it('handles offset beyond buffer length', () => {
+      recorder._buffers[0] = [
+        { timestamp: 1000, type: EventType.Meta, data: {} },
+        { timestamp: 2000, type: EventType.Meta, data: {} },
+      ];
+      recorder._buffers[1] = [
+        { timestamp: 3000, type: EventType.Meta, data: {} },
+      ];
+      recorder._currentSlot = 1;
+
+      const cursor = { slot: 0, offset: 10 };
+      const events = recorder._collectEventsFromCursor(cursor);
+
+      expect(events).to.have.lengthOf(2);
+      expect(events[0].timestamp).to.equal(3000);
+      expect(events[1].data.tag).to.equal('replay.end');
+    });
+  });
+
+  describe('bufferCursor', () => {
+    it('returns current buffer index and offset', () => {
+      recorder._buffers[0] = [
+        { timestamp: 1000, type: EventType.Meta, data: {} },
+        { timestamp: 2000, type: EventType.Meta, data: {} },
+      ];
+      recorder._currentSlot = 0;
+
+      const cursor = recorder.bufferCursor();
+
+      expect(cursor).to.deep.equal({ slot: 0, offset: 1 });
+    });
+
+    it('updates after checkout', () => {
+      recorder._buffers[1] = [
+        { timestamp: 3000, type: EventType.Meta, data: {} },
+      ];
+      recorder._currentSlot = 1;
+
+      const cursor = recorder.bufferCursor();
+
+      expect(cursor).to.deep.equal({ slot: 1, offset: 0 });
+    });
+  });
+});

--- a/test/replay/unit/replayManager.test.js
+++ b/test/replay/unit/replayManager.test.js
@@ -211,7 +211,7 @@ describe('ReplayManager', function () {
         .stub(replayManager, '_exportSpansAndAddTracingPayload')
         .resolves();
 
-      const resp = replayManager.add(replayId, uuid);
+      const resp = replayManager.capture(replayId, uuid);
 
       expect(resp).to.equal(replayId);
       expect(id.gen.calledWith(8)).to.be.false;
@@ -224,7 +224,7 @@ describe('ReplayManager', function () {
         .stub(replayManager, '_exportSpansAndAddTracingPayload')
         .resolves();
 
-      const replayId = replayManager.add(null, uuid);
+      const replayId = replayManager.capture(null, uuid);
 
       expect(replayId).to.equal('1234567890abcdef');
       expect(id.gen.calledWith(8)).to.be.true;
@@ -236,9 +236,9 @@ describe('ReplayManager', function () {
       const processStub = sinon
         .stub(replayManager, '_exportSpansAndAddTracingPayload')
         .resolves();
-        mockRecorder.isReady = false;
+      mockRecorder.isReady = false;
 
-      const replayId = replayManager.add(null, uuid);
+      const replayId = replayManager.capture(null, uuid);
 
       expect(replayId).to.be.null;
       expect(id.gen.called).to.be.false;

--- a/test/replay/unit/replayManager.test.js
+++ b/test/replay/unit/replayManager.test.js
@@ -106,7 +106,10 @@ describe('ReplayManager', function () {
 
       const expectedPayload = [{ id: 'span1' }, { id: 'span2' }];
 
-      await replayManager._exportSpansAndAddTracingPayload(replayId, occurrenceUuid);
+      await replayManager._exportSpansAndAddTracingPayload(
+        replayId,
+        occurrenceUuid,
+      );
 
       expect(mockTelemeter.exportTelemetrySpan.calledOnce).to.be.true;
       expect(
@@ -145,7 +148,10 @@ describe('ReplayManager', function () {
       const loggerSpy = sinon.spy(logger, 'error');
       const replayId = '1234567890abcdef';
       const occurrenceUuid = 'test-uuid';
-      await replayManager._exportSpansAndAddTracingPayload(replayId, occurrenceUuid);
+      await replayManager._exportSpansAndAddTracingPayload(
+        replayId,
+        occurrenceUuid,
+      );
 
       expect(mockRecorder.exportRecordingSpan.called).to.be.true;
       expect(
@@ -177,7 +183,10 @@ describe('ReplayManager', function () {
       const occurrenceUuid = 'test-uuid';
 
       const expectedPayload = [{ id: 'span1' }, { id: 'span2' }];
-      await replayManager._exportSpansAndAddTracingPayload(replayId, occurrenceUuid);
+      await replayManager._exportSpansAndAddTracingPayload(
+        replayId,
+        occurrenceUuid,
+      );
       expect(mockRecorder.exportRecordingSpan.called).to.be.true;
       expect(
         mockRecorder.exportRecordingSpan.calledWith(mockTracing, {

--- a/test/replay/util/recorder.js
+++ b/test/replay/util/recorder.js
@@ -1,0 +1,9 @@
+/**
+ * Test utilities for accessing Recorder's ring buffer internals.
+ */
+
+export const currentBuffer = (r) => r._buffers[r._currentSlot];
+export const previousBuffer = (r) => r._buffers[r._previousSlot];
+
+export const setCurrentBuffer = (r, es) => (r._buffers[r._currentSlot] = es);
+export const setPreviousBuffer = (r, es) => (r._buffers[r._previousSlot] = es);


### PR DESCRIPTION
## Description of the change

Implements post-trigger replay capture, enabling recording of user actions *after* a trigger event, such as an occurrence. Complements existing pre-trigger (trailing) replay with configurable `postDuration`.

### Sub-PRs (All Approved)

1. #1334 - Capture leading replayInitial implementation with event count boundary
2. #1337 - Renamed ReplayManager.add to ReplayManager.captureAPI clarity improvement
3. #1338 - Move send replay from Queue to ReplayManagerArchitectural refactor for leading replay coordination
4. #1339 - Replace count-based boundary with buffer cursorStable {slot, offset} cursor eliminates rotation bugs

### Implementation Highlights

#### Architecture
- Two-phase capture: trailing (immediate) + leading (delayed by `postDuration`).
- Trailing prioritized for high success rate; leading sent only if trailing succeeds.
- Coordinated via `TrailingStatus` state machine (`PENDING` → `SENT`/`FAILED`).

#### Buffer Cursor System
- Replaced fragile event count with `{slot: 0|1, offset: number}` cursor.
- Survives single checkout rotation; best-effort with multiple checkouts.
- 2-slot ring buffer with XOR-based `_previousSlot` getter.

#### Key Features
- Configure via `recorder.postDuration` (seconds)
- Automatic coordination between trailing/leading sends
- Complete state cleanup on success/failure/discard
- 29 new tests; 124 total replay tests passing

### Changes
- Core: Recorder, ReplayManager
- Tests: Unit, integration, e2e coverage

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- https://linear.app/rollbar-inc/issue/PRO-535/story-send-session-recording-only-when-relevant
- https://linear.app/rollbar-inc/issue/PRO-1036/verify-that-at-least-5-seconds-of-session-data-can-be-sent-after-the
