### PR TITLE
`.git-blame-ignore-revs` to ignore the prettier mass format from diffs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Prettier mass-format
+7a829f8ac3bbd146425a401b8434cf9cbaddaba1


### PR DESCRIPTION
## Description of the change

This pull request adds a new commit hash to the `.git-blame-ignore-revs` file to ignore a mass-formatting change made by Prettier.

[SDK-548/complete-prettier-rollout](https://linear.app/rollbar-inc/issue/SDK-548/complete-prettier-rollout)