### PR TITLE
Rethrow span export errors to prevent unnecessary `sendIfReady` calls

### DIFF
--- a/test/replay/unit/replayManager.test.js
+++ b/test/replay/unit/replayManager.test.js
@@ -148,7 +148,7 @@ describe('ReplayManager', function () {
 
     it('should not store anything when exportRecordingSpan throws', async function () {
       mockRecorder.exportRecordingSpan.throws(
-        new Error('Replay recording cannot have less than 3 events'),
+        new Error('Replay recording has no events'),
       );
 
       const loggerSpy = sinon.spy(logger, 'error');


### PR DESCRIPTION
> [!NOTE]
> This is being merged into a feature branch:
> `feature/matux/streaming-capture`

## Description of the change

Rethrow span export errors to prevent unnecessary `sendIfReady` calls.

The main difference now is that the scheduler won't call `sendIfReady` if the export fails, since it's a noop call because at this point, the replay has been already discarded.

It makes the flow more logical, and more aligned with the streaming/chunk-based version since it's more precise in its "send" calls.

#### Other minor changes:
- `ScheduledCapture._export` is no longer `async` since it wasn't doing anything async-related.
- `ScheduledCapture.sendIfReady` is no longer awaited in `ScheduledCapture.schedule`'s timer since there's no need to await anything.
- Updated some error messages.
- Added a type annotation for `Recorder` to keep the IDE from letting me make stupid mistakes.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

[CAT-485/extended-post-trigger-replay-duration](https://linear.app/rollbar-inc/issue/CAT-485/extended-post-trigger-replay-duration)