### PR TITLE
Add .npmrc ignore-scripts=true (Miasma install-hook mitigation)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+ignore-scripts=true

--- a/package.json
+++ b/package.json
@@ -132,10 +132,9 @@
     "webpack-node-externals": "^3.0.0"
   },
   "scripts": {
-    "build": "webpack --mode production",
-    "postbuild": "npm run validate:es5 && npm run update:snippets:examples && npm run pack",
-    "build:dev": "webpack --mode development",
-    "postbuild:dev": "npm run postbuild",
+    "build": "webpack --mode production && npm run build:finalize",
+    "build:dev": "webpack --mode development && npm run build:finalize",
+    "build:finalize": "npm run validate:es5 && npm run update:snippets:examples && npm run pack",
     "test": "npm run test:wtr && npm run test:server",
     "test:server": "node scripts/run-server-tests.js",
     "test:wtr": "web-test-runner",


### PR DESCRIPTION
## Description of the change

Adds a repo-local `.npmrc` containing `ignore-scripts=true` so npm does not auto-execute dependency lifecycle scripts (`preinstall`/`install`/`postinstall`) on `npm install`. This blocks the execution mechanism used by the Miasma / Shai-Hulud npm supply-chain worm.

Config-only change. Explicit `npm run <script>` invocations are unaffected; only automatic install-time lifecycle scripts are suppressed. Part of a fleet-wide rollout tracked in Linear **PLA-1580** (one PR per repo).

## Type of change

- [x] Maintenance

## Related issues

- PLA-1580 (Linear): https://linear.app/rollbar-inc/issue/PLA-1580

## Checklists

### Development

- [x] N/A — configuration-only change, no code or tests affected

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer
- [ ] Issue from task tracker has a link to this pull request
