### PR TITLE
Remove `index.js` from tests

### DIFF
--- a/test/replay/index.js
+++ b/test/replay/index.js
@@ -1,2 +1,0 @@
-export * from './integration/index.js';
-export * from './unit/index.js';

--- a/test/replay/integration/index.js
+++ b/test/replay/integration/index.js
@@ -1,9 +1,0 @@
-/**
- * Session Replay Integration Tests
- */
-
-export * from './sessionRecording.test.js';
-export * from './api.spans.test.js';
-export * from './replayManager.test.js';
-export * from './queue.replayManager.test.js';
-export * from './e2e.test.js';

--- a/test/replay/unit/index.js
+++ b/test/replay/unit/index.js
@@ -1,7 +1,0 @@
-/**
- * Session Replay Unit Tests
- */
-
-export * from './replayManager.test.js';
-export * from './api.postSpans.test.js';
-export * from './queue.replayManager.test.js';


### PR DESCRIPTION
## Description of the change

> [!NOTE]
> This is being merged into a feature branch:
> `feature/matux/streaming-capture`

This PR removes some `index.js` files that were making WTR check several tests twice.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
