### PR TITLE
Qualify namespace types in published index.d.ts (#1475)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -21,7 +21,9 @@ declare class Rollbar implements Rollbar.Components {
   public critical(...args: Rollbar.LogArgument[]): Rollbar.LogResult;
   public wait(callback: () => void): void;
 
-  public triggerDirectReplay(context: Dictionary): Dictionary | null;
+  public triggerDirectReplay(
+    context: Rollbar.Dictionary,
+  ): Rollbar.Dictionary | null;
 
   public captureEvent(
     metadata: object,
@@ -37,18 +39,18 @@ declare class Rollbar implements Rollbar.Components {
 
   // Components
 
-  public telemeter?: TelemeterType;
-  public instrumenter?: InstrumenterType;
-  public wrapGlobals?: WrapGlobalsType;
-  public scrub?: ScrubType;
-  public truncation?: TruncationType;
-  public tracing?: TracingType;
+  public telemeter?: Rollbar.TelemeterType;
+  public instrumenter?: Rollbar.InstrumenterType;
+  public wrapGlobals?: Rollbar.WrapGlobalsType;
+  public scrub?: Rollbar.ScrubType;
+  public truncation?: Rollbar.TruncationType;
+  public tracing?: Rollbar.TracingType;
   /**
    * Replay component for session recording.
    * Only available when using replay bundles (rollbar.replay.*).
    * Use `import Rollbar from 'rollbar/replay'` to access.
    */
-  public replay?: ReplayType;
+  public replay?: Rollbar.ReplayType;
 
   // Used with rollbar-react for rollbar-react-native compatibility.
   public rollbar: Rollbar;

--- a/test/server.types.test.js
+++ b/test/server.types.test.js
@@ -1,0 +1,87 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { expect } from 'chai';
+
+const repoRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '..',
+);
+
+/**
+ * Run `tsc` against a throwaway consumer that imports `rollbar` the way
+ * downstream projects do, with skipLibCheck disabled so errors in the
+ * published index.d.ts are visible.
+ *
+ * @returns {import('node:child_process').SpawnSyncReturns<string>}
+ */
+function typecheckPublishedTypes() {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'rollbar-types-'));
+  const pkgDir = path.join(tmp, 'node_modules', 'rollbar');
+
+  fs.mkdirSync(pkgDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(tmp, 'package.json'),
+    JSON.stringify({ type: 'module' }),
+  );
+  fs.writeFileSync(
+    path.join(pkgDir, 'package.json'),
+    JSON.stringify({ name: 'rollbar', types: './index.d.ts' }),
+  );
+  fs.symlinkSync(
+    path.join(repoRoot, 'index.d.ts'),
+    path.join(pkgDir, 'index.d.ts'),
+  );
+  fs.writeFileSync(
+    path.join(tmp, 'main.ts'),
+    [
+      "import Rollbar from 'rollbar';",
+      "const rollbar = new Rollbar({ accessToken: 'x' });",
+      "rollbar.error('test');",
+      '',
+    ].join('\n'),
+  );
+
+  try {
+    return spawnSync(
+      process.execPath,
+      [
+        path.join(repoRoot, 'node_modules', 'typescript', 'bin', 'tsc'),
+        '--strict',
+        '--skipLibCheck',
+        'false',
+        '--noEmit',
+        '--target',
+        'es2022',
+        '--lib',
+        'es2022,dom',
+        '--module',
+        'nodenext',
+        '--moduleResolution',
+        'nodenext',
+        '--pretty',
+        'false',
+        'main.ts',
+      ],
+      { cwd: tmp, encoding: 'utf8' },
+    );
+  } finally {
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+}
+
+describe('published types', function () {
+  it('type-checks with skipLibCheck: false', function () {
+    this.timeout(30000);
+
+    const result = typecheckPublishedTypes();
+    const output = `${result.stdout}${result.stderr}`;
+
+    expect(result.error, output).to.equal(undefined);
+    expect(output, output).to.not.match(/error TS2304/);
+    expect(result.status, output).to.equal(0);
+  });
+});


### PR DESCRIPTION
## Description of the change

Qualify the class-body members `triggerDirectReplay`, `telemeter`, `instrumenter`, `wrapGlobals`, `scrub`, `truncation`, `tracing`, and `replay` in `index.d.ts` as `Rollbar.*`. Those types exist only inside `namespace Rollbar`. Class/namespace merging does not put those exports in the class body's scope, so projects that compile with `skipLibCheck: false` fail with nine `TS2304` errors as soon as they `import Rollbar from 'rollbar'`. `skipLibCheck: true` hides it, which is why `npm run typecheck` and the TypeScript examples did not catch it. The rest of the class already uses `Rollbar.Configuration` and `Rollbar.LogArgument`.

Those nine references are now `Rollbar.*`. A server test type-checks a consumer import with `skipLibCheck` disabled (the reporter's reproduction).

The issue text labeled line 24 as `addRequestData`. In 3.1.0 and current master that line is `triggerDirectReplay`. `addRequestData` is on `Rollbar.Configuration` inside the namespace, where `Dictionary` is already in scope. The published diagnostics (`Cannot find name 'Dictionary'` at 24,39 / 24,52, plus the seven component aliases) are the errors this change removes.

Fixes #1475

Prefix with `Rollbar.` on the class members rather than lifting `Dictionary` and the component type aliases to the top level of the module. The same class and the per-component `.d.ts` files already use `Rollbar.*`. Can switch to top-level aliases.

The regression test lives under `test/server.types.test.js` so `npm run test:server` (which CI runs) exercises it. `npm run typecheck` still uses `skipLibCheck: true` and does not include `index.d.ts`. Wiring published-types checking into that script would be a follow-up.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #1475
- [SDK-611](https://linear.app/rollbar-inc/issue/SDK-611)

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
