### PR TITLE
Add ReplayManager.triggerReplay

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -194,6 +194,16 @@ class Rollbar {
     return this.client.sendJsonPayload(jsonPayload);
   }
 
+  triggerDirectReplay(context) {
+    return this.triggerReplay({ type: 'direct', ...context });
+  }
+
+  triggerReplay(context) {
+    if (!this.replayManager) return null;
+
+    return this.replayManager.triggerReplay(context);
+  }
+
   setupUnhandledCapture() {
     var gWindow = _gWindow();
 


### PR DESCRIPTION
## Description of the change

Adds `triggerReplay` method to ReplayManager, with different requirements than the occurrence-centric `capture` and `sendOrDiscardReplay`.
* Initiates `send` immediately after export, and therefore awaits export.
* Tolerates triggering before the recorder is ready, so that postDuration triggers work when triggered at code init.
* `triggerReplay` is async so that it can be non-blocking for the caller and also return the replayId when it succeeds.
* Doesn't use occurrence-based `_canSendReplay`.

There may be an opportunity to refactor `triggerReplay` and `capture` to use more shared code. This PR doesn't attempt to solve that. It enables the needed triggers in the short term, allowing more time to consider a preferred refactoring.

## Type of change


- [x] New feature (non-breaking change that adds functionality)


## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

