### PR TITLE
Expose wait() on the browser notifier (#1138)

### DIFF
--- a/src/browser/core.js
+++ b/src/browser/core.js
@@ -195,6 +195,10 @@ class Rollbar {
     return this.client.sendJsonPayload(jsonPayload);
   }
 
+  wait(callback) {
+    this.client.wait(callback);
+  }
+
   triggerDirectReplay(context) {
     return this.triggerReplay({ type: 'direct', ...context });
   }
@@ -532,6 +536,7 @@ class Rollbar {
     Rollbar.callInstance('buildJsonPayload', args);
   static sendJsonPayload = (...args) =>
     Rollbar.callInstance('sendJsonPayload', args);
+  static wait = (...args) => Rollbar.callInstance('wait', args);
   static wrap = (...args) => Rollbar.callInstance('wrap', args);
   static captureEvent = (...args) => Rollbar.callInstance('captureEvent', args);
 }

--- a/src/browser/rollbarWrapper.js
+++ b/src/browser/rollbarWrapper.js
@@ -15,7 +15,7 @@ function _setupForwarding(prototype) {
   };
 
   var _methods =
-    'log,debug,info,warn,warning,error,critical,global,configure,handleUncaughtException,handleAnonymousErrors,handleUnhandledRejection,_createItem,wrap,loadFull,shimId,captureEvent,captureDomContentLoaded,captureLoad'.split(
+    'log,debug,info,warn,warning,error,critical,global,configure,handleUncaughtException,handleAnonymousErrors,handleUnhandledRejection,_createItem,wrap,loadFull,shimId,captureEvent,wait,captureDomContentLoaded,captureLoad'.split(
       ',',
     );
   for (const method of _methods) {

--- a/src/browser/shim.js
+++ b/src/browser/shim.js
@@ -224,7 +224,7 @@ function stub(method) {
 }
 
 var _methods =
-  'log,debug,info,warn,warning,error,critical,global,configure,handleUncaughtException,handleAnonymousErrors,handleUnhandledRejection,captureEvent,captureDomContentLoaded,captureLoad'.split(
+  'log,debug,info,warn,warning,error,critical,global,configure,handleUncaughtException,handleAnonymousErrors,handleUnhandledRejection,captureEvent,wait,captureDomContentLoaded,captureLoad'.split(
     ',',
   );
 

--- a/test/browser.rollbar.test.ts
+++ b/test/browser.rollbar.test.ts
@@ -56,6 +56,10 @@ function TestClientGen() {
       this.options = o;
       this.payloadData = payloadData;
     };
+    this.waitCalls = [];
+    this.wait = function (callback) {
+      this.waitCalls.push(callback);
+    };
     this.tracer = ValidOpenTracingTracerStub;
   };
 
@@ -78,6 +82,7 @@ describe('Rollbar()', function () {
     expect(rollbar).to.have.property('warning');
     expect(rollbar).to.have.property('error');
     expect(rollbar).to.have.property('critical');
+    expect(rollbar.wait).to.be.a('function');
   });
 
   it('should have all of the expected methods', function () {
@@ -92,6 +97,7 @@ describe('Rollbar()', function () {
     expect(rollbar).to.have.property('warning');
     expect(rollbar).to.have.property('error');
     expect(rollbar).to.have.property('critical');
+    expect(rollbar.wait).to.be.a('function');
   });
 
   it('should have some default options', function () {
@@ -1230,6 +1236,23 @@ describe('callback options', function () {
   });
 });
 
+describe('wait', function () {
+  afterEach(function () {
+    window.rollbar.configure({ autoInstrument: false, captureUncaught: false });
+  });
+
+  it('should pass the callback through to the client', function () {
+    const client = new (TestClientGen())();
+    const options = {};
+    const rollbar = (window.rollbar = new Rollbar(options, client));
+    const callback = function () {};
+
+    rollbar.wait(callback);
+
+    expect(client.waitCalls).to.eql([callback]);
+  });
+});
+
 describe('captureEvent', function () {
   afterEach(function () {
     window.rollbar.configure({ autoInstrument: false, captureUncaught: false });
@@ -1451,5 +1474,9 @@ describe('singleton', function () {
     const loggedItemSingleton = client.logCalls[1].item;
     expect(loggedItemDirect.message).to.eql('hello 1');
     expect(loggedItemSingleton.message).to.eql('hello 2');
+
+    const callback = function () {};
+    Rollbar.wait(callback);
+    expect(client.waitCalls).to.eql([callback]);
   });
 });


### PR DESCRIPTION
## Description of the change

Browser `Rollbar` never exposed `wait()`, even though the shared client already implements it, server and React Native wrap it, and `index.d.ts` already types `wait(callback: () => void)`.

This adds the same thin wrappers the other platforms use: instance `wait` calls `this.client.wait`, and static `Rollbar.wait` goes through the global instance. `wait` is also added to the snippet shim and wrapper method lists so a snippet-loaded `Rollbar` can call it after the full script loads.

Fixes #1138.

**Decision:** wire `wait` on the browser class and the snippet method lists. Alternative: class only (`src/browser/core.js`). Reasoning: other public methods such as `captureEvent` already live in all three places; snippet callers talk to the wrapper, so the class method alone would stay unreachable there. Happy to drop the shim/wrapper list edits if you want the npm-only surface.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Maintenance
- [ ] New release

## Related issues

- Fix #1138

## Checklists

### Development

- [x] Lint rules pass locally
- [x] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x] This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers assigned
- [ ] Issue from task tracker has a link to this pull request
- [ ] Changes have been reviewed by at least one other engineer
