### PR TITLE
Allow tracing without a session

### DIFF
--- a/src/tracing/tracer.js
+++ b/src/tracing/tracer.js
@@ -39,7 +39,7 @@ export class Tracer {
     const span = new Span({
       resource: resource,
       scope: this.tracing.scope,
-      session: this.tracing.session.session,
+      session: this.tracing.session?.session,
       context,
       spanContext,
       name,


### PR DESCRIPTION
## Description of the change

Allow tracing to work without a session present. Affects web workers, and any condition where sessionStorage isn't available.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)


## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development


