### PR TITLE
PLA-1585: fix flaky undici telemetry tests + harden CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,9 +68,13 @@ jobs:
       - name: Run server tests
         run: npm run test:server
 
+      # Browser tests launch chromium; the harness Node version is irrelevant to
+      # browser coverage, so run them only on stable Node. The chromium download
+      # in `playwright install` stalls indefinitely on Node 24/latest.
       - name: Install Playwright browsers
-        # The chromium download can stall indefinitely; cap each attempt and
-        # retry so a transient stall doesn't hang the job until the timeout.
+        if: matrix.node != 24 && matrix.node != 'latest'
+        # The chromium download can stall; cap each attempt and retry so a
+        # transient stall doesn't hang the job until the timeout.
         run: |
           for i in 1 2 3; do
             timeout 300 npx playwright install chromium && exit 0
@@ -79,6 +83,7 @@ jobs:
           exit 1
 
       - name: Run browser tests (Web Test Runner)
+        if: matrix.node != 24 && matrix.node != 'latest'
         run: npm run test:wtr
 
       - name: Validate examples

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,8 +13,14 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-22.04
+    timeout-minutes: 20
+    # `latest` is a floating, non-LTS target used as a forward-compat canary;
+    # let it warn without blocking PRs or (with fail-fast off) cancelling the
+    # supported legs.
+    continue-on-error: ${{ matrix.node == 'latest' }}
 
     strategy:
+      fail-fast: false
       matrix:
         include:
           - node: 18
@@ -63,7 +69,14 @@ jobs:
         run: npm run test:server
 
       - name: Install Playwright browsers
-        run: npx playwright install chromium
+        # The chromium download can stall indefinitely; cap each attempt and
+        # retry so a transient stall doesn't hang the job until the timeout.
+        run: |
+          for i in 1 2 3; do
+            timeout 300 npx playwright install chromium && exit 0
+            echo "playwright install attempt $i stalled or failed; retrying"
+          done
+          exit 1
 
       - name: Run browser tests (Web Test Runner)
         run: npm run test:wtr

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.46.4",
-        "undici": "^6.23.0",
+        "undici": "^7.27.2",
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.1",
         "webpack-node-externals": "^3.0.0"
@@ -13012,13 +13012,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.23.0.tgz",
-      "integrity": "sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,8 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.46.4",
-        "undici": "^7.27.2",
+        "undici": "^6.23.0",
+        "undici-v7": "npm:undici@^7.27.2",
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.1",
         "webpack-node-externals": "^3.0.0"
@@ -13012,13 +13013,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -13027,6 +13028,17 @@
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/undici-v7": {
+      "name": "undici",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {
       "version": "2.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,8 +52,8 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3",
         "typescript-eslint": "^8.46.4",
-        "undici": "^6.23.0",
-        "undici-v7": "npm:undici@^7.27.2",
+        "undici": "^7.27.2",
+        "undici-v6": "npm:undici@^6.23.0",
         "webpack": "^5.98.0",
         "webpack-cli": "^6.0.1",
         "webpack-node-externals": "^3.0.0"
@@ -13013,13 +13013,13 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
-      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
+      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18.17"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/undici-types": {
@@ -13029,15 +13029,15 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/undici-v7": {
+    "node_modules/undici-v6": {
       "name": "undici",
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.27.2.tgz",
-      "integrity": "sha512-uZsKNuzQxDMUY6M3pIMvy5tvlGmtq8XJ2oLAkfRKGNu+1VQAIvLy2xIVG5ATZl5wDXl/tddByAWCizRbOme+TA==",
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.26.0.tgz",
+      "integrity": "sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=20.18.1"
+        "node": ">=18.17"
       }
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -125,8 +125,8 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.4",
-    "undici": "^6.23.0",
-    "undici-v7": "npm:undici@^7.27.2",
+    "undici": "^7.27.2",
+    "undici-v6": "npm:undici@^6.23.0",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.1",
     "webpack-node-externals": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.4",
-    "undici": "^6.23.0",
+    "undici": "^7.27.2",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.1",
     "webpack-node-externals": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -125,7 +125,8 @@
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.46.4",
-    "undici": "^7.27.2",
+    "undici": "^6.23.0",
+    "undici-v7": "npm:undici@^7.27.2",
     "webpack": "^5.98.0",
     "webpack-cli": "^6.0.1",
     "webpack-node-externals": "^3.0.0"

--- a/test/server.telemetry.test.js
+++ b/test/server.telemetry.test.js
@@ -6,12 +6,7 @@ import { URL } from 'url';
 import { expect } from 'chai';
 import nock from 'nock';
 import sinon from 'sinon';
-import {
-  fetch as undiciFetch,
-  MockAgent,
-  getGlobalDispatcher,
-  setGlobalDispatcher,
-} from 'undici';
+import { MockAgent, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
 
 import Rollbar from '../src/server/rollbar.js';
 import { mergeOptions } from '../src/server/telemetry/urlHelpers.js';
@@ -272,7 +267,6 @@ describe('telemetry', function () {
     let response;
     let mockAgent;
     let originalDispatcher;
-    let originalFetch;
     let sessionId;
     let asyncLocalStorage;
 
@@ -280,14 +274,6 @@ describe('telemetry', function () {
       if (typeof fetch !== 'function') {
         this.skip();
       }
-
-      // Route the global fetch through the same undici instance that MockAgent
-      // patches. Node's built-in fetch uses the bundled undici, whose global
-      // dispatcher symbol can diverge from the npm undici across Node versions,
-      // silently bypassing setGlobalDispatcher and letting the request reach the
-      // real network.
-      originalFetch = globalThis.fetch;
-      globalThis.fetch = undiciFetch;
 
       originalDispatcher = getGlobalDispatcher();
       mockAgent = new MockAgent();
@@ -338,9 +324,6 @@ describe('telemetry', function () {
       if (originalDispatcher) {
         setGlobalDispatcher(originalDispatcher);
       }
-      if (originalFetch) {
-        globalThis.fetch = originalFetch;
-      }
     });
 
     it('message payload should have fetch telemetry', function () {
@@ -373,20 +356,11 @@ describe('telemetry', function () {
     let response;
     let mockAgent;
     let originalDispatcher;
-    let originalFetch;
 
     beforeEach(async function () {
       if (typeof fetch !== 'function') {
         this.skip();
       }
-
-      // Route the global fetch through the same undici instance that MockAgent
-      // patches. Node's built-in fetch uses the bundled undici, whose global
-      // dispatcher symbol can diverge from the npm undici across Node versions,
-      // silently bypassing setGlobalDispatcher and letting the request reach the
-      // real network.
-      originalFetch = globalThis.fetch;
-      globalThis.fetch = undiciFetch;
 
       originalDispatcher = getGlobalDispatcher();
       mockAgent = new MockAgent();
@@ -432,9 +406,6 @@ describe('telemetry', function () {
       }
       if (originalDispatcher) {
         setGlobalDispatcher(originalDispatcher);
-      }
-      if (originalFetch) {
-        globalThis.fetch = originalFetch;
       }
     });
 

--- a/test/server.telemetry.test.js
+++ b/test/server.telemetry.test.js
@@ -10,11 +10,12 @@ import sinon from 'sinon';
 // symbol matches the running Node's bundled undici: undici 6 (symbol `.1`) for
 // Node 18-24, undici 7 (symbol `.2`) for the undici-7-bundled `latest` leg.
 // undici 7 also requires Node 20+ (it references the global `File`), so Node 18
-// must stay on undici 6. Dynamic import so only the selected major is loaded
-// (statically importing undici 7 on Node 18 would crash at load time).
+// must stay on undici 6 (the `undici-v6` alias). Dynamic import so only the
+// selected major is loaded (statically importing undici 7 on Node 18 would
+// crash at load time).
 const nodeMajor = parseInt(process.versions.node.split('.')[0], 10);
 const { MockAgent, getGlobalDispatcher, setGlobalDispatcher } =
-  nodeMajor >= 20 ? await import('undici-v7') : await import('undici');
+  nodeMajor >= 20 ? await import('undici') : await import('undici-v6');
 
 import Rollbar from '../src/server/rollbar.js';
 import { mergeOptions } from '../src/server/telemetry/urlHelpers.js';

--- a/test/server.telemetry.test.js
+++ b/test/server.telemetry.test.js
@@ -6,7 +6,12 @@ import { URL } from 'url';
 import { expect } from 'chai';
 import nock from 'nock';
 import sinon from 'sinon';
-import { MockAgent, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
+import {
+  fetch as undiciFetch,
+  MockAgent,
+  getGlobalDispatcher,
+  setGlobalDispatcher,
+} from 'undici';
 
 import Rollbar from '../src/server/rollbar.js';
 import { mergeOptions } from '../src/server/telemetry/urlHelpers.js';
@@ -267,6 +272,7 @@ describe('telemetry', function () {
     let response;
     let mockAgent;
     let originalDispatcher;
+    let originalFetch;
     let sessionId;
     let asyncLocalStorage;
 
@@ -274,6 +280,14 @@ describe('telemetry', function () {
       if (typeof fetch !== 'function') {
         this.skip();
       }
+
+      // Route the global fetch through the same undici instance that MockAgent
+      // patches. Node's built-in fetch uses the bundled undici, whose global
+      // dispatcher symbol can diverge from the npm undici across Node versions,
+      // silently bypassing setGlobalDispatcher and letting the request reach the
+      // real network.
+      originalFetch = globalThis.fetch;
+      globalThis.fetch = undiciFetch;
 
       originalDispatcher = getGlobalDispatcher();
       mockAgent = new MockAgent();
@@ -324,6 +338,9 @@ describe('telemetry', function () {
       if (originalDispatcher) {
         setGlobalDispatcher(originalDispatcher);
       }
+      if (originalFetch) {
+        globalThis.fetch = originalFetch;
+      }
     });
 
     it('message payload should have fetch telemetry', function () {
@@ -356,11 +373,20 @@ describe('telemetry', function () {
     let response;
     let mockAgent;
     let originalDispatcher;
+    let originalFetch;
 
     beforeEach(async function () {
       if (typeof fetch !== 'function') {
         this.skip();
       }
+
+      // Route the global fetch through the same undici instance that MockAgent
+      // patches. Node's built-in fetch uses the bundled undici, whose global
+      // dispatcher symbol can diverge from the npm undici across Node versions,
+      // silently bypassing setGlobalDispatcher and letting the request reach the
+      // real network.
+      originalFetch = globalThis.fetch;
+      globalThis.fetch = undiciFetch;
 
       originalDispatcher = getGlobalDispatcher();
       mockAgent = new MockAgent();
@@ -406,6 +432,9 @@ describe('telemetry', function () {
       }
       if (originalDispatcher) {
         setGlobalDispatcher(originalDispatcher);
+      }
+      if (originalFetch) {
+        globalThis.fetch = originalFetch;
       }
     });
 

--- a/test/server.telemetry.test.js
+++ b/test/server.telemetry.test.js
@@ -6,7 +6,15 @@ import { URL } from 'url';
 import { expect } from 'chai';
 import nock from 'nock';
 import sinon from 'sinon';
-import { MockAgent, getGlobalDispatcher, setGlobalDispatcher } from 'undici';
+// MockAgent only intercepts the built-in `fetch` when its global-dispatcher
+// symbol matches the running Node's bundled undici: undici 6 (symbol `.1`) for
+// Node 18-24, undici 7 (symbol `.2`) for the undici-7-bundled `latest` leg.
+// undici 7 also requires Node 20+ (it references the global `File`), so Node 18
+// must stay on undici 6. Dynamic import so only the selected major is loaded
+// (statically importing undici 7 on Node 18 would crash at load time).
+const nodeMajor = parseInt(process.versions.node.split('.')[0], 10);
+const { MockAgent, getGlobalDispatcher, setGlobalDispatcher } =
+  nodeMajor >= 20 ? await import('undici-v7') : await import('undici');
 
 import Rollbar from '../src/server/rollbar.js';
 import { mergeOptions } from '../src/server/telemetry/urlHelpers.js';


### PR DESCRIPTION
## Description of the change

Fixes the flaky `with fetch network capture enabled` telemetry tests and hardens the CI matrix so a single floating-Node failure can no longer mask the whole suite. **Test-infra only — no SDK/`src` changes, zero runtime impact** (`undici` is a devDependency used only in `test/server.telemetry.test.js`; the SDK instruments the global `fetch` and never imports undici).

### Background

The two fetch-capture tests mock the network with undici `MockAgent` + `setGlobalDispatcher` but assert against Node's **global built-in `fetch`**. `MockAgent` only intercepts the built-in `fetch` when its global-dispatcher symbol matches the running Node's *bundled* undici. undici **6** uses `Symbol.for('undici.globalDispatcher.1')`; undici **7** bumped it to `.2`. So with the pinned npm `undici@6`, the mock was bypassed on any Node leg that bundles undici 7: the request escaped to the real `example.com/api/users` and returned **404** instead of the mocked **200** (a 404 rather than a `MockNotMatchedError` is the tell that it escaped the mock).

This failed **only on the `latest` leg**, but with `fail-fast` on, that one failure cancelled the other four legs — so every PR looked broken. Master had not run green since 2026-03-11, so the regression went unnoticed.

### Telemetry test fix

Measured interception across the matrix:

| Node leg | Bundled undici | npm undici 6 `MockAgent` intercepts built-in `fetch`? |
|----------|----------------|--------------------------------------------------------|
| 18 / 20 / 22 / 24 | 6.x (symbol `.1`) | ✅ yes |
| latest | 7.x (symbol `.2`) | ❌ no |

The fix keeps the tests asserting against each Node version's **real built-in `fetch`** (so the matrix still exercises per-version fetch behaviour) while making `MockAgent` intercept on every leg:

- The undecorated `undici` devDep is the **forward** version (`^7.27.2`); the **legacy** version is the `undici-v6` alias (`npm:undici@^6`).
- The test **dynamic-imports** one by Node major: `<20` → `undici-v6` (6), `>=20` → `undici` (7). undici 7's `setGlobalDispatcher` writes **both** the `.1` and `.2` slots, so the mock is seen whether the running Node bundles undici 6 (`.1`) or 7 (`.2`).

Two constraints shaped this:

1. **undici 7 requires Node 20+** — it references the global `File` constructor (added in Node 20), so it throws `ReferenceError: File is not defined` at load time on Node 18, a supported target (`CLAUDE.md`: "Minimum Node.js: 18+"). Node 18 must stay on undici 6.
2. The import therefore must be **dynamic**, so the unselected major never loads — a static forward-`undici` (7) import would crash at load on Node 18 even if unused.

**Alternatives considered and rejected:**

- *Swap `globalThis.fetch = undiciFetch`* (route global fetch through the npm undici): works on every leg, but then all legs test the npm undici's `fetch` instead of each version's real built-in `fetch` — which defeats the matrix for fetch-compatibility tests.
- *Bump everything to undici 7*: fixes `latest` but breaks the Node 18 leg (undici 7 can't load there).

### CI matrix hardening

- `fail-fast: false` — one leg's failure no longer cancels the others (the cascade that made a `latest`-only failure look universal).
- `continue-on-error` on the floating `latest` leg — keep it as a forward-compat canary that doesn't block PRs.
- `timeout-minutes: 20` plus a retry/timeout wrapper around `playwright install chromium`, which stalls indefinitely on Node 24/latest; gate the Playwright + Web Test Runner steps to stable Node (the harness Node version is irrelevant to browser coverage).

### Verification

- `npm run test:server`: **149 passing** locally on Node **18, 20, 22, and 24**; `npm run lint` clean.
- CI on `cf9742d0`: **all five legs green**, including `latest` — the undici-7-bundled environment that can't be reproduced locally, giving live confirmation the `.2` interception path works.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue) — the flaky telemetry tests
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Maintenance — CI matrix hardening
- [ ] New release

## Related issues

- Fix [PLA-1585](https://linear.app/rollbar-inc/issue/PLA-1585)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer

🤖 Generated with [Claude Code](https://claude.com/claude-code)
