### PR TITLE
Add rollbar.replay.url.full attribute

### DIFF
--- a/src/browser/replay/replayManager.js
+++ b/src/browser/replay/replayManager.js
@@ -1,3 +1,4 @@
+import * as _ from '../../utility.js';
 import id from '../../tracing/id.js';
 import logger from '../../logger.js';
 import Recorder from './recorder.js';
@@ -75,6 +76,7 @@ export default class ReplayManager {
         'rollbar.replay.trigger.type': trigger.type,
         'rollbar.replay.trigger.context': JSON.stringify(triggerContext),
         'rollbar.replay.trigger': JSON.stringify(trigger),
+        'rollbar.replay.url.full': _.sanitizeHref(window.location.href),
       });
     } catch (error) {
       logger.error('Error exporting recording span:', error);

--- a/src/utility.js
+++ b/src/utility.js
@@ -172,6 +172,21 @@ var LEVELS = {
   critical: 4,
 };
 
+function sanitizeHref(url) {
+  try {
+    const urlObject = new URL(url);
+    if (urlObject.password) {
+      urlObject.password = redact();
+    }
+    if (urlObject.search) {
+      urlObject.search = redact();
+    }
+    return urlObject.toString();
+  } catch (_) {
+    return url; // Return original URL if parsing fails
+  }
+}
+
 function sanitizeUrl(url) {
   var baseUrlParts = parseUri(url);
   if (!baseUrlParts) {
@@ -798,6 +813,7 @@ export {
   merge,
   now,
   redact,
+  sanitizeHref,
   sanitizeUrl,
   set,
   stringify,

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -176,7 +176,7 @@ describe('Session Replay E2E', function () {
           expect(span_r).to.have.property('events');
           expect(span_r.events).to.be.an('array');
           expect(span_r).to.have.property('attributes').that.is.an('array');
-          expect(span_r.attributes).to.have.lengthOf(12);
+          expect(span_r.attributes).to.have.lengthOf(13);
 
           expect(span_r.attributes).to.deep.include({
             key: 'rollbar.replay.id',

--- a/test/replay/integration/replayManager.bufferIndex.checkoutResilience.test.js
+++ b/test/replay/integration/replayManager.bufferIndex.checkoutResilience.test.js
@@ -89,6 +89,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
         'rollbar.replay.trigger.type': trigger.type,
         'rollbar.replay.trigger.context': JSON.stringify(triggerContext),
         'rollbar.replay.trigger': JSON.stringify(trigger),
+        'rollbar.replay.url.full': 'http://localhost:8000/?********',
       },
     ]);
     expect(recorder.exportRecordingSpan.secondCall.args).to.deep.equal([
@@ -146,6 +147,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
         'rollbar.replay.trigger.type': trigger.type,
         'rollbar.replay.trigger.context': JSON.stringify(triggerContext),
         'rollbar.replay.trigger': JSON.stringify(trigger),
+        'rollbar.replay.url.full': 'http://localhost:8000/?********',
       },
     ]);
     expect(recorder.exportRecordingSpan.secondCall.args).to.deep.equal([
@@ -208,6 +210,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
         'rollbar.replay.trigger.type': trigger.type,
         'rollbar.replay.trigger.context': JSON.stringify(triggerContext),
         'rollbar.replay.trigger': JSON.stringify(trigger),
+        'rollbar.replay.url.full': 'http://localhost:8000/?********',
       },
     ]);
     expect(recorder.exportRecordingSpan.secondCall.args).to.deep.equal([

--- a/test/replay/integration/replayManager.bufferIndex.test.js
+++ b/test/replay/integration/replayManager.bufferIndex.test.js
@@ -130,6 +130,7 @@ describe('ReplayManager buffer-index integration', function () {
         'rollbar.replay.trigger.type': trigger.type,
         'rollbar.replay.trigger.context': JSON.stringify(triggerContext),
         'rollbar.replay.trigger': JSON.stringify(trigger),
+        'rollbar.replay.url.full': 'http://localhost:8000/?********',
       },
     ]);
 

--- a/test/replay/integration/replayManager.test.js
+++ b/test/replay/integration/replayManager.test.js
@@ -102,6 +102,7 @@ describe('ReplayManager API Integration', function () {
         'rollbar.replay.trigger.type': trigger.type,
         'rollbar.replay.trigger.context': JSON.stringify(triggerContext),
         'rollbar.replay.trigger': JSON.stringify(trigger),
+        'rollbar.replay.url.full': 'http://localhost:8000/?********',
       }),
     ).to.be.true;
     expect(tracing.exporter.toPayload.calledOnce).to.be.true;

--- a/test/replay/unit/replayManager.test.js
+++ b/test/replay/unit/replayManager.test.js
@@ -128,6 +128,7 @@ describe('ReplayManager', function () {
           'rollbar.replay.trigger.type': trigger.type,
           'rollbar.replay.trigger.context': JSON.stringify(triggerContext),
           'rollbar.replay.trigger': JSON.stringify(trigger),
+          'rollbar.replay.url.full': 'http://localhost:8000/?********',
         }),
       ).to.be.true;
 
@@ -168,6 +169,7 @@ describe('ReplayManager', function () {
           'rollbar.replay.trigger.type': trigger.type,
           'rollbar.replay.trigger.context': JSON.stringify(triggerContext),
           'rollbar.replay.trigger': JSON.stringify(trigger),
+          'rollbar.replay.url.full': 'http://localhost:8000/?********',
         }),
       ).to.be.true;
 
@@ -207,6 +209,7 @@ describe('ReplayManager', function () {
           'rollbar.replay.trigger.type': trigger.type,
           'rollbar.replay.trigger.context': JSON.stringify(triggerContext),
           'rollbar.replay.trigger': JSON.stringify(trigger),
+          'rollbar.replay.url.full': 'http://localhost:8000/?********',
         }),
       ).to.be.true;
 


### PR DESCRIPTION
## Description of the change

Adds the `rollbar.replay.url.full` attribute.

## Type of change


- [x] New feature (non-breaking change that adds functionality)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


