### PR TITLE
Use values in the payload key as session attributes

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -450,13 +450,17 @@ class Rollbar {
   }
 
   setSessionAttributesFromOptions(options) {
-    if (options.person) {
-      this.setSessionUser(options.person);
+    const person = options.person || options.payload?.person;
+    if (person) {
+      this.setSessionUser(person);
     }
     const code_version =
       options.client?.javascript?.code_version ||
       options.codeVersion ||
-      options.code_version;
+      options.code_version ||
+      options.payload?.client?.javascript?.code_version ||
+      options.payload?.code_version ||
+      options.payload?.codeVersion;
     this.setSessionAttributes({
       'rollbar.codeVersion': code_version,
       'rollbar.notifier.name': 'rollbar-browser-js',

--- a/test/browser.core.test.js
+++ b/test/browser.core.test.js
@@ -58,6 +58,27 @@ describe('options', function () {
     expect(session.attributes['user.email']).to.equal('user@test.com');
     expect(session.attributes['rollbar.codeVersion']).to.equal('abc123');
   });
+
+  it('should set session attributes from payload key', function () {
+    const rollbar = new Rollbar({
+      accessToken: 'POST_CLIENT_ITEM_TOKEN',
+      captureUnhandledRejections: false,
+      payload: {
+        person: {
+          id: '12345',
+          name: 'Test User',
+          email: 'user@test.com',
+        },
+        codeVersion: 'abc123',
+      },
+    });
+    const session = rollbar.tracing.session;
+    expect(session).to.exist;
+    expect(session.attributes['user.id']).to.equal('12345');
+    expect(session.attributes['user.name']).to.equal('Test User');
+    expect(session.attributes['user.email']).to.equal('user@test.com');
+    expect(session.attributes['rollbar.codeVersion']).to.equal('abc123');
+  });
 });
 
 describe('options.captureUncaught', function () {


### PR DESCRIPTION
## Description of the change

These values may be set directly in the payload vs their config keys. This PR updates to look for values set there.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

