### PR TITLE
Make lint-action go through the same script extensions for prettier

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
     tags: [v*]
   pull_request:
 
+permissions:
+  checks: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Description of the change

This PR updates the `prettier_extensions` option in the CI workflow to follow the same extension list as our `format` script in `package.json`.

[SDK-548/complete-prettier-rollout](https://linear.app/rollbar-inc/issue/SDK-548/complete-prettier-rollout)