### PR TITLE
Add client.address session attribute

### DIFF
--- a/src/tracing/session.js
+++ b/src/tracing/session.js
@@ -84,6 +84,7 @@ export class Session {
       'browser.language': navigator.language,
       'browser.mobile': navigator.userAgentData?.mobile,
       'browser.platform': navigator.userAgentData?.platform,
+      'client.address': '$remote_ip', // updated at the API
       'user_agent.original': navigator.userAgent,
       ...attrs,
     });

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -176,7 +176,7 @@ describe('Session Replay E2E', function () {
           expect(span_r).to.have.property('events');
           expect(span_r.events).to.be.an('array');
           expect(span_r).to.have.property('attributes').that.is.an('array');
-          expect(span_r.attributes).to.have.lengthOf(13);
+          expect(span_r.attributes).to.have.lengthOf(14);
 
           expect(span_r.attributes).to.deep.include({
             key: 'rollbar.replay.id',


### PR DESCRIPTION
## Description of the change

Add `client.address` attribute, which is updated with the client ip address at the API.

## Type of change

- [x] New feature (non-breaking change that adds functionality)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


