### PR TITLE
Promote ReplayManager to component, replacing Recorder

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -12,9 +12,8 @@ import * as sharedTransforms from '../transforms.js';
 import * as predicates from './predicates.js';
 import * as sharedPredicates from '../predicates.js';
 import errorParser from '../errorParser.js';
-import recorderDefaults from './replay/defaults.js';
+import replayDefaults from './replay/defaults.js';
 import tracingDefaults from '../tracing/defaults.js';
-import ReplayManager from './replay/replayManager.js';
 
 // Used to support global `Rollbar` instance.
 let _instance = null;
@@ -31,7 +30,7 @@ class Rollbar {
     this.scrub = this.components.scrub;
     const truncation = this.components.truncation;
     const Tracing = this.components.tracing;
-    const Recorder = this.components.recorder;
+    const ReplayManager = this.components.replayManager;
 
     const transport = new Transport(truncation);
     const api = new API(this.options, transport, urllib, truncation);
@@ -43,18 +42,16 @@ class Rollbar {
       this.telemeter = new Telemeter(this.options, this.tracing);
     }
 
-    if (Recorder && _.isBrowser()) {
-      const recorderOptions = this.options.recorder;
-      this.recorder = new Recorder(recorderOptions);
+    if (ReplayManager && _.isBrowser()) {
+      const replayOptions = this.options.replay;
       this.replayManager = new ReplayManager({
-        recorder: this.recorder,
-        api: api,
         tracing: this.tracing,
         telemeter: this.telemeter,
+        options: replayOptions,
       });
 
-      if (recorderOptions.enabled && recorderOptions.autoStart) {
-        this.recorder.start();
+      if (replayOptions.enabled && replayOptions.autoStart) {
+        this.replayManager.recorder.start();
       }
     }
 
@@ -129,7 +126,7 @@ class Rollbar {
     );
 
     this.tracing?.configure(this.options);
-    this.recorder?.configure(this.options);
+    this.replayManager?.recorder?.configure(this.options);
     this.client.configure(this.options, payloadData);
     this.instrumenter?.configure(this.options);
     this.setupUnhandledCapture();
@@ -582,7 +579,7 @@ import {
 } from '../defaults.js';
 import browserDefaults from './defaults.js';
 
-var defaultOptions = {
+const defaultOptions = {
   environment: 'unknown',
   version: version,
   scrubFields: browserDefaults.scrubFields,
@@ -599,7 +596,7 @@ var defaultOptions = {
   inspectAnonymousErrors: true,
   ignoreDuplicateErrors: true,
   wrapGlobalEventHandlers: false,
-  recorder: recorderDefaults,
+  replay: replayDefaults,
   tracing: tracingDefaults,
 };
 

--- a/src/browser/replay/recorder.js
+++ b/src/browser/replay/recorder.js
@@ -27,15 +27,12 @@ export default class Recorder {
    * Creates a new Recorder instance for capturing DOM events
    *
    * @param {Object} options - Configuration options for the recorder
-   * @param {Function} [recordFn=rrwebRecordFn] - The recording function to use
    */
-  constructor(options, recordFn = rrwebRecordFn) {
-    if (!recordFn) {
-      throw new TypeError("Expected 'recordFn' to be provided");
-    }
-
+  constructor(options) {
     this.options = options;
-    this._recordFn = recordFn;
+
+    // Tests inject a custom rrweb record function or mock.
+    this._recordFn = options.recordFn ||rrwebRecordFn;
   }
 
   get isRecording() {

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -5,7 +5,7 @@ import wrapGlobals from './wrapGlobals.js';
 import scrub from '../scrub.js';
 import truncation from '../truncation.js';
 import Tracing from '../tracing/tracing.js';
-import Recorder from './replay/recorder.js';
+import ReplayManager from './replay/replayManager.js';
 
 Rollbar.setComponents({
   telemeter: Telemeter,
@@ -14,7 +14,7 @@ Rollbar.setComponents({
   scrub: scrub,
   truncation: truncation,
   tracing: Tracing,
-  recorder: Recorder,
+  replayManager: ReplayManager,
 });
 
 export default Rollbar;

--- a/test/browser.replay.recorder.test.js
+++ b/test/browser.replay.recorder.test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { record as rrwebRecordFn } from '@rrweb/record';
 import { EventType } from '@rrweb/types';
 
 import Recorder from '../src/browser/replay/recorder.js';
@@ -65,17 +66,16 @@ describe('Recorder', function () {
       });
     });
 
-    it('should throw error if no record function is passed', function () {
-      expect(() => new Recorder({}, null)).to.throw(
-        TypeError,
-        "Expected 'recordFn' to be provided",
-      );
+    it('should use the default recorder if no record function is passed', function () {
+      const recorder = new Recorder({});
+
+      expect(recorder._recordFn).to.equal(rrwebRecordFn);
     });
   });
 
   describe('recording management', function () {
     it('should start recording correctly', function () {
-      const recorder = new Recorder({ enabled: true }, recordFnStub);
+      const recorder = new Recorder({ enabled: true, recordFn: recordFnStub });
       recorder.start();
 
       expect(recorder.isRecording).to.be.true;
@@ -88,7 +88,7 @@ describe('Recorder', function () {
     });
 
     it('should not start if already recording', function () {
-      const recorder = new Recorder({ enabled: true }, recordFnStub);
+      const recorder = new Recorder({ enabled: true, recordFn: recordFnStub });
       recorder.start();
       recorder.start();
 
@@ -96,7 +96,7 @@ describe('Recorder', function () {
     });
 
     it('should not start if disabled', function () {
-      const recorder = new Recorder({ enabled: false }, recordFnStub);
+      const recorder = new Recorder({ enabled: false, recordFn: recordFnStub });
       recorder.start();
 
       expect(recorder.isRecording).to.be.false;
@@ -104,7 +104,7 @@ describe('Recorder', function () {
     });
 
     it('should stop recording correctly', function () {
-      const recorder = new Recorder({ enabled: true }, recordFnStub);
+      const recorder = new Recorder({ enabled: true, recordFn: recordFnStub });
       recorder.start();
       recorder.stop();
 
@@ -124,7 +124,7 @@ describe('Recorder', function () {
 
   describe('event handling', function () {
     it('should handle events correctly', function () {
-      const recorder = new Recorder({}, recordFnStub);
+      const recorder = new Recorder({ recordFn: recordFnStub });
       recorder.start();
 
       const event1 = { timestamp: 1000, type: 'event1', data: { a: 1 } };
@@ -166,7 +166,7 @@ describe('Recorder', function () {
     });
 
     it('should be ready after first full snapshot', function () {
-      const recorder = new Recorder({}, recordFnStub);
+      const recorder = new Recorder({ recordFn: recordFnStub });
       recorder.start();
 
       // First checkout
@@ -181,7 +181,7 @@ describe('Recorder', function () {
     });
 
     it('should handle checkout events correctly', function () {
-      const recorder = new Recorder({}, recordFnStub);
+      const recorder = new Recorder({ recordFn: recordFnStub });
       recorder.start();
 
       // First checkout
@@ -308,7 +308,7 @@ describe('Recorder', function () {
 
   describe('dump functionality', function () {
     it('should create a span with events and return formatted payload', function () {
-      const recorder = new Recorder({}, recordFnStub);
+      const recorder = new Recorder({ recordFn: recordFnStub });
       recorder.start();
 
       emitCallback({ timestamp: 1000, type: 'event1', data: { a: 1 } }, false);
@@ -355,7 +355,7 @@ describe('Recorder', function () {
     });
 
     it('should create a span with the correct span name', function () {
-      const recorder = new Recorder({}, recordFnStub);
+      const recorder = new Recorder({ recordFn: recordFnStub });
       recorder.start();
 
       emitCallback({ timestamp: 1000, type: 'event1', data: { a: 1 } }, false);
@@ -371,7 +371,7 @@ describe('Recorder', function () {
     });
 
     it('should add events with the correct event name and replayId', function () {
-      const recorder = new Recorder({}, recordFnStub);
+      const recorder = new Recorder({ recordFn: recordFnStub });
       recorder.start();
 
       emitCallback(
@@ -402,7 +402,7 @@ describe('Recorder', function () {
     });
 
     it('should handle no events', function () {
-      const recorder = new Recorder({}, recordFnStub);
+      const recorder = new Recorder({ recordFn: recordFnStub });
 
       expect(() => {
         recorder.exportRecordingSpan(mockTracing, {
@@ -417,7 +417,7 @@ describe('Recorder', function () {
 
   describe('configure', function () {
     it('should update options', function () {
-      const recorder = new Recorder({ enabled: true }, recordFnStub);
+      const recorder = new Recorder({ enabled: true, recordFn: recordFnStub });
 
       recorder.configure({ enabled: false, maxSeconds: 20 });
 
@@ -449,7 +449,7 @@ describe('Recorder', function () {
     });
 
     it('should stop recording if enabled set to false', function () {
-      const recorder = new Recorder({ enabled: true }, recordFnStub);
+      const recorder = new Recorder({ enabled: true, recordFn: recordFnStub });
       recorder.start();
 
       expect(recorder.isRecording).to.be.true;

--- a/test/browser.rollbar.test.js
+++ b/test/browser.rollbar.test.js
@@ -105,7 +105,7 @@ describe('Rollbar()', function () {
     var client = new (TestClientGen())();
     var options = {
       scrubFields: ['foobar'],
-      recorder: {
+      replay: {
         enabled: true,
       },
       tracing: {
@@ -116,8 +116,8 @@ describe('Rollbar()', function () {
 
     expect(rollbar.options.scrubFields).to.contain('foobar');
     expect(rollbar.options.scrubFields).to.contain('password');
-    expect(rollbar.options.recorder.enabled).to.be.true;
-    expect(rollbar.options.recorder.triggers[0].level).to.eql([
+    expect(rollbar.options.replay.enabled).to.be.true;
+    expect(rollbar.options.replay.triggers[0].level).to.eql([
       'error',
       'critical',
     ]);
@@ -869,7 +869,7 @@ describe('log', function () {
 
     expect(body.data.body.trace.exception.message).to.eql('test error');
     expect(body.data.attributes).to.be.an('array');
-    expect(body.data.attributes.length).to.eql(4);
+    expect(body.data.attributes.length).to.eql(3);
     expect(body.data.attributes[0].key).to.eql('session_id');
     expect(body.data.attributes[0].value).to.match(/^[a-f0-9]{32}$/);
     expect(body.data.attributes[1].key).to.eql('span_id');

--- a/test/replay/unit/recorder.test.js
+++ b/test/replay/unit/recorder.test.js
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
+import { record as rrwebRecordFn } from '@rrweb/record';
 
 import Recorder from '../../../src/browser/replay/recorder.js';
 
@@ -29,11 +30,10 @@ describe('Recorder', function () {
       expect(recorder.isRecording).to.be.false;
     });
 
-    it('throws when recordFn is not provided', function () {
-      expect(() => new Recorder({}, null)).to.throw(
-        TypeError,
-        "Expected 'recordFn' to be provided",
-      );
+    it('uses default when recordFn is not provided', function () {
+      const recorder = new Recorder({})
+
+      expect(recorder._recordFn).to.equal(rrwebRecordFn);
     });
 
     it('initializes buffers and slots correctly', function () {


### PR DESCRIPTION
## Description of the change

This PR replaces `Recorder` as a component passed to core.js with `ReplayManager` and encapsulates `Recorder` and `replayPredicates` within `ReplayManager`. This allows all replay classes to be removed when replay is not added as a component.

This PR also renames the `recorder` config key to `replay`.

## Type of change


- [x] Refactor


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

