### PR TITLE
Rename ReplayManager to Replay

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -166,7 +166,7 @@ The `src/tracing/` directory contains an OpenTelemetry-inspired tracing implemen
 The `src/browser/replay` directory contains the implementation of the Session Replay feature:
 
 - **Recorder**: Core class that integrates with rrweb to record DOM events
-- **ReplayManager**: Manages the mapping between error occurrences and session recordings
+- **Replay**: Manages the mapping between error occurrences and session recordings
 - **Configuration**: Configurable options in `defaults.js` for replay behavior
 
 The Session Replay feature utilizes our tracing infrastructure to:
@@ -180,10 +180,10 @@ The Session Replay feature utilizes our tracing infrastructure to:
 ### Session Replay Flow
 
 1. **Recording**: The Recorder class continuously records DOM events using rrweb
-2. **Error Occurrence**: When an error occurs, Queue.addItem() calls ReplayManager.add()
-3. **Correlation**: ReplayManager generates a replayId and attaches it to the error
-4. **Coordination**: After successful error submission, Queue triggers ReplayManager.send()
-5. **Transport**: ReplayManager retrieves stored replay data and sends via api.postSpans()
+2. **Error Occurrence**: When an error occurs, Queue.addItem() calls Replay.add()
+3. **Correlation**: Replay generates a replayId and attaches it to the error
+4. **Coordination**: After successful error submission, Queue triggers Replay.send()
+5. **Transport**: Replay retrieves stored replay data and sends via api.postSpans()
 
 ### Testing Infrastructure
 

--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -30,7 +30,7 @@ class Rollbar {
     this.scrub = this.components.scrub;
     const truncation = this.components.truncation;
     const Tracing = this.components.tracing;
-    const ReplayManager = this.components.replayManager;
+    const Replay = this.components.replay;
 
     const transport = new Transport(truncation);
     const api = new API(this.options, transport, urllib, truncation);
@@ -42,16 +42,16 @@ class Rollbar {
       this.telemeter = new Telemeter(this.options, this.tracing);
     }
 
-    if (ReplayManager && _.isBrowser()) {
+    if (Replay && _.isBrowser()) {
       const replayOptions = this.options.replay;
-      this.replayManager = new ReplayManager({
+      this.replay = new Replay({
         tracing: this.tracing,
         telemeter: this.telemeter,
         options: replayOptions,
       });
 
       if (replayOptions.enabled && replayOptions.autoStart) {
-        this.replayManager.recorder.start();
+        this.replay.recorder.start();
       }
     }
 
@@ -63,7 +63,7 @@ class Rollbar {
         logger,
         this.telemeter,
         this.tracing,
-        this.replayManager,
+        this.replay,
         'browser',
       );
     var gWindow = _gWindow();
@@ -126,7 +126,7 @@ class Rollbar {
     );
 
     this.tracing?.configure(this.options);
-    this.replayManager?.configure(this.options);
+    this.replay?.configure(this.options);
     this.client.configure(this.options, payloadData);
     this.instrumenter?.configure(this.options);
     this.setupUnhandledCapture();
@@ -199,9 +199,9 @@ class Rollbar {
   }
 
   triggerReplay(context) {
-    if (!this.replayManager) return null;
+    if (!this.replay) return null;
 
-    return this.replayManager.triggerReplay(context);
+    return this.replay.triggerReplay(context);
   }
 
   setupUnhandledCapture() {

--- a/src/browser/replay/replay.js
+++ b/src/browser/replay/replay.js
@@ -21,11 +21,11 @@ const TrailingStatus = Object.freeze({
 });
 
 /**
- * ReplayManager - Manages the mapping between error occurrences and their associated
+ * Replay - Manages the mapping between error occurrences and their associated
  * session recordings. This class handles the coordination between when recordings
  * are dumped and when they are eventually sent to the backend.
  */
-export default class ReplayManager {
+export default class Replay {
   _map;
   /** @type {Recorder} */
   _recorder;
@@ -35,7 +35,7 @@ export default class ReplayManager {
   _trailingStatus;
 
   /**
-   * Creates a new ReplayManager instance
+   * Creates a new Replay instance
    *
    * @param {Object} [props.tracing] - The tracing instance used to create spans and manage context
    * @param {Object} [props.telemeter] - Optional telemeter instance for capturing telemetry events
@@ -156,7 +156,7 @@ export default class ReplayManager {
   capture(replayId, occurrenceUuid, triggerContext) {
     if (!this._recorder.isReady) {
       logger.warn(
-        'ReplayManager.capture: Recorder is not ready, cannot export replay',
+        'Replay.capture: Recorder is not ready, cannot export replay',
       );
       return null;
     }
@@ -276,7 +276,7 @@ export default class ReplayManager {
    * @returns {Promise<void>} A promise that resolves when the operation is complete
    */
   async sendOrDiscardReplay(replayId, err, resp, headers) {
-    const canSendReplay = ReplayManager._canSendReplay(err, resp, headers);
+    const canSendReplay = Replay._canSendReplay(err, resp, headers);
 
     if (canSendReplay) {
       try {
@@ -303,11 +303,11 @@ export default class ReplayManager {
    */
   async send(replayId) {
     if (!replayId) {
-      throw Error('ReplayManager.send: No replayId provided');
+      throw Error('Replay.send: No replayId provided');
     }
 
     if (!this._map.has(replayId)) {
-      throw Error(`ReplayManager.send: No replay found for id: ${replayId}`);
+      throw Error(`Replay.send: No replay found for id: ${replayId}`);
     }
 
     const payload = this._map.get(replayId);
@@ -320,7 +320,7 @@ export default class ReplayManager {
       (payload.resourceSpans && payload.resourceSpans.length === 0);
 
     if (isEmpty) {
-      throw Error(`ReplayManager.send: No payload found for id: ${replayId}`);
+      throw Error(`Replay.send: No payload found for id: ${replayId}`);
     }
 
     await this._tracing.exporter.post(payload, {
@@ -340,7 +340,7 @@ export default class ReplayManager {
    */
   discard(replayId) {
     if (!replayId) {
-      logger.error('ReplayManager.discard: No replayId provided');
+      logger.error('Replay.discard: No replayId provided');
       return false;
     }
 
@@ -348,9 +348,7 @@ export default class ReplayManager {
     this._scheduledCapture.discard(replayId);
 
     if (!this._map.has(replayId)) {
-      logger.error(
-        `ReplayManager.discard: No replay found for replayId: ${replayId}`,
-      );
+      logger.error(`Replay.discard: No replay found for replayId: ${replayId}`);
       return false;
     }
 

--- a/src/browser/replay/scheduledStreamCapture.js
+++ b/src/browser/replay/scheduledStreamCapture.js
@@ -162,7 +162,7 @@ export default class ScheduledStreamCapture {
   /**
    * Sends queued chunks if ready and coordination allows it.
    *
-   * Called by ReplayManager after trailing replay succeeds. Sends chunks
+   * Called by Replay after trailing replay succeeds. Sends chunks
    * sequentially, waiting for each to complete before sending the next. If any
    * chunk fails to send, aborts the entire stream.
    *

--- a/src/browser/rollbar.js
+++ b/src/browser/rollbar.js
@@ -5,7 +5,7 @@ import wrapGlobals from './wrapGlobals.js';
 import scrub from '../scrub.js';
 import truncation from '../truncation.js';
 import Tracing from '../tracing/tracing.js';
-import ReplayManager from './replay/replayManager.js';
+import Replay from './replay/replay.js';
 
 Rollbar.setComponents({
   telemeter: Telemeter,
@@ -14,7 +14,7 @@ Rollbar.setComponents({
   scrub: scrub,
   truncation: truncation,
   tracing: Tracing,
-  replayManager: ReplayManager,
+  replay: Replay,
 });
 
 export default Rollbar;

--- a/src/rollbar.js
+++ b/src/rollbar.js
@@ -10,15 +10,7 @@ import * as _ from './utility.js';
  * @param api
  * @param logger
  */
-function Rollbar(
-  options,
-  api,
-  logger,
-  telemeter,
-  tracing,
-  replayManager,
-  platform,
-) {
+function Rollbar(options, api, logger, telemeter, tracing, replay, platform) {
   this.options = _.merge(options);
   this.logger = logger;
   Rollbar.rateLimiter.configureGlobal(this.options);
@@ -29,7 +21,7 @@ function Rollbar(
     api,
     logger,
     this.options,
-    replayManager,
+    replay,
   );
 
   this.tracing = tracing;

--- a/test/replay/integration/queue.replay.test.js
+++ b/test/replay/integration/queue.replay.test.js
@@ -1,5 +1,5 @@
 /**
- * Integration tests for Queue and ReplayManager
+ * Integration tests for Queue and Replay
  */
 
 import { expect } from 'chai';
@@ -9,9 +9,9 @@ import logger from '../../../src/logger.js';
 import Queue from '../../../src/queue.js';
 import Api from '../../../src/api.js';
 
-describe('Queue ReplayManager Integration', function () {
+describe('Queue Replay Integration', function () {
   let queue;
-  let replayManager;
+  let replay;
   let api;
   let transport;
   let replayId;
@@ -47,7 +47,7 @@ describe('Queue ReplayManager Integration', function () {
     );
 
     replayId = '1234567812345678';
-    replayManager = {
+    replay = {
       capture: sinon.stub().callsFake(() => replayId),
       send: sinon.stub().resolves(true),
       discard: sinon.stub().returns(true),
@@ -62,7 +62,7 @@ describe('Queue ReplayManager Integration', function () {
       api,
       console,
       { transmit: true },
-      replayManager,
+      replay,
     );
   });
 
@@ -86,7 +86,7 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       expect(item).to.have.property('replayId', item.replayId);
-      expect(replayManager.capture.calledOnce).to.be.true;
+      expect(replay.capture.calledOnce).to.be.true;
       done();
     });
   });
@@ -107,17 +107,18 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       setTimeout(() => {
-        expect(replayManager.sendOrDiscardReplay.calledOnce).to.be.true;
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[0]).to.equal(
+        expect(replay.sendOrDiscardReplay.calledOnce).to.be.true;
+        expect(replay.sendOrDiscardReplay.firstCall.args[0]).to.equal(
           item.replayId,
         );
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[1]).to.be.null; // no error
-        expect(
-          replayManager.sendOrDiscardReplay.firstCall.args[2],
-        ).to.deep.equal({ err: 0, result: { id: '12345' } });
-        expect(
-          replayManager.sendOrDiscardReplay.firstCall.args[3],
-        ).to.deep.equal({ 'Rollbar-Replay-Enabled': 'true' });
+        expect(replay.sendOrDiscardReplay.firstCall.args[1]).to.be.null; // no error
+        expect(replay.sendOrDiscardReplay.firstCall.args[2]).to.deep.equal({
+          err: 0,
+          result: { id: '12345' },
+        });
+        expect(replay.sendOrDiscardReplay.firstCall.args[3]).to.deep.equal({
+          'Rollbar-Replay-Enabled': 'true',
+        });
         done();
       }, 50);
     });
@@ -145,14 +146,15 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       setTimeout(() => {
-        expect(replayManager.sendOrDiscardReplay.calledOnce).to.be.true;
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[0]).to.equal(
+        expect(replay.sendOrDiscardReplay.calledOnce).to.be.true;
+        expect(replay.sendOrDiscardReplay.firstCall.args[0]).to.equal(
           item.replayId,
         );
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[1]).to.be.null;
-        expect(
-          replayManager.sendOrDiscardReplay.firstCall.args[2],
-        ).to.deep.equal({ err: 1, message: 'API Error' });
+        expect(replay.sendOrDiscardReplay.firstCall.args[1]).to.be.null;
+        expect(replay.sendOrDiscardReplay.firstCall.args[2]).to.deep.equal({
+          err: 1,
+          message: 'API Error',
+        });
         done();
       }, 50);
     });
@@ -184,17 +186,18 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       setTimeout(() => {
-        expect(replayManager.sendOrDiscardReplay.calledOnce).to.be.true;
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[0]).to.equal(
+        expect(replay.sendOrDiscardReplay.calledOnce).to.be.true;
+        expect(replay.sendOrDiscardReplay.firstCall.args[0]).to.equal(
           item.replayId,
         );
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[1]).to.be.null;
-        expect(
-          replayManager.sendOrDiscardReplay.firstCall.args[2],
-        ).to.have.property('err', 0);
-        expect(
-          replayManager.sendOrDiscardReplay.firstCall.args[3],
-        ).to.deep.equal({ 'Rollbar-Replay-Enabled': 'false' });
+        expect(replay.sendOrDiscardReplay.firstCall.args[1]).to.be.null;
+        expect(replay.sendOrDiscardReplay.firstCall.args[2]).to.have.property(
+          'err',
+          0,
+        );
+        expect(replay.sendOrDiscardReplay.firstCall.args[3]).to.deep.equal({
+          'Rollbar-Replay-Enabled': 'false',
+        });
         done();
       }, 50);
     });
@@ -229,17 +232,16 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       setTimeout(() => {
-        expect(replayManager.sendOrDiscardReplay.calledOnce).to.be.true;
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[0]).to.equal(
+        expect(replay.sendOrDiscardReplay.calledOnce).to.be.true;
+        expect(replay.sendOrDiscardReplay.firstCall.args[0]).to.equal(
           item.replayId,
         );
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[1]).to.be.null;
-        expect(
-          replayManager.sendOrDiscardReplay.firstCall.args[2],
-        ).to.have.property('err', 0);
-        expect(
-          replayManager.sendOrDiscardReplay.firstCall.args[3],
-        ).to.deep.equal({
+        expect(replay.sendOrDiscardReplay.firstCall.args[1]).to.be.null;
+        expect(replay.sendOrDiscardReplay.firstCall.args[2]).to.have.property(
+          'err',
+          0,
+        );
+        expect(replay.sendOrDiscardReplay.firstCall.args[3]).to.deep.equal({
           'Rollbar-Replay-Enabled': 'true',
           'Rollbar-Replay-RateLimit-Remaining': '0',
         });
@@ -288,15 +290,15 @@ describe('Queue ReplayManager Integration', function () {
 
         setTimeout(() => {
           // After retry succeeds, sendOrDiscardReplay should be called
-          expect(replayManager.sendOrDiscardReplay.called).to.be.true;
-          expect(replayManager.sendOrDiscardReplay.firstCall.args[0]).to.equal(
+          expect(replay.sendOrDiscardReplay.called).to.be.true;
+          expect(replay.sendOrDiscardReplay.firstCall.args[0]).to.equal(
             '1234567812345678',
           );
-          expect(replayManager.sendOrDiscardReplay.firstCall.args[1]).to.be
-            .null; // no error
-          expect(
-            replayManager.sendOrDiscardReplay.firstCall.args[2],
-          ).to.deep.equal({ err: 0, result: { id: '12345' } });
+          expect(replay.sendOrDiscardReplay.firstCall.args[1]).to.be.null; // no error
+          expect(replay.sendOrDiscardReplay.firstCall.args[2]).to.deep.equal({
+            err: 0,
+            result: { id: '12345' },
+          });
           done();
         }, 50);
       }
@@ -314,7 +316,7 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       expect(item).to.not.have.property('replayId');
-      expect(replayManager.capture.called).to.be.false;
+      expect(replay.capture.called).to.be.false;
       done();
     });
   });
@@ -337,7 +339,7 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       expect(item.replayId).to.be.null;
-      expect(replayManager.capture.called).to.be.true;
+      expect(replay.capture.called).to.be.true;
       done();
     });
   });
@@ -366,21 +368,21 @@ describe('Queue ReplayManager Integration', function () {
         level: 'error',
       };
 
-      expect(replayManager.size).to.equal(0);
+      expect(replay.size).to.equal(0);
       queue.addItem(item, (err) => {
         expect(err).to.be.instanceof(Error);
         setTimeout(() => {
           // Verify replay was added and sendOrDiscardReplay was called
-          expect(replayManager.capture.calledOnce).to.be.true;
-          expect(replayManager.sendOrDiscardReplay.calledOnce).to.be.true;
-          expect(replayManager.sendOrDiscardReplay.firstCall.args[0]).to.equal(
+          expect(replay.capture.calledOnce).to.be.true;
+          expect(replay.sendOrDiscardReplay.calledOnce).to.be.true;
+          expect(replay.sendOrDiscardReplay.firstCall.args[0]).to.equal(
             item.replayId,
           );
-          expect(replayManager.sendOrDiscardReplay.firstCall.args[1]).to.equal(
+          expect(replay.sendOrDiscardReplay.firstCall.args[1]).to.equal(
             transportError,
           );
           // Ensure no memory leak - replay should be removed from map
-          expect(replayManager.size).to.equal(0);
+          expect(replay.size).to.equal(0);
           done();
         }, 50);
       });
@@ -411,17 +413,16 @@ describe('Queue ReplayManager Integration', function () {
 
       queue.addItem(item, () => {
         setTimeout(() => {
-          expect(replayManager.sendOrDiscardReplay.calledOnce).to.be.true;
-          expect(replayManager.sendOrDiscardReplay.firstCall.args[0]).to.equal(
+          expect(replay.sendOrDiscardReplay.calledOnce).to.be.true;
+          expect(replay.sendOrDiscardReplay.firstCall.args[0]).to.equal(
             item.replayId,
           );
-          expect(replayManager.sendOrDiscardReplay.firstCall.args[1]).to.be
-            .null;
-          expect(
-            replayManager.sendOrDiscardReplay.firstCall.args[2],
-          ).to.deep.equal({ err: 0, result: { id: '12345' } });
-          expect(replayManager.sendOrDiscardReplay.firstCall.args[3]).to.be
-            .null;
+          expect(replay.sendOrDiscardReplay.firstCall.args[1]).to.be.null;
+          expect(replay.sendOrDiscardReplay.firstCall.args[2]).to.deep.equal({
+            err: 0,
+            result: { id: '12345' },
+          });
+          expect(replay.sendOrDiscardReplay.firstCall.args[3]).to.be.null;
           done();
         }, 50);
       });
@@ -458,13 +459,11 @@ describe('Queue ReplayManager Integration', function () {
 
       queue.addItem(item, () => {
         setTimeout(() => {
-          expect(replayManager.sendOrDiscardReplay.calledOnce).to.be.true;
-          expect(replayManager.sendOrDiscardReplay.firstCall.args[0]).to.equal(
+          expect(replay.sendOrDiscardReplay.calledOnce).to.be.true;
+          expect(replay.sendOrDiscardReplay.firstCall.args[0]).to.equal(
             item.replayId,
           );
-          expect(
-            replayManager.sendOrDiscardReplay.firstCall.args[3],
-          ).to.deep.equal({
+          expect(replay.sendOrDiscardReplay.firstCall.args[3]).to.deep.equal({
             'Rollbar-Replay-Enabled': 'true',
             'Rollbar-Replay-RateLimit-Remaining': '0',
           });
@@ -505,9 +504,9 @@ describe('Queue ReplayManager Integration', function () {
           if (completed === items.length) {
             setTimeout(() => {
               // All replays should have sendOrDiscardReplay called
-              expect(replayManager.sendOrDiscardReplay.callCount).to.equal(5);
+              expect(replay.sendOrDiscardReplay.callCount).to.equal(5);
               // No memory leaks
-              expect(replayManager.size).to.equal(0);
+              expect(replay.size).to.equal(0);
               done();
             }, 50);
           }
@@ -538,12 +537,12 @@ describe('Queue ReplayManager Integration', function () {
 
     queue.addItem(item, () => {
       setTimeout(() => {
-        expect(replayManager.sendOrDiscardReplay.calledOnce).to.be.true;
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[0]).to.equal(
+        expect(replay.sendOrDiscardReplay.calledOnce).to.be.true;
+        expect(replay.sendOrDiscardReplay.firstCall.args[0]).to.equal(
           item.replayId,
         );
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[1]).to.be.null;
-        expect(replayManager.sendOrDiscardReplay.firstCall.args[2]).to.be.null;
+        expect(replay.sendOrDiscardReplay.firstCall.args[1]).to.be.null;
+        expect(replay.sendOrDiscardReplay.firstCall.args[2]).to.be.null;
         done();
       }, 50);
     });

--- a/test/replay/unit/replayPredicates.test.js
+++ b/test/replay/unit/replayPredicates.test.js
@@ -5,7 +5,7 @@
 import { expect } from 'chai';
 import ReplayPredicates from '../../../src/browser/replay/replayPredicates.js';
 
-describe('ReplayManager', function () {
+describe('Replay', function () {
   let replayId;
   let replayConfig;
   let replayPredicates;


### PR DESCRIPTION
## Description of the change

Renames `ReplayManager` to `Replay` to align with component naming convention and shorten the class name.

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance
- [ ] New release