### PR TITLE
Fixed call to schedule capturing that was moved

### DIFF
--- a/src/browser/replay/replayManager.js
+++ b/src/browser/replay/replayManager.js
@@ -217,7 +217,7 @@ export default class ReplayManager {
 
       const leadingSeconds = this._recorder.options?.postDuration || 0;
       if (leadingSeconds > 0) {
-        this._scheduleLeadingCapture(replayId, null, leadingSeconds);
+        this._scheduledCapture.schedule(replayId, null, leadingSeconds);
       }
     }
 


### PR DESCRIPTION
## Description of the change

This PR replaces a call to the `_scheduleLeadingCapture` method with a call to the `schedule` method of the `_scheduledCapture` object, since `_scheduleLeadingCapture` was removed in https://github.com/rollbar/rollbar.js/pull/1360.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release
