### PR TITLE
Add rollbar.occurrence.uuids attribute via a transform fn

### DIFF
--- a/src/tracing/spanProcessor.js
+++ b/src/tracing/spanProcessor.js
@@ -5,6 +5,27 @@ export class SpanProcessor {
     this.exporter = exporter;
     this.options = options;
     this.pendingSpans = new Map();
+    this.transforms = [this.userTransform.bind(this)];
+  }
+
+  addTransform(transformFn) {
+    this.transforms.unshift(transformFn);
+  }
+
+  userTransform(span) {
+    if (this.options.transformSpan) {
+      this.options.transformSpan({ span: span });
+    }
+  }
+
+  applyTransforms(span) {
+    for (const transform of this.transforms) {
+      try {
+        transform(span);
+      } catch (e) {
+        logger.error('Error running span transform callback', e);
+      }
+    }
   }
 
   onStart(span, _parentContext) {
@@ -12,13 +33,7 @@ export class SpanProcessor {
   }
 
   onEnd(span) {
-    try {
-      if (this.options.transformSpan) {
-        this.options.transformSpan({ span: span.span });
-      }
-    } catch (e) {
-      logger.error('Error running transformSpan callback', e);
-    }
+    this.applyTransforms(span.span);
     this.exporter.export([span.export()]);
     this.pendingSpans.delete(span.span.spanContext.spanId);
   }

--- a/src/tracing/tracing.js
+++ b/src/tracing/tracing.js
@@ -69,6 +69,10 @@ export default class Tracing {
     return this.tracer;
   }
 
+  addSpanTransform(transformFn) {
+    this.spanProcessor.addTransform(transformFn);
+  }
+
   getSpan(context = this.contextManager.active()) {
     return context.getValue(SPAN_KEY);
   }

--- a/test/replay/integration/e2e.test.js
+++ b/test/replay/integration/e2e.test.js
@@ -178,7 +178,7 @@ describe('Session Replay E2E', function () {
           expect(span_r).to.have.property('events');
           expect(span_r.events).to.be.an('array');
           expect(span_r).to.have.property('attributes').that.is.an('array');
-          expect(span_r.attributes).to.have.lengthOf(15);
+          expect(span_r.attributes).to.have.lengthOf(16);
 
           expect(span_r.attributes).to.deep.include({
             key: 'rollbar.replay.id',

--- a/test/replay/integration/replay.bufferIndex.checkoutResilience.test.js
+++ b/test/replay/integration/replay.bufferIndex.checkoutResilience.test.js
@@ -31,6 +31,7 @@ describe('Replay - Buffer Index Checkout Resilience', function () {
         post: sinon.stub(),
       },
       session: { attributes: {} },
+      addSpanTransform() {},
     };
 
     telemeter = { exportTelemetrySpan: sinon.stub() };

--- a/test/replay/integration/replay.bufferIndex.test.js
+++ b/test/replay/integration/replay.bufferIndex.test.js
@@ -48,6 +48,7 @@ describe('Replay buffer-index integration', function () {
       session: {
         attributes: {},
       },
+      addSpanTransform() {},
     };
 
     api = {

--- a/test/replay/unit/replay.test.js
+++ b/test/replay/unit/replay.test.js
@@ -29,6 +29,8 @@ class MockTracing {
       post: sinon.stub().resolves({ success: true }),
     };
   }
+
+  addSpanTransform() {}
 }
 
 class MockTelemeter {

--- a/test/tracing/spanProcessor.test.js
+++ b/test/tracing/spanProcessor.test.js
@@ -75,8 +75,12 @@ describe('SpanProcessor()', function () {
         span.resource.attributes['rollbar.environment'] = 'prod-3';
       },
     };
+    const otherTransform = (span) => {
+      span.attributes['test-id'] = '1234';
+    };
     const exporter = new SpanExporter();
     const spanProcessor = new SpanProcessor(exporter, tracingOptions);
+    spanProcessor.addTransform(otherTransform);
 
     expect(spanProcessor.pendingSpans.size).to.equal(0);
 
@@ -93,6 +97,7 @@ describe('SpanProcessor()', function () {
     expect(span.span.resource.attributes['rollbar.environment']).to.equal(
       'prod-3',
     );
+    expect(span.span.attributes['test-id']).to.equal('1234');
     expect(spanProcessor.pendingSpans.size).to.equal(0);
 
     done();


### PR DESCRIPTION
## Description of the change

Adds `rollbar.occurrence.uuids` attribute to the replay span, containing uuids for occurrences in telemetry with timestamps within the range of the current replay span.

Note:
Will add tests for Replay.uuidsTransform() in a follow up PR.

## Type of change

- [x] New feature (non-breaking change that adds functionality)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


