### PR TITLE
Fix replay options on configure

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -126,7 +126,7 @@ class Rollbar {
     );
 
     this.tracing?.configure(this.options);
-    this.replay?.configure(this.options);
+    this.replay?.configure(this.options.replay);
     this.client.configure(this.options, payloadData);
     this.instrumenter?.configure(this.options);
     this.setupUnhandledCapture();


### PR DESCRIPTION
## Description of the change

Replay.configure expects replay options only.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)

