### PR TITLE
Init `logger` in replay integration tests to log errors

### DIFF
--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -5,6 +5,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import logger from '../../../src/logger.js';
 import Tracing from '../../../src/tracing/tracing.js';
 import Telemeter from '../../../src/telemetry.js';
 import ReplayManager from '../../../src/browser/replay/replayManager.js';
@@ -55,6 +56,8 @@ describe('Session Replay E2E', function () {
   let rateLimiter;
 
   beforeEach(function () {
+    logger.init({ logLevel: 'warn' });
+
     transport = {
       post: sinon
         .stub()
@@ -73,7 +76,9 @@ describe('Session Replay E2E', function () {
     const truncationMock = {
       truncate: sinon.stub().returns({ error: null, value: '{}' }),
     };
-    const logger = { error: sinon.spy(), log: sinon.spy() };
+
+    sinon.spy(logger, 'error');
+    sinon.spy(logger, 'log');
 
     api = new Api(
       { accessToken: 'test-token-12345' },

--- a/test/replay/integration/queue.replayManager.test.js
+++ b/test/replay/integration/queue.replayManager.test.js
@@ -5,6 +5,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import logger from '../../../src/logger.js';
 import Queue from '../../../src/queue.js';
 import Api from '../../../src/api.js';
 
@@ -16,6 +17,8 @@ describe('Queue ReplayManager Integration', function () {
   let replayId;
 
   beforeEach(function () {
+    logger.init({ logLevel: 'warn' });
+
     transport = {
       post: sinon
         .stub()

--- a/test/replay/integration/replayManager.bufferIndex.checkoutResilience.test.js
+++ b/test/replay/integration/replayManager.bufferIndex.checkoutResilience.test.js
@@ -1,15 +1,17 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import logger from '../../../src/logger.js';
 import ReplayManager from '../../../src/browser/replay/replayManager.js';
 import mockRecordFn from '../util/mockRecordFn.js';
-import logger from '../../../src/logger.js';
 
 describe('ReplayManager – Buffer Index Checkout Resilience', function () {
   let options, replayManager, recorder, api, tracing, telemeter, clock;
 
   beforeEach(function () {
     clock = sinon.useFakeTimers();
+    logger.init({ logLevel: 'warn' });
+
     api = { postSpans: sinon.stub().resolves() };
     tracing = {
       startSpan: sinon.stub().returns({

--- a/test/replay/integration/replayManager.bufferIndex.test.js
+++ b/test/replay/integration/replayManager.bufferIndex.test.js
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import sinon from 'sinon';
 import { EventType } from '@rrweb/types';
 
-import Recorder from '../../../src/browser/replay/recorder.js';
+import logger from '../../../src/logger.js';
 import ReplayManager from '../../../src/browser/replay/replayManager.js';
 import {
   currentBuffer,
@@ -15,6 +15,7 @@ describe('ReplayManager buffer-index integration', function () {
 
   beforeEach(function () {
     clock = sinon.useFakeTimers();
+    logger.init({ logLevel: 'warn' });
 
     const mockRecordFn = () => () => {};
     options = {

--- a/test/replay/integration/replayManager.test.js
+++ b/test/replay/integration/replayManager.test.js
@@ -4,10 +4,9 @@
 
 import { expect } from 'chai';
 import sinon from 'sinon';
-import { record as rrwebRecordFn } from '@rrweb/record';
 
+import logger from '../../../src/logger.js';
 import ReplayManager from '../../../src/browser/replay/replayManager.js';
-import Recorder from '../../../src/browser/replay/recorder.js';
 import Tracing from '../../../src/tracing/tracing.js';
 import Api from '../../../src/api.js';
 import mockRecordFn from '../util/mockRecordFn.js';
@@ -34,6 +33,8 @@ describe('ReplayManager API Integration', function () {
   let replayManager;
 
   beforeEach(function () {
+    logger.init({ logLevel: 'warn' });
+
     transport = {
       post: sinon
         .stub()

--- a/test/replay/integration/sessionRecording.test.js
+++ b/test/replay/integration/sessionRecording.test.js
@@ -5,6 +5,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
+import logger from '../../../src/logger.js';
 import Tracing from '../../../src/tracing/tracing.js';
 import { Context } from '../../../src/tracing/context.js';
 import Recorder from '../../../src/browser/replay/recorder.js';
@@ -64,6 +65,8 @@ describe('Session Replay Integration', function () {
   let recorder;
 
   beforeEach(function () {
+    logger.init({ logLevel: 'warn' });
+
     tracing = new Tracing(window, null, options);
     tracing.initSession();
   });
@@ -201,6 +204,8 @@ describe('Session Replay Transport Integration', function () {
   let queue;
 
   beforeEach(function () {
+    logger.init({ logLevel: 'warn' });
+
     transport = createMockTransport();
     const urlMock = { parse: sinon.stub().returns({}) };
     const truncationMock = {


### PR DESCRIPTION
> [!NOTE]
> This is being merged into a feature branch:
> `feature/matux/streaming-capture`

## Description of the change

This PR initializes our internal `logger` in replay integration tests in order to log errors and facilitate debugging.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release
