### PR TITLE
Renamed `LeadingCapture` to `ScheduledCapture` and related

### DIFF
--- a/src/browser/replay/scheduledCapture.js
+++ b/src/browser/replay/scheduledCapture.js
@@ -3,12 +3,14 @@ import logger from '../../logger.js';
 /** @typedef {import('./recorder.js').BufferCursor} BufferCursor */
 
 /**
- * Manages delayed "leading" (post-trigger) replay captures.
+ * A utility for coordinating delayed, cursor-based captures.
  *
- * Coordinates timing, buffer cursor stability, and payload preparation
- * for events that occur AFTER the trigger event.
+ * Manages timer-based capture scheduling, buffer cursor stability across
+ * checkouts, and payload preparation. Used primarily for capturing events
+ * that occur after a trigger (leading replays), but the implementation is
+ * generic and could be used for any delayed capture scenario.
  */
-export default class LeadingCapture {
+export default class ScheduledCapture {
   _recorder;
   _tracing;
   _telemeter;
@@ -17,7 +19,7 @@ export default class LeadingCapture {
   _onComplete;
 
   /**
-   * Creates a new LeadingCapture instance
+   * Creates a new ScheduledCapture instance
    *
    * @param {Object} props - Configuration object
    * @param {Object} props.recorder - Recorder instance for capturing events

--- a/test/replay/integration/replayManager.bufferIndex.checkoutResilience.test.js
+++ b/test/replay/integration/replayManager.bufferIndex.checkoutResilience.test.js
@@ -72,7 +72,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
     await clock.tickAsync(100);
 
     const cursor =
-      replayManager._leadingCapture._pending.get(replayId).bufferCursor;
+      replayManager._scheduledCapture._pending.get(replayId).bufferCursor;
     expect(cursor).to.be.an('object');
     expect(cursor.slot).to.equal(0);
 
@@ -107,7 +107,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._leadingCapture._pending.size).to.equal(0);
+    expect(replayManager._scheduledCapture._pending.size).to.equal(0);
 
     recorder.exportRecordingSpan.restore();
   });
@@ -165,7 +165,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._leadingCapture._pending.size).to.equal(0);
+    expect(replayManager._scheduledCapture._pending.size).to.equal(0);
 
     recorder.exportRecordingSpan.restore();
   });
@@ -195,7 +195,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
     await clock.tickAsync(100);
 
     const cursor =
-      replayManager._leadingCapture._pending.get(replayId).bufferCursor;
+      replayManager._scheduledCapture._pending.get(replayId).bufferCursor;
     expect(cursor).to.be.an('object');
 
     await clock.tickAsync(2000);
@@ -229,7 +229,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._leadingCapture._pending.size).to.equal(0);
+    expect(replayManager._scheduledCapture._pending.size).to.equal(0);
 
     recorder.exportRecordingSpan.restore();
   });
@@ -266,7 +266,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._leadingCapture._pending.size).to.equal(0);
+    expect(replayManager._scheduledCapture._pending.size).to.equal(0);
   });
 
   it('collects events strictly after the cursor', async function () {
@@ -292,7 +292,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
     await clock.tickAsync(100);
 
     const cursor =
-      replayManager._leadingCapture._pending.get(replayId).bufferCursor;
+      replayManager._scheduledCapture._pending.get(replayId).bufferCursor;
 
     sinon.spy(recorder, '_collectEventsFromCursor');
 
@@ -315,7 +315,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._leadingCapture._pending.size).to.equal(0);
+    expect(replayManager._scheduledCapture._pending.size).to.equal(0);
 
     recorder._collectEventsFromCursor.restore();
   });
@@ -357,7 +357,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
     );
 
     expect(replayManager._map.has(replayId)).to.be.false;
-    expect(replayManager._leadingCapture._pending.has(replayId)).to.be.false;
+    expect(replayManager._scheduledCapture._pending.has(replayId)).to.be.false;
     sinon.assert.notCalled(api.postSpans);
 
     logger.error.restore();
@@ -401,7 +401,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId },
     ]);
-    expect(replayManager._leadingCapture._pending.has(replayId)).to.be.false;
+    expect(replayManager._scheduledCapture._pending.has(replayId)).to.be.false;
   });
 
   it('discard cancels timer; success clears state', async function () {
@@ -422,7 +422,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
     replayManager.capture(replayId1, 'test-uuid-1', trigger, triggerContext);
     await clock.tickAsync(100);
 
-    expect(replayManager._leadingCapture._pending.has(replayId1)).to.be.true;
+    expect(replayManager._scheduledCapture._pending.has(replayId1)).to.be.true;
 
     replayManager.discard(replayId1);
     await clock.tickAsync(10000);
@@ -441,7 +441,7 @@ describe('ReplayManager – Buffer Index Checkout Resilience', function () {
       { resourceSpans: [{ spanData: 'test' }] },
       { 'X-Rollbar-Replay-Id': replayId2 },
     ]);
-    expect(replayManager._leadingCapture._pending.has(replayId2)).to.be.false;
+    expect(replayManager._scheduledCapture._pending.has(replayId2)).to.be.false;
     expect(replayManager._trailingStatus.has(replayId2)).to.be.false;
   });
 });

--- a/test/replay/unit/scheduledCapture.test.js
+++ b/test/replay/unit/scheduledCapture.test.js
@@ -1,15 +1,15 @@
 /**
- * Unit tests for LeadingCapture
+ * Unit tests for ScheduledCapture
  */
 
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import LeadingCapture from '../../../src/browser/replay/leadingCapture.js';
+import ScheduledCapture from '../../../src/browser/replay/scheduledCapture.js';
 import logger from '../../../src/logger.js';
 
-describe('LeadingCapture', function () {
-  let leadingCapture;
+describe('ScheduledCapture', function () {
+  let scheduledCapture;
   let mockRecorder;
   let mockTracing;
   let mockTelemeter;
@@ -41,7 +41,7 @@ describe('LeadingCapture', function () {
     shouldSendStub = sinon.stub().returns(true);
     onCompleteStub = sinon.stub();
 
-    leadingCapture = new LeadingCapture({
+    scheduledCapture = new ScheduledCapture({
       recorder: mockRecorder,
       tracing: mockTracing,
       telemeter: mockTelemeter,
@@ -57,39 +57,40 @@ describe('LeadingCapture', function () {
 
   describe('constructor', function () {
     it('should initialize with required dependencies', function () {
-      expect(leadingCapture._recorder).to.equal(mockRecorder);
-      expect(leadingCapture._tracing).to.equal(mockTracing);
-      expect(leadingCapture._telemeter).to.equal(mockTelemeter);
-      expect(leadingCapture._shouldSend).to.equal(shouldSendStub);
-      expect(leadingCapture._onComplete).to.equal(onCompleteStub);
+      expect(scheduledCapture._recorder).to.equal(mockRecorder);
+      expect(scheduledCapture._tracing).to.equal(mockTracing);
+      expect(scheduledCapture._telemeter).to.equal(mockTelemeter);
+      expect(scheduledCapture._shouldSend).to.equal(shouldSendStub);
+      expect(scheduledCapture._onComplete).to.equal(onCompleteStub);
+      expect(scheduledCapture._pending).to.be.instanceOf(Map);
     });
 
     it('should initialize with empty pending map', function () {
-      expect(leadingCapture._pending).to.be.instanceOf(Map);
-      expect(leadingCapture._pending.size).to.equal(0);
+      expect(scheduledCapture._pending).to.be.instanceOf(Map);
+      expect(scheduledCapture._pending.size).to.equal(0);
     });
   });
 
   describe('schedule', function () {
     it('should capture buffer cursor at time of scheduling', function () {
-      leadingCapture.schedule('replay-1', 'uuid-1', 5);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 5);
 
       expect(mockRecorder.bufferCursor.calledOnce).to.be.true;
-      const context = leadingCapture._pending.get('replay-1');
+      const context = scheduledCapture._pending.get('replay-1');
       expect(context.bufferCursor).to.deep.equal({ slot: 0, offset: 5 });
     });
 
     it('should schedule timer for specified duration', function () {
-      leadingCapture.schedule('replay-1', 'uuid-1', 3);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 3);
 
-      const context = leadingCapture._pending.get('replay-1');
+      const context = scheduledCapture._pending.get('replay-1');
       expect(context.timerId).to.be.a('number');
     });
 
     it('should store replay context in pending map', function () {
-      leadingCapture.schedule('replay-1', 'uuid-1', 5);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 5);
 
-      const context = leadingCapture._pending.get('replay-1');
+      const context = scheduledCapture._pending.get('replay-1');
       expect(context).to.deep.include({
         occurrenceUuid: 'uuid-1',
         bufferCursor: { slot: 0, offset: 5 },
@@ -99,36 +100,36 @@ describe('LeadingCapture', function () {
     });
 
     it('should export and send after delay', async function () {
-      sinon.spy(leadingCapture, '_export');
-      sinon.spy(leadingCapture, 'sendIfReady');
+      sinon.spy(scheduledCapture, '_export');
+      sinon.spy(scheduledCapture, 'sendIfReady');
 
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.1);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.1);
 
       await clock.tickAsync(100);
 
-      expect(leadingCapture._export.calledOnce).to.be.true;
+      expect(scheduledCapture._export.calledOnce).to.be.true;
       expect(
-        leadingCapture._export.calledWith('replay-1', 'uuid-1', {
+        scheduledCapture._export.calledWith('replay-1', 'uuid-1', {
           slot: 0,
           offset: 5,
         }),
       ).to.be.true;
-      expect(leadingCapture.sendIfReady.calledWith('replay-1')).to.be.true;
+      expect(scheduledCapture.sendIfReady.calledWith('replay-1')).to.be.true;
     });
 
     it('should handle multiple scheduled captures', function () {
-      leadingCapture.schedule('replay-1', 'uuid-1', 5);
-      leadingCapture.schedule('replay-2', 'uuid-2', 10);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 5);
+      scheduledCapture.schedule('replay-2', 'uuid-2', 10);
 
-      expect(leadingCapture._pending.size).to.equal(2);
-      expect(leadingCapture._pending.has('replay-1')).to.be.true;
-      expect(leadingCapture._pending.has('replay-2')).to.be.true;
+      expect(scheduledCapture._pending.size).to.equal(2);
+      expect(scheduledCapture._pending.has('replay-1')).to.be.true;
+      expect(scheduledCapture._pending.has('replay-2')).to.be.true;
     });
   });
 
   describe('_export', function () {
     beforeEach(function () {
-      leadingCapture._pending.set('replay-1', {
+      scheduledCapture._pending.set('replay-1', {
         timerId: 123,
         occurrenceUuid: 'uuid-1',
         bufferCursor: { slot: 0, offset: 5 },
@@ -137,7 +138,7 @@ describe('LeadingCapture', function () {
     });
 
     it('should export recording span with cursor', async function () {
-      await leadingCapture._export('replay-1', 'uuid-1', {
+      await scheduledCapture._export('replay-1', 'uuid-1', {
         slot: 0,
         offset: 5,
       });
@@ -156,7 +157,7 @@ describe('LeadingCapture', function () {
     });
 
     it('should export telemetry span', async function () {
-      await leadingCapture._export('replay-1', 'uuid-1', {
+      await scheduledCapture._export('replay-1', 'uuid-1', {
         slot: 0,
         offset: 5,
       });
@@ -170,9 +171,9 @@ describe('LeadingCapture', function () {
     });
 
     it('should work without telemeter', async function () {
-      leadingCapture._telemeter = null;
+      scheduledCapture._telemeter = null;
 
-      await leadingCapture._export('replay-1', 'uuid-1', {
+      await scheduledCapture._export('replay-1', 'uuid-1', {
         slot: 0,
         offset: 5,
       });
@@ -182,12 +183,12 @@ describe('LeadingCapture', function () {
     });
 
     it('should update context with payload and mark as ready', async function () {
-      await leadingCapture._export('replay-1', 'uuid-1', {
+      await scheduledCapture._export('replay-1', 'uuid-1', {
         slot: 0,
         offset: 5,
       });
 
-      const context = leadingCapture._pending.get('replay-1');
+      const context = scheduledCapture._pending.get('replay-1');
       expect(context.ready).to.be.true;
       expect(context.payload).to.deep.equal({
         resourceSpans: [{ spanData: 'test' }],
@@ -198,9 +199,9 @@ describe('LeadingCapture', function () {
       const exportError = new Error('Replay recording has no events');
       mockRecorder.exportRecordingSpan.throws(exportError);
       sinon.spy(logger, 'error');
-      sinon.spy(leadingCapture, 'discard');
+      sinon.spy(scheduledCapture, 'discard');
 
-      await leadingCapture._export('replay-1', 'uuid-1', {
+      await scheduledCapture._export('replay-1', 'uuid-1', {
         slot: 0,
         offset: 5,
       });
@@ -212,14 +213,14 @@ describe('LeadingCapture', function () {
           exportError,
         ),
       ).to.be.true;
-      expect(leadingCapture.discard.calledWith('replay-1')).to.be.true;
+      expect(scheduledCapture.discard.calledWith('replay-1')).to.be.true;
       expect(mockTelemeter.exportTelemetrySpan.called).to.be.false;
     });
 
     it('should return early if context was already cleaned up', async function () {
-      leadingCapture._pending.delete('replay-1');
+      scheduledCapture._pending.delete('replay-1');
 
-      await leadingCapture._export('replay-1', 'uuid-1', {
+      await scheduledCapture._export('replay-1', 'uuid-1', {
         slot: 0,
         offset: 5,
       });
@@ -231,7 +232,7 @@ describe('LeadingCapture', function () {
 
   describe('sendIfReady', function () {
     beforeEach(function () {
-      leadingCapture._pending.set('replay-1', {
+      scheduledCapture._pending.set('replay-1', {
         timerId: 123,
         occurrenceUuid: 'uuid-1',
         bufferCursor: { slot: 0, offset: 5 },
@@ -243,7 +244,7 @@ describe('LeadingCapture', function () {
     it('should send payload when ready and shouldSend returns true', async function () {
       shouldSendStub.returns(true);
 
-      await leadingCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-1');
 
       expect(shouldSendStub.calledWith('replay-1')).to.be.true;
       expect(mockTracing.exporter.post.calledOnce).to.be.true;
@@ -258,50 +259,50 @@ describe('LeadingCapture', function () {
     it('should not send when shouldSend returns false', async function () {
       shouldSendStub.returns(false);
 
-      await leadingCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-1');
 
       expect(shouldSendStub.calledWith('replay-1')).to.be.true;
       expect(mockTracing.exporter.post.called).to.be.false;
     });
 
     it('should not send when context is not ready', async function () {
-      leadingCapture._pending.set('replay-1', {
+      scheduledCapture._pending.set('replay-1', {
         ready: false,
         payload: { resourceSpans: [] },
       });
 
-      await leadingCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-1');
 
       expect(mockTracing.exporter.post.called).to.be.false;
       expect(shouldSendStub.called).to.be.false;
     });
 
     it('should not send when payload is missing', async function () {
-      leadingCapture._pending.set('replay-1', {
+      scheduledCapture._pending.set('replay-1', {
         ready: true,
         payload: null,
       });
 
-      await leadingCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-1');
 
       expect(mockTracing.exporter.post.called).to.be.false;
     });
 
     it('should not send when context does not exist', async function () {
-      await leadingCapture.sendIfReady('nonexistent');
+      await scheduledCapture.sendIfReady('nonexistent');
 
       expect(mockTracing.exporter.post.called).to.be.false;
       expect(shouldSendStub.called).to.be.false;
     });
 
     it('should discard context after sending', async function () {
-      await leadingCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-1');
 
-      expect(leadingCapture._pending.has('replay-1')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.false;
     });
 
     it('should call onComplete after sending', async function () {
-      await leadingCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-1');
 
       expect(onCompleteStub.calledOnce).to.be.true;
       expect(onCompleteStub.calledWith('replay-1')).to.be.true;
@@ -312,93 +313,93 @@ describe('LeadingCapture', function () {
       mockTracing.exporter.post.rejects(postError);
       sinon.spy(logger, 'error');
 
-      await leadingCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-1');
 
       expect(logger.error.calledOnce).to.be.true;
       expect(
         logger.error.calledWith('Failed to send leading replay:', postError),
       ).to.be.true;
-      expect(leadingCapture._pending.has('replay-1')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.false;
       expect(onCompleteStub.calledWith('replay-1')).to.be.true;
     });
 
     it('should work without onComplete callback', async function () {
-      leadingCapture._onComplete = null;
+      scheduledCapture._onComplete = null;
 
-      await leadingCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-1');
 
       expect(mockTracing.exporter.post.calledOnce).to.be.true;
-      expect(leadingCapture._pending.has('replay-1')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.false;
     });
   });
 
   describe('discard', function () {
     it('should cancel timer and remove context', function () {
       const timerId = setTimeout(() => {}, 5000);
-      leadingCapture._pending.set('replay-1', {
+      scheduledCapture._pending.set('replay-1', {
         timerId,
         occurrenceUuid: 'uuid-1',
         bufferCursor: { slot: 0, offset: 5 },
         ready: false,
       });
 
-      leadingCapture.discard('replay-1');
+      scheduledCapture.discard('replay-1');
 
-      expect(leadingCapture._pending.has('replay-1')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.false;
     });
 
     it('should handle discarding non-existent replay', function () {
-      leadingCapture.discard('nonexistent');
+      scheduledCapture.discard('nonexistent');
 
-      expect(leadingCapture._pending.has('nonexistent')).to.be.false;
+      expect(scheduledCapture._pending.has('nonexistent')).to.be.false;
     });
 
     it('should handle context without timerId', function () {
-      leadingCapture._pending.set('replay-1', {
+      scheduledCapture._pending.set('replay-1', {
         occurrenceUuid: 'uuid-1',
         ready: true,
       });
 
-      leadingCapture.discard('replay-1');
+      scheduledCapture.discard('replay-1');
 
-      expect(leadingCapture._pending.has('replay-1')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.false;
     });
 
     it('should prevent scheduled export from running after discard', async function () {
-      sinon.spy(leadingCapture, '_export');
+      sinon.spy(scheduledCapture, '_export');
 
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.1);
-      leadingCapture.discard('replay-1');
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.1);
+      scheduledCapture.discard('replay-1');
 
       await clock.tickAsync(200);
 
-      expect(leadingCapture._export.called).to.be.false;
+      expect(scheduledCapture._export.called).to.be.false;
     });
   });
 
   describe('schedule and export integration', function () {
     it('should complete full cycle: schedule -> export -> sendIfReady', async function () {
-      sinon.spy(leadingCapture, '_export');
-      sinon.spy(leadingCapture, 'sendIfReady');
+      sinon.spy(scheduledCapture, '_export');
+      sinon.spy(scheduledCapture, 'sendIfReady');
 
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.1);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.1);
 
-      expect(leadingCapture._pending.has('replay-1')).to.be.true;
-      expect(leadingCapture._pending.get('replay-1').ready).to.be.false;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.true;
+      expect(scheduledCapture._pending.get('replay-1').ready).to.be.false;
 
       await clock.tickAsync(100);
 
-      expect(leadingCapture._export.calledOnce).to.be.true;
-      expect(leadingCapture.sendIfReady.calledOnce).to.be.true;
+      expect(scheduledCapture._export.calledOnce).to.be.true;
+      expect(scheduledCapture.sendIfReady.calledOnce).to.be.true;
       expect(mockRecorder.exportRecordingSpan.calledOnce).to.be.true;
       expect(mockTracing.exporter.post.calledOnce).to.be.true;
-      expect(leadingCapture._pending.has('replay-1')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.false;
     });
 
     it('should not send if shouldSend returns false after export', async function () {
       shouldSendStub.returns(false);
 
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.1);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.1);
       await clock.tickAsync(100);
 
       expect(mockRecorder.exportRecordingSpan.calledOnce).to.be.true;
@@ -410,10 +411,10 @@ describe('LeadingCapture', function () {
       mockRecorder.bufferCursor.onFirstCall().returns({ slot: 0, offset: 5 });
       mockRecorder.bufferCursor.onSecondCall().returns({ slot: 1, offset: 10 });
 
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.2);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.2);
 
       const capturedCursor =
-        leadingCapture._pending.get('replay-1').bufferCursor;
+        scheduledCapture._pending.get('replay-1').bufferCursor;
       expect(capturedCursor).to.deep.equal({ slot: 0, offset: 5 });
 
       await clock.tickAsync(100);
@@ -434,26 +435,26 @@ describe('LeadingCapture', function () {
     it('should wait for shouldSend to return true', async function () {
       shouldSendStub.returns(false);
 
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.05);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.05);
       await clock.tickAsync(50);
 
-      const context = leadingCapture._pending.get('replay-1');
+      const context = scheduledCapture._pending.get('replay-1');
       expect(context.ready).to.be.true;
       expect(mockTracing.exporter.post.called).to.be.false;
 
       shouldSendStub.returns(true);
-      await leadingCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-1');
 
       expect(mockTracing.exporter.post.calledOnce).to.be.true;
     });
 
     it('should call shouldSend with replay ID', async function () {
-      leadingCapture._pending.set('replay-1', {
+      scheduledCapture._pending.set('replay-1', {
         ready: true,
         payload: { resourceSpans: [] },
       });
 
-      await leadingCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-1');
 
       expect(shouldSendStub.calledOnce).to.be.true;
       expect(shouldSendStub.calledWith('replay-1')).to.be.true;
@@ -466,7 +467,7 @@ describe('LeadingCapture', function () {
       mockRecorder.exportRecordingSpan.throws(exportError);
       sinon.spy(logger, 'error');
 
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.05);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.05);
       await clock.tickAsync(50);
 
       expect(
@@ -480,40 +481,40 @@ describe('LeadingCapture', function () {
     it('should clean up after export error', async function () {
       mockRecorder.exportRecordingSpan.throws(new Error('Export failed'));
 
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.05);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.05);
       await clock.tickAsync(50);
 
-      expect(leadingCapture._pending.has('replay-1')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.false;
     });
 
     it('should handle post error and still call onComplete', async function () {
       const postError = new Error('Network error');
       mockTracing.exporter.post.rejects(postError);
 
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.05);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.05);
       await clock.tickAsync(50);
 
       expect(onCompleteStub.calledWith('replay-1')).to.be.true;
-      expect(leadingCapture._pending.has('replay-1')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.false;
     });
   });
 
   describe('timer management', function () {
     it('should clear timer on discard', function () {
-      leadingCapture.schedule('replay-1', 'uuid-1', 10);
-      const context = leadingCapture._pending.get('replay-1');
+      scheduledCapture.schedule('replay-1', 'uuid-1', 10);
+      const context = scheduledCapture._pending.get('replay-1');
       const timerId = context.timerId;
 
-      leadingCapture.discard('replay-1');
+      scheduledCapture.discard('replay-1');
 
-      expect(leadingCapture._pending.has('replay-1')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.false;
     });
 
     it('should not interfere with other timers when discarding', async function () {
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.1);
-      leadingCapture.schedule('replay-2', 'uuid-2', 0.1);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.1);
+      scheduledCapture.schedule('replay-2', 'uuid-2', 0.1);
 
-      leadingCapture.discard('replay-1');
+      scheduledCapture.discard('replay-1');
 
       await clock.tickAsync(100);
 
@@ -529,37 +530,37 @@ describe('LeadingCapture', function () {
       mockRecorder.bufferCursor.onFirstCall().returns({ slot: 0, offset: 5 });
       mockRecorder.bufferCursor.onSecondCall().returns({ slot: 1, offset: 10 });
 
-      leadingCapture.schedule('replay-1', 'uuid-1', 0.1);
-      leadingCapture.schedule('replay-2', 'uuid-2', 0.2);
+      scheduledCapture.schedule('replay-1', 'uuid-1', 0.1);
+      scheduledCapture.schedule('replay-2', 'uuid-2', 0.2);
 
-      const context1 = leadingCapture._pending.get('replay-1');
-      const context2 = leadingCapture._pending.get('replay-2');
+      const context1 = scheduledCapture._pending.get('replay-1');
+      const context2 = scheduledCapture._pending.get('replay-2');
 
       expect(context1.bufferCursor).to.deep.equal({ slot: 0, offset: 5 });
       expect(context2.bufferCursor).to.deep.equal({ slot: 1, offset: 10 });
 
       await clock.tickAsync(100);
 
-      expect(leadingCapture._pending.has('replay-1')).to.be.false;
-      expect(leadingCapture._pending.has('replay-2')).to.be.true;
+      expect(scheduledCapture._pending.has('replay-1')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-2')).to.be.true;
 
       await clock.tickAsync(100);
 
-      expect(leadingCapture._pending.has('replay-2')).to.be.false;
+      expect(scheduledCapture._pending.has('replay-2')).to.be.false;
     });
 
     it('should handle concurrent exports without interference', async function () {
-      leadingCapture._pending.set('replay-1', {
+      scheduledCapture._pending.set('replay-1', {
         ready: true,
         payload: { resourceSpans: [{ id: '1' }] },
       });
-      leadingCapture._pending.set('replay-2', {
+      scheduledCapture._pending.set('replay-2', {
         ready: true,
         payload: { resourceSpans: [{ id: '2' }] },
       });
 
-      await leadingCapture.sendIfReady('replay-1');
-      await leadingCapture.sendIfReady('replay-2');
+      await scheduledCapture.sendIfReady('replay-1');
+      await scheduledCapture.sendIfReady('replay-2');
 
       expect(mockTracing.exporter.post.callCount).to.equal(2);
       expect(mockTracing.exporter.post.firstCall.args[0]).to.deep.equal({


### PR DESCRIPTION
## Description of the change

The class is a generic utility for coordinating delayed, cursor-based captures. It has no knowledge of "leading" vs "trailing" replays or trigger types. The new name better reflects what it actually does: schedule replay captures with timer coordination.

### Changes
- Renamed `leadingCapture.js` -> `scheduledCapture.js`
- Renamed class `LeadingCapture` → `ScheduledCapture`
- Updated class documentation to emphasize generic utility nature
- Renamed `_leadingCapture` -> `_scheduledCapture` in ReplayManager
- Updated all test references
- Removed redundant "leading" prefixes from internal properties

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release