### PR TITLE
Prototype pollution prevention

### DIFF
--- a/src/merge.js
+++ b/src/merge.js
@@ -34,7 +34,7 @@ function merge() {
     copy,
     clone,
     name,
-    result = {},
+    result = Object.create(null), // no prototype pollution on Object
     current = null,
     length = arguments.length;
 

--- a/src/utility.js
+++ b/src/utility.js
@@ -660,6 +660,10 @@ function set(obj, path, value) {
   if (!obj) {
     return;
   }
+
+  // Prevent prototype pollution by setting the prototype to null.
+  Object.setPrototypeOf(obj, null);
+
   var keys = path.split('.');
   var len = keys.length;
   if (len < 1) {

--- a/test/utility.test.js
+++ b/test/utility.test.js
@@ -446,6 +446,13 @@ describe('merge', function () {
     expect(e.amihere).to.eql('yes');
     done();
   });
+  it('should be secure against prototype pollution', function () {
+    const o1 = JSON.parse('{"__proto__": {"polluted": "yes"}}');
+    const o2 = JSON.parse('{"__proto__": {"polluted": "yes"}}');
+    const result = _.merge(o1, o2);
+    expect({}.polluted).to.not.eql('yes');
+    expect(result.polluted).to.not.eql('yes');
+  });
 });
 
 var traverse = require('../src/utility/traverse');
@@ -764,6 +771,12 @@ describe('set', function () {
     expect(o.foo.a).to.eql(98);
     expect(o.foo.bar.buzz).to.eql(97);
     expect(o.foo.bar.baz.fizz).to.eql(1);
+  });
+  it('should be secure against prototype pollution', function () {
+    const o = {};
+    _.set(o, '__proto__.polluted', 'yes');
+    expect({}.polluted).to.not.eql('yes');
+    expect(o.polluted).to.not.eql('yes');
   });
 });
 


### PR DESCRIPTION
## Description of the change

Fixes two potential entry points for prototype pollution by ensuring the modified objects do not have a prototype.

Note:
Both new test cases failed before the fix.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development
