### PR TITLE
Extract leading capture logic from replay manager

### DIFF
--- a/src/browser/replay/leadingCapture.js
+++ b/src/browser/replay/leadingCapture.js
@@ -1,0 +1,158 @@
+import logger from '../../logger.js';
+
+/** @typedef {import('./recorder.js').BufferCursor} BufferCursor */
+
+/**
+ * Manages delayed "leading" (post-trigger) replay captures.
+ *
+ * Coordinates timing, buffer cursor stability, and payload preparation
+ * for events that occur AFTER the trigger event.
+ */
+export default class LeadingCapture {
+  _recorder;
+  _tracing;
+  _telemeter;
+  _pending = new Map();
+  _shouldSend;
+  _onComplete;
+
+  /**
+   * Creates a new LeadingCapture instance
+   *
+   * @param {Object} props - Configuration object
+   * @param {Object} props.recorder - Recorder instance for capturing events
+   * @param {Object} props.tracing - Tracing instance for span management
+   * @param {Object} props.telemeter - Optional telemeter for telemetry spans
+   * @param {Function} props.shouldSend - Function to check if replay can be sent
+   * @param {Function} props.onComplete - Function to call when leading capture completes
+   */
+  constructor({ recorder, tracing, telemeter, shouldSend, onComplete }) {
+    this._recorder = recorder;
+    this._tracing = tracing;
+    this._telemeter = telemeter;
+    this._shouldSend = shouldSend;
+    this._onComplete = onComplete;
+  }
+
+  /**
+   * Schedules the capture of leading replay events after a delay.
+   *
+   * Captures a buffer cursor at the time of scheduling, which remains stable
+   * even as the buffer continues to receive events. When the timer fires,
+   * events after this cursor position are exported as the leading replay.
+   *
+   * @param {string} replayId - The replay ID
+   * @param {string} occurrenceUuid - The occurrence UUID
+   * @param {number} seconds - Number of seconds to wait before capturing
+   */
+  schedule(replayId, occurrenceUuid, seconds) {
+    const bufferCursor = this._recorder.bufferCursor();
+
+    const timerId = setTimeout(async () => {
+      try {
+        await this._export(replayId, occurrenceUuid, bufferCursor);
+        await this.sendIfReady(replayId);
+      } catch (error) {
+        logger.error('Error during leading replay processing:', error);
+      }
+    }, seconds * 1000);
+
+    this._pending.set(replayId, {
+      timerId,
+      occurrenceUuid,
+      bufferCursor,
+      ready: false,
+    });
+  }
+
+  /**
+   * Exports replay spans and adds the payload to pending context.
+   *
+   * Uses the captured buffer cursor to collect events that occurred after
+   * the trigger. Exports both recording and telemetry spans, then generates
+   * the payload and stores it for later sending.
+   *
+   * @param {string} replayId - The replay ID
+   * @param {string} occurrenceUuid - The occurrence UUID
+   * @param {BufferCursor} bufferCursor - Buffer cursor position
+   * @private
+   */
+  async _export(replayId, occurrenceUuid, bufferCursor) {
+    const pendingContext = this._pending.get(replayId);
+
+    if (!pendingContext) {
+      // Already cleaned up, possibly due to discard
+      return;
+    }
+
+    try {
+      this._recorder.exportRecordingSpan(
+        this._tracing,
+        {
+          'rollbar.replay.id': replayId,
+          'rollbar.occurrence.uuid': occurrenceUuid,
+        },
+        bufferCursor,
+      );
+    } catch (error) {
+      logger.error('Error exporting leading recording span:', error);
+      this.discard(replayId);
+      return;
+    }
+
+    this._telemeter?.exportTelemetrySpan({
+      'rollbar.replay.id': replayId,
+    });
+
+    const payload = this._tracing.exporter.toPayload();
+    this._pending.set(replayId, { ready: true, payload });
+  }
+
+  /**
+   * Sends the payload if it's ready and coordination allows it.
+   *
+   * Checks if the replay can be sent via the delegate function and only
+   * sends if coordination requirements are met.
+   *
+   * @param {string} replayId - The replay ID
+   * @returns {Promise<void>}
+   */
+  async sendIfReady(replayId) {
+    const pendingContext = this._pending.get(replayId);
+
+    if (
+      !pendingContext?.ready ||
+      !pendingContext?.payload ||
+      !this._shouldSend(replayId)
+    ) {
+      return;
+    }
+
+    try {
+      await this._tracing.exporter.post(pendingContext.payload, {
+        'X-Rollbar-Replay-Id': replayId,
+      });
+    } catch (error) {
+      logger.error('Failed to send leading replay:', error);
+    }
+
+    this.discard(replayId);
+    this._onComplete?.(replayId);
+  }
+
+  /**
+   * Cancels a scheduled capture and cleans up all state.
+   *
+   * Clears the timer if it hasn't fired yet, and removes all pending
+   * context for the replay.
+   *
+   * @param {string} replayId - The replay ID to discard
+   */
+  discard(replayId) {
+    const pendingContext = this._pending.get(replayId);
+    if (pendingContext?.timerId) {
+      clearTimeout(pendingContext.timerId);
+    }
+    this._pending.delete(replayId);
+  }
+}

--- a/test/replay/integration/replayManager.bufferIndex.checkoutResilience.test.js
+++ b/test/replay/integration/replayManager.bufferIndex.checkoutResilience.test.js
@@ -71,7 +71,8 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
     );
     await clock.tickAsync(100);
 
-    const cursor = replayManager._pendingLeading.get(replayId).bufferCursor;
+    const cursor =
+      replayManager._leadingCapture._pending.get(replayId).bufferCursor;
     expect(cursor).to.be.an('object');
     expect(cursor.slot).to.equal(0);
 
@@ -106,7 +107,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._pendingLeading.size).to.equal(0);
+    expect(replayManager._leadingCapture._pending.size).to.equal(0);
 
     recorder.exportRecordingSpan.restore();
   });
@@ -164,7 +165,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._pendingLeading.size).to.equal(0);
+    expect(replayManager._leadingCapture._pending.size).to.equal(0);
 
     recorder.exportRecordingSpan.restore();
   });
@@ -193,7 +194,8 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
     );
     await clock.tickAsync(100);
 
-    const cursor = replayManager._pendingLeading.get(replayId).bufferCursor;
+    const cursor =
+      replayManager._leadingCapture._pending.get(replayId).bufferCursor;
     expect(cursor).to.be.an('object');
 
     await clock.tickAsync(2000);
@@ -227,7 +229,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._pendingLeading.size).to.equal(0);
+    expect(replayManager._leadingCapture._pending.size).to.equal(0);
 
     recorder.exportRecordingSpan.restore();
   });
@@ -264,7 +266,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._pendingLeading.size).to.equal(0);
+    expect(replayManager._leadingCapture._pending.size).to.equal(0);
   });
 
   it('collects events strictly after the cursor', async function () {
@@ -289,7 +291,8 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
     );
     await clock.tickAsync(100);
 
-    const cursor = replayManager._pendingLeading.get(replayId).bufferCursor;
+    const cursor =
+      replayManager._leadingCapture._pending.get(replayId).bufferCursor;
 
     sinon.spy(recorder, '_collectEventsFromCursor');
 
@@ -312,7 +315,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._pendingLeading.size).to.equal(0);
+    expect(replayManager._leadingCapture._pending.size).to.equal(0);
 
     recorder._collectEventsFromCursor.restore();
   });
@@ -354,7 +357,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
     );
 
     expect(replayManager._map.has(replayId)).to.be.false;
-    expect(replayManager._pendingLeading.has(replayId)).to.be.false;
+    expect(replayManager._leadingCapture._pending.has(replayId)).to.be.false;
     sinon.assert.notCalled(api.postSpans);
 
     logger.error.restore();
@@ -398,7 +401,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._pendingLeading.has(replayId)).to.be.false;
+    expect(replayManager._leadingCapture._pending.has(replayId)).to.be.false;
   });
 
   it('discard cancels timer; success clears state', async function () {
@@ -419,7 +422,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
     replayManager.capture(replayId1, 'test-uuid-1', trigger, triggerContext);
     await clock.tickAsync(100);
 
-    expect(replayManager._pendingLeading.has(replayId1)).to.be.true;
+    expect(replayManager._leadingCapture._pending.has(replayId1)).to.be.true;
 
     replayManager.discard(replayId1);
     await clock.tickAsync(10000);
@@ -438,7 +441,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId2 },
     ]);
-    expect(replayManager._pendingLeading.has(replayId2)).to.be.false;
+    expect(replayManager._leadingCapture._pending.has(replayId2)).to.be.false;
     expect(replayManager._trailingStatus.has(replayId2)).to.be.false;
   });
 });


### PR DESCRIPTION
## Description of the change

Refactors ReplayManager by extracting leading (post-trigger) replay coordination logic into a dedicated LeadingCapture component.

### Motivation
`ReplayManager` has grown to 438 lines with multiple responsibilities. The leading capture logic (scheduling, export, coordination) is ~150 lines of complex async state management that deserves its own focused class.

Plus, we're adding more complex logic around scheduling, exporting and sending post-trigger replay events in chunks to prevent loss of data.

On top of that, we're adding more complex logic surrounding replay triggers.

### Changes
- **Created** `src/browser/replay/leadingCapture.js` (158 lines)
  - Manages delayed post-trigger replay captures
  - Handles timer scheduling and buffer cursor stability
  - Coordinates with trailing replay via delegate pattern
- **Refactored** `src/browser/replay/replayManager.js` (438 → 330 lines, -25%)
  - Uses composition: `_leadingCapture` instance
  - Delegate methods: `_shouldSendLeading()`, `_onLeadingComplete()`
  - Clearer separation of concerns
- **Updated** integration tests to access `_leadingCapture._pending` directly

### Architecture
LeadingCapture uses delegate pattern for coordination:
- `shouldSend(replayId)` - Checks if coordination allows sending
- `onComplete(replayId)` - Notifies when capture completes

This inverts dependencies: `LeadingCapture` doesn't know about `TrailingStatus` or trailing replays, avoiding circular imports.

### Testing
- All tests pass with no logic changes, only some renaming, no API changes.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
